### PR TITLE
rename `Miss` inline component to `NoMatch`

### DIFF
--- a/website/pages/quick-start.md
+++ b/website/pages/quick-start.md
@@ -70,7 +70,7 @@ const About = () => (
   </div>
 )
 
-const Miss = ({ location }) => (
+const NoMatch = ({ location }) => (
   <div>
     <h2>Whoops</h2>
     <p>Sorry but {location.pathname} didn’t match any pages</p>


### PR DESCRIPTION
Line 57 refers to a `NoMatch` component that is not defined elsewhere. These docs are looking great, good job!