### PR TITLE
Fix basename support

### DIFF
--- a/modules/BrowserRouter.js
+++ b/modules/BrowserRouter.js
@@ -11,6 +11,7 @@ const BrowserRouter = ({ basename, keyLength, ...rest }) => (
       <StaticRouter
         action={action}
         location={location}
+        basename={basename}
         onPush={history.push}
         onReplace={history.replace}
         blockTransitions={history.block}

--- a/modules/HashRouter.js
+++ b/modules/HashRouter.js
@@ -11,6 +11,7 @@ const HashRouter = ({ basename, hashType, ...rest }) => (
       <StaticRouter
         action={action}
         location={location}
+        basename={basename}
         onPush={history.push}
         onReplace={history.replace}
         onGo={history.go}

--- a/modules/StaticRouter.js
+++ b/modules/StaticRouter.js
@@ -20,6 +20,7 @@ class StaticRouter extends React.Component {
     children: PropTypes.oneOfType([ PropTypes.node, PropTypes.func ]),
     createHref: PropTypes.func.isRequired,
     location: PropTypes.oneOfType([ PropTypes.object, PropTypes.string ]).isRequired,
+    basename: PropTypes.string,
     onPush: PropTypes.func.isRequired,
     onReplace: PropTypes.func.isRequired,
     stringifyQuery: PropTypes.func.isRequired,
@@ -45,7 +46,10 @@ class StaticRouter extends React.Component {
 
   getChildContext() {
     const createHref = (to) => {
-      const path = createRouterPath(to, this.props.stringifyQuery)
+      const path = createRouterPath(
+        this.props.basename ? this.props.basename + to : to,
+        this.props.stringifyQuery
+      )
       return this.props.createHref(path)
     }
 

--- a/modules/StaticRouter.js
+++ b/modules/StaticRouter.js
@@ -46,10 +46,8 @@ class StaticRouter extends React.Component {
 
   getChildContext() {
     const createHref = (to) => {
-      const path = createRouterPath(
-        this.props.basename ? this.props.basename + to : to,
-        this.props.stringifyQuery
-      )
+      let path = createRouterPath(to, this.props.stringifyQuery)
+      if (this.props.basename) path = this.props.basename + path
       return this.props.createHref(path)
     }
 

--- a/modules/__tests__/StaticRouter-test.js
+++ b/modules/__tests__/StaticRouter-test.js
@@ -1,6 +1,7 @@
 import expect from 'expect'
 import React from 'react'
 import StaticRouter from '../StaticRouter'
+import { router as routerType } from '../PropTypes'
 import { renderToString } from 'react-dom/server'
 
 //console.error = () => {}
@@ -185,6 +186,34 @@ describe('StaticRouter', () => {
         })
       })
 
+    })
+  })
+
+  describe('basename support', () => {
+    class Test extends React.Component {
+      static contextTypes = {
+        router: routerType
+      }
+
+      render() {
+        return <div>{this.context.router.createHref('/bar')}</div>
+      }
+    }
+
+    const BASENAME = "/foo"
+    const routerProps = {
+      location: '/',
+      action: 'POP',
+      onPush: () => {},
+      onReplace: () => {}
+    }
+
+    it('uses the basename when creating hrefs', () => {
+      expect(renderToString(
+        <StaticRouter {...routerProps} basename={BASENAME}>
+          <Test />
+        </StaticRouter>
+      )).toContain(BASENAME)
     })
   })
 })


### PR DESCRIPTION
Fixes #3839
Uses @chentsulin's code from #3843

Basenames are handled by the history, but not by the stuff that actually displays URLs. This fixes things so rendered hrefs include the basename.

Note: This is broken as-is, as we need to strip the basename from the location pushed to history too.