### PR TITLE
Fix auth sample login route

### DIFF
--- a/website/examples/Auth.js
+++ b/website/examples/Auth.js
@@ -87,7 +87,7 @@ class Login extends React.Component {
   }
 
   render() {
-    const { from } = this.props.location.state
+    const { from } = this.props.location.state || '/'
     const { redirectToReferrer } = this.state
 
     return (


### PR DESCRIPTION
Attempting to visit the /login route directly results in a "this.props.location.state is null" error which breaks the example.  This fix tells the login component to redirect back to the root route on login if the login route was accessed directly.