### PR TITLE
Discard optional paren history based on params evaluation

### DIFF
--- a/modules/PatternUtils.js
+++ b/modules/PatternUtils.js
@@ -183,7 +183,7 @@ export function formatPattern(pattern, params) {
 
       invariant(
         paramValue != null || parenCount > 0,
-        'missing "%s" parameter for path "%s"',
+        'Missing "%s" parameter for path "%s"',
         paramName, pattern
       )
 
@@ -204,7 +204,7 @@ export function formatPattern(pattern, params) {
 
           invariant(
             nextParenIdx > 0,
-            'missing end parameter'
+            'Path "%s" is missing end paren at segment "%s"', pattern, tokensSubset.join('')
           )
 
           // jump to ending paren
@@ -223,6 +223,11 @@ export function formatPattern(pattern, params) {
         pathname += token
     }
   }
+
+  invariant(
+    parenCount <= 0,
+    'Path "%s" is missing end paren', pattern
+  )
 
   return pathname.replace(/\/+/g, '/')
 }

--- a/modules/__tests__/formatPattern-test.js
+++ b/modules/__tests__/formatPattern-test.js
@@ -58,18 +58,18 @@ describe('formatPattern', function () {
     })
 
     describe('and a param is optional with multiple segments and addtional text prior to the params', function () {
-      const pattern = '/search(/forum/:form_id)(/comment/:comment_id)'
+      const pattern = '/search(/forum/:forum_id)(/comment/:comment_id)'
 
       it('returns the correct path when param is supplied', function () {
-        expect(formatPattern(pattern, { form_id:'123', comment_id: '456' })).toEqual('/search/forum/123/comment/456')
+        expect(formatPattern(pattern, { forum_id: '123', comment_id: '456' })).toEqual('/search/forum/123/comment/456')
       })
 
-      it('returns the correct path when param is supplied', function () {
-        expect(formatPattern(pattern, { form_id:'123' })).toEqual('/search/forum/123')
+      it('returns the correct path when forum_id param is supplied', function () {
+        expect(formatPattern(pattern, { forum_id: '123' })).toEqual('/search/forum/123')
       })
 
-      it('returns the correct path when param is supplied', function () {
-        expect(formatPattern(pattern, { comment_id:'456' })).toEqual('/search/comment/456')
+      it('returns the correct path when comment_id param is supplied', function () {
+        expect(formatPattern(pattern, { comment_id: '456' })).toEqual('/search/comment/456')
       })
 
       it('returns the correct path when param is not supplied', function () {
@@ -78,18 +78,58 @@ describe('formatPattern', function () {
     })
 
     describe('and a param is optional with multiple segments in the optional part', function () {
-      const pattern = '/search(/forum/:form_id/comment/:comment_id)'
+      const pattern = '/search(/forum/:forum_id/comment/:comment_id)'
 
       it('returns the correct path when param is supplied', function () {
-        expect(formatPattern(pattern, { form_id:'123', comment_id: '456' })).toEqual('/search/forum/123/comment/456')
+        expect(formatPattern(pattern, { forum_id:'123', comment_id: '456' })).toEqual('/search/forum/123/comment/456')
+      })
+
+      it('returns the correct path when forum_id param is not supplied', function () {
+        expect(formatPattern(pattern, { forum_id:'123' })).toEqual('/search')
+      })
+
+      it('returns the correct path when comment_id param is not supplied 2', function () {
+        expect(formatPattern(pattern, { comment_id:'456' })).toEqual('/search')
       })
 
       it('returns the correct path when param is not supplied', function () {
-        expect(formatPattern(pattern, { form_id:'123' })).toEqual('/search')
+        expect(formatPattern(pattern, { })).toEqual('/search')
+      })
+    })
+
+    describe('and a param is optional with nested optional segments with addtional text prior to the params', function () {
+      const pattern = '/search(/forum/:forum_id(/comment/:comment_id))'
+
+      it('returns the correct path when params are supplied', function () {
+        expect(formatPattern(pattern, { forum_id:'123', comment_id: '456' })).toEqual('/search/forum/123/comment/456')
       })
 
-      it('returns the correct path when param is not supplied 2', function () {
-        expect(formatPattern(pattern, { comment_id:'456' })).toEqual('/search')
+      it('returns the correct path when forum_id param is supplied', function () {
+        expect(formatPattern(pattern, { forum_id:'123' })).toEqual('/search/forum/123')
+      })
+
+      it('returns the correct path when comment_id param is supplied', function () {
+        expect(formatPattern(pattern, { comment_id: '456' })).toEqual('/search')
+      })
+
+      it('returns the correct path when param is not supplied', function () {
+        expect(formatPattern(pattern, { })).toEqual('/search')
+      })
+    })
+
+    describe('and a param is optional with nested optional segments with addtional text prior to the params in different order', function () {
+      const pattern = '/search((/forum/:forum_id)/comment/:comment_id)'
+
+      it('returns the correct path when params are supplied', function () {
+        expect(formatPattern(pattern, { forum_id:'123', comment_id: '456' })).toEqual('/search/forum/123/comment/456')
+      })
+
+      it('returns the correct path when comment_id param is supplied', function () {
+        expect(formatPattern(pattern, { comment_id: '456' })).toEqual('/search/comment/456')
+      })
+
+      it('returns the correct path when forum_id param is supplied', function () {
+        expect(formatPattern(pattern, { forum_id:'123' })).toEqual('/search')
       })
 
       it('returns the correct path when param is not supplied', function () {

--- a/modules/__tests__/formatPattern-test.js
+++ b/modules/__tests__/formatPattern-test.js
@@ -45,6 +45,58 @@ describe('formatPattern', function () {
       })
     })
 
+    describe('and a param is optional with addtional text prior to the params', function () {
+      const pattern = '/search(/forum/:id)'
+
+      it('returns the correct path when param is supplied', function () {
+        expect(formatPattern(pattern, { id:'123' })).toEqual('/search/forum/123')
+      })
+
+      it('returns the correct path when param is not supplied', function () {
+        expect(formatPattern(pattern, { })).toEqual('/search')
+      })
+    })
+
+    describe('and a param is optional with multiple segments and addtional text prior to the params', function () {
+      const pattern = '/search(/forum/:form_id)(/comment/:comment_id)'
+
+      it('returns the correct path when param is supplied', function () {
+        expect(formatPattern(pattern, { form_id:'123', comment_id: '456' })).toEqual('/search/forum/123/comment/456')
+      })
+
+      it('returns the correct path when param is supplied', function () {
+        expect(formatPattern(pattern, { form_id:'123' })).toEqual('/search/forum/123')
+      })
+
+      it('returns the correct path when param is supplied', function () {
+        expect(formatPattern(pattern, { comment_id:'456' })).toEqual('/search/comment/456')
+      })
+
+      it('returns the correct path when param is not supplied', function () {
+        expect(formatPattern(pattern, { })).toEqual('/search')
+      })
+    })
+
+    describe('and a param is optional with multiple segments in the optional part', function () {
+      const pattern = '/search(/forum/:form_id/comment/:comment_id)'
+
+      it('returns the correct path when param is supplied', function () {
+        expect(formatPattern(pattern, { form_id:'123', comment_id: '456' })).toEqual('/search/forum/123/comment/456')
+      })
+
+      it('returns the correct path when param is not supplied', function () {
+        expect(formatPattern(pattern, { form_id:'123' })).toEqual('/search')
+      })
+
+      it('returns the correct path when param is not supplied 2', function () {
+        expect(formatPattern(pattern, { comment_id:'456' })).toEqual('/search')
+      })
+
+      it('returns the correct path when param is not supplied', function () {
+        expect(formatPattern(pattern, { })).toEqual('/search')
+      })
+    })
+
     describe('and all params are present', function () {
       it('returns the correct path', function () {
         expect(formatPattern(pattern, { id: 'abc' })).toEqual('/comments/abc/edit')

--- a/modules/__tests__/formatPattern-test.js
+++ b/modules/__tests__/formatPattern-test.js
@@ -10,6 +10,28 @@ describe('formatPattern', function () {
     })
   })
 
+  describe('with a bad pattern', function () {
+    describe('that is missing an end param', function () {
+      const pattern = '/comments/(:id'
+
+      describe('with no value given to the formatPattern function', function () {
+        it('throws an error', function () {
+          expect(function () {
+            formatPattern(pattern, {})
+          }).toThrow(/Path "\/comments\/\(:id" is missing end paren at segment ":id"/)
+        })
+      })
+
+      describe('with value given to the formatPattern function', function () {
+        it('throws an error', function () {
+          expect(function () {
+            formatPattern(pattern, { id: '1' })
+          }).toThrow(/Path "\/comments\/\(:id" is missing end paren/)
+        })
+      })
+    })
+  })
+
   describe('when a pattern has dynamic segments', function () {
     const pattern = '/comments/:id/edit'
 


### PR DESCRIPTION
Working on a URL generator based on a route path.  Using `formatPattern` gets close, but fails when we have routes like `search(/collection/:collectionId)`.  This PR takes care of that case.