### PR TITLE
Allow <Link> to be used outside of Router, add warning

### DIFF
--- a/modules/Link.js
+++ b/modules/Link.js
@@ -46,17 +46,20 @@ class Link extends React.Component {
   }
 
   handleClick = (event) => {
+
     if (this.props.onClick)
       this.props.onClick(event)
 
-    if (
-      !event.defaultPrevented && // onClick prevented default
-      !this.props.target && // let browser handle "target=_blank" etc.
-      !isModifiedEvent(event) &&
-      isLeftClickEvent(event)
-    ) {
-      event.preventDefault()
-      this.context.router.transitionTo(this.props.to)
+    if (this.context.router) {
+      if (
+        !event.defaultPrevented && // onClick prevented default
+        !this.props.target && // let browser handle "target=_blank" etc.
+        !isModifiedEvent(event) &&
+        isLeftClickEvent(event)
+      ) {
+        event.preventDefault()
+        this.context.router.transitionTo(this.props.to)
+      }
     }
   }
 
@@ -66,6 +69,7 @@ class Link extends React.Component {
 
   render() {
     const { router } = this.context
+
     const {
       to,
       style,
@@ -80,11 +84,11 @@ class Link extends React.Component {
 
     const currentLocation = location || this.context.location
 
-    const isActive = getIsActive(
+    const isActive = router ? getIsActive(
       currentLocation,
       createLocationDescriptor(to),
       this.props
-    )
+    ) : false
 
     // If children is a function, we are using a Function as Children Component
     // so useful values will be passed down to the children function.
@@ -113,6 +117,7 @@ class Link extends React.Component {
         }
       />
     )
+
   }
 }
 


### PR DESCRIPTION
Fixes #3889<br /><br />Previously, using a Link outside of the Router would break the program. The breaking was caused by the inability to find location when outside of the router context. This PR fixes that by checking if the context contains the router, and if not, marking "isActive" as false by default. This introduces the assumption that all <Links> outside of the router are not active.<br /><br />This also adds a warning to indicate that the user is using the <Link> is being used outside of the error. I am not exactly sure what copy to use in the error.<br /><br />As of right now, since there is no invariant in handleClick, a <Link> can be "used" outside of a router. It simply reloads the page based on the href.<br /><br />This is my first time contributing, so let me know if there is anything else that needs to be changed or added to resolve this issue.