### PR TITLE
Fix the website link to the GitHub Repo

### DIFF
--- a/website/pages/home.md
+++ b/website/pages/home.md
@@ -20,7 +20,7 @@ declaratively.
 
 ## Contributing
 
-We'd love your help, the code is [hosted on GitHub](https://github.com/reactjstraining/react-router).
+We'd love your help, the code is [hosted on GitHub](https://github.com/reactjs/react-router).
 
 ## Thanks
 


### PR DESCRIPTION
reactjstraining organization does not exist, updated link to reference repository in reactjs org.