### PR TITLE
update history version check

### DIFF
--- a/modules/Router.js
+++ b/modules/Router.js
@@ -16,8 +16,9 @@ function isDeprecatedHistory(history) {
 
 /* istanbul ignore next: sanity check */
 function isUnsupportedHistory(history) {
-  // v3 histories expose getCurrentLocation, but aren't currently supported.
-  return history && history.getCurrentLocation
+  // v3 - v4.0.0-1 histories expose getCurrentLocation and >v4.0.0-1 histories
+  // expose location, but aren't currently supported
+  return history && (history.getCurrentLocation || history.location)
 }
 
 const { func, object } = React.PropTypes
@@ -104,8 +105,8 @@ const Router = React.createClass({
 
     invariant(
       !isUnsupportedHistory(history),
-      'You have provided a history object created with history v3.x. ' +
-      'This version of React Router is not compatible with v3 history ' +
+      'You have provided a history object created with history v>=3 ' +
+      'This version of React Router is not compatible with v>=3 history ' +
       'objects. Please use history v2.x instead.'
     )
 


### PR DESCRIPTION
`history.getCurrentLocation`  was [removed](https://github.com/mjackson/history/compare/v4.0.0-1...v4.0.0-2#diff-04c6e90faac2675aa89e2176d2eec7d8L51) on history `v4.0.0-2` so I thought this check could be updated.

I also took a look to the check on [v3](https://github.com/ReactTraining/react-router/blob/v3/modules/Router.js#L79), it seems that it will catch correctly(besides wording) histories created with history versions `>=4.0.0-2` but no versions `4.0.0` and `4.0.0-1`, I could also make a PR for that if you think is ok. 