### PR TITLE
Explicitly export createServerRenderContext

### DIFF
--- a/modules/index.js
+++ b/modules/index.js
@@ -15,3 +15,6 @@ export StaticRouter from './StaticRouter'
 
 // Util for server rendering "pre-render match"
 export matchPattern from './matchPattern'
+
+// Util for server rendering context
+export createServerRenderContext from './createServerRenderContext'


### PR DESCRIPTION
This adds `createServerRenderContext` to the main exports file, allowing it to be accessed exactly as it is in the v4 docs website.