### PR TITLE
Failing test to demonstrate problem with multiple children

### DIFF
--- a/modules/StaticRouter.js
+++ b/modules/StaticRouter.js
@@ -82,6 +82,9 @@ class StaticRouter extends React.Component {
       <MatchProvider>
         {typeof children === 'function' ? (
           children({ location, router: this.getChildContext().router })
+        ) : React.Children.count(children) > 1 ? (
+          // TODO: get rid of all DOM stuff
+          <div>{children}</div>
         ) : (
           children
         )}

--- a/modules/__tests__/StaticRouter-test.js
+++ b/modules/__tests__/StaticRouter-test.js
@@ -36,6 +36,15 @@ describe('StaticRouter', () => {
       )).toContain('test')
     })
 
+    it('renders multiple static children', () => {
+      expect(renderToString(
+        <StaticRouter {...requiredProps}>
+          <div>test</div>
+          <div>test-2</div>
+        </StaticRouter>
+      )).toContain('test-2')
+    })
+
     it('passes the location to function children', () => {
       let actualLocation
       renderToString(

--- a/modules/__tests__/integration-test.js
+++ b/modules/__tests__/integration-test.js
@@ -130,10 +130,8 @@ describe('Ambiguous matches?', () => {
     const div = document.createElement('div')
     render(
       <Router location="/foo">
-        <div>
-          <Match pattern="/foo" render={() => <div>static</div>}/>
-          <Match pattern="/:name" render={() => <div>param</div>}/>
-        </div>
+        <Match pattern="/foo" render={() => <div>static</div>}/>
+        <Match pattern="/:name" render={() => <div>param</div>}/>
       </Router>,
       div)
     expect(div.innerHTML).toContain('static')
@@ -146,14 +144,12 @@ describe('Ambiguous matches?', () => {
       const pathname = '/non-static-param'
       render((
         <Router location={pathname}>
-          <div>
-            <Match pattern="/:name" render={({ params }) => (
-              <div>
-                <Match pattern="/foo" render={() => <div>foo</div>}/>
-                <Miss render={() => <div>{params.name}</div>}/>
-              </div>
-            )}/>
-          </div>
+          <Match pattern="/:name" render={({ params }) => (
+            <div>
+              <Match pattern="/foo" render={() => <div>foo</div>}/>
+              <Miss render={() => <div>{params.name}</div>}/>
+            </div>
+          )}/>
         </Router>
       ), div)
       expect(div.innerHTML).toNotContain('foo')
@@ -165,10 +161,8 @@ describe('Ambiguous matches?', () => {
       const pathname = '/foo'
       render((
         <Router location={pathname}>
-          <div>
-            <Match pattern="/foo" render={() => <div>match</div>}/>
-            <Miss render={() => <div>miss</div>}/>
-          </div>
+          <Match pattern="/foo" render={() => <div>match</div>}/>
+          <Miss render={() => <div>miss</div>}/>
         </Router>
       ), div)
       expect(div.innerHTML).toContain('match')
@@ -195,10 +189,10 @@ describe('clicking around', () => {
       <Router>
         <div>
           <Link id="one" to="/one">One</Link>
-          <Match pattern="/one" render={() => (
-            <h1>{TEXT1}</h1>
-          )}/>
         </div>
+        <Match pattern="/one" render={() => (
+          <h1>{TEXT1}</h1>
+        )}/>
       </Router>
     ), div)
     expect(div.innerHTML).toNotContain(TEXT1)

--- a/website/pages/quick-start.md
+++ b/website/pages/quick-start.md
@@ -36,25 +36,27 @@ const App = () => (
   //    and make the location available to other components
   //    automatically
   <BrowserRouter>
-    <ul>
-      {/* 3. Link to some paths with `Link` */}
-      <li><Link to="/">Home</Link></li>
-      <li><Link to="/about">About</Link></li>
-      <li><Link to="/topics">Topics</Link></li>
-    </ul>
+    <div>
+      <ul>
+        {/* 3. Link to some paths with `Link` */}
+        <li><Link to="/">Home</Link></li>
+        <li><Link to="/about">About</Link></li>
+        <li><Link to="/topics">Topics</Link></li>
+      </ul>
 
-    <hr/>
+      <hr/>
 
-    {/* 4. Render some `<Match/>` components.
-           When the current location matches the `pattern`
-           then the `component` will render.
-    */}
-    <Match exactly pattern="/" component={Home} />
-    <Match pattern="/about" component={About} />
-    <Match pattern="/topics" component={Topics} />
+      {/* 4. Render some `<Match/>` components.
+             When the current location matches the `pattern`
+             then the `component` will render.
+      */}
+      <Match exactly pattern="/" component={Home} />
+      <Match pattern="/about" component={About} />
+      <Match pattern="/topics" component={Topics} />
 
-    {/* If none of those match, then a sibling `Miss` will render. */}
-    <Miss component={NoMatch}/>
+      {/* If none of those match, then a sibling `Miss` will render. */}
+      <Miss component={NoMatch}/>
+    </div>
   </BrowserRouter>
 )
 


### PR DESCRIPTION
`MatchProvider` (and, by extension, `StaticRouter`), can only accept a single child (or a function). The Quick Start has a `BrowserRouter` with multiple children but it throws an error. This commit fixes that example, but an addition to the documentation may be warranted if this is intended behavior until multiple components can be returned from render (https://github.com/facebook/react/issues/2127).

A possible fix would be to wrap a div around the children in `MatchProvider` but that would introduce a block element into the render and may not be the user's intent.