### PR TITLE
Fix ReferenceError in ServerRouter

### DIFF
--- a/modules/ServerRouter.js
+++ b/modules/ServerRouter.js
@@ -23,7 +23,7 @@ class ServerRouter extends React.Component {
   }
 
   render() {
-    const { context, ...rest } = this.props
+    const { context, location, ...rest } = this.props
     const redirect = (location) => {
       context.setRedirect(location)
     }


### PR DESCRIPTION
The destructuring assignment should include location, otherwise Node throws *location is not defined* ReferenceError.