### PR TITLE
fix histories docs

### DIFF
--- a/docs/guides/Histories.md
+++ b/docs/guides/Histories.md
@@ -151,7 +151,7 @@ Defining a basename:
 
 ```js
 import { useRouterHistory } from 'react-router'
-import { createHistory } from 'history'
+import { createHistory } from 'history/es6'
 
 const history = useRouterHistory(createHistory)({
   basename: '/base-path'
@@ -164,7 +164,7 @@ enhancer:
 
 ```js
 import { useRouterHistory } from 'react-router'
-import { createHistory, useBeforeUnload } from 'history'
+import { createHistory, useBeforeUnload } from 'history/es6'
 
 const history = useRouterHistory(useBeforeUnload(createHistory))()
 


### PR DESCRIPTION
index.js isn't in the root directory in `history@2.1.2` which version is used by `react-router`