### PR TITLE
add reference to react-router-scroll to the docs

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -114,7 +114,7 @@ A [location descriptor](https://github.com/ReactTraining/history/blob/master/doc
   * `hash`: A hash to put in the URL, e.g. `#a-hash`.
   * `state`: State to persist to the `location`.
 
-_Note: React Router currently does not manage scroll position, and will not scroll to the element corresponding to `hash`._
+_Note: React Router currently does not manage scroll position, and will not scroll to the element corresponding to `hash`. You can use [react-router-scroll](https://github.com/taion/react-router-scroll) to manage the scroll position._
 
 ##### `activeClassName`
 The className a `<Link>` receives when its route is active. No active class by default.


### PR DESCRIPTION
I guess [this](https://github.com/reactjs/react-router/pull/657) was removed because the functionality was removed from the router, and then someone [created](https://github.com/reactjs/react-router/issues/2019#issuecomment-222102709) a standalone package for this right?

But lots of [old](https://github.com/reactjs/react-router/issues/655) [issues](https://github.com/reactjs/react-router/issues/1196) and [pulls](https://github.com/reactjs/react-router/pull/657) still [reference](https://github.com/reactjs/react-router/issues/810) the old docs "rackt" that don't exist any more. But people will still find those issues and can't find any reference to the old scroll behavior in the current docs. 

Let's add this reference.