### PR TITLE
Add overflow in docs to tell Firefox to constrain to parent's size (v4)

### DIFF
--- a/website/components/bricks.js
+++ b/website/components/bricks.js
@@ -43,7 +43,7 @@ export class B extends React.Component {
 
 export class Flex extends React.Component {
   render() {
-    return <B {...this.props} display="flex"/>
+    return <B {...this.props} display="flex" overflow="hidden" />
   }
 }
 


### PR DESCRIPTION
This might fix the new docs in Firefox. I was able to fix it in the developer tools, and I think this is the right place to apply it. Honestly, I find Firefox's flexbox implementation to be closer to the spec usually, so Firefox's behavior may be correct and you need this.

I can't figure out how to run the site, so I don't know if this works. Opening this PR to at least point you in the right direction.