### PR TITLE
Fix non-exact match of pattern with trailing slash.

### DIFF
--- a/modules/__tests__/Match-test.js
+++ b/modules/__tests__/Match-test.js
@@ -272,6 +272,69 @@ describe('Match', () => {
     })
   })
 
+  describe('with a trailing slash', () => {
+    const TEXT = 'TEXT'
+    const run = (location, cb) => (
+      cb(renderToString(
+        <Match
+          pattern="/foo/"
+          location={location}
+          render={() => (
+            <div>{TEXT}</div>
+          )}
+        />
+      ))
+    )
+
+    describe('when matched exactly', () => {
+      it('renders', () => {
+        run({ pathname: '/foo/' }, (html) => {
+          expect(html).toContain(TEXT)
+        })
+      })
+    })
+
+    describe('when matched partially', () => {
+      it('renders', () => {
+        run({ pathname: '/foo/bar/' }, (html) => {
+          expect(html).toContain(TEXT)
+        })
+      })
+    })
+  })
+
+  describe('`exactly` prop with a trailing slash', () => {
+    const TEXT = 'TEXT'
+    const run = (location, cb) => (
+      cb(renderToString(
+        <Match
+          exactly
+          pattern="/foo/"
+          location={location}
+          render={() => (
+            <div>{TEXT}</div>
+          )}
+        />
+      ))
+    )
+
+    describe('when matched exactly', () => {
+      it('renders', () => {
+        run({ pathname: '/foo/' }, (html) => {
+          expect(html).toContain(TEXT)
+        })
+      })
+    })
+
+    describe('when matched partially', () => {
+      it('does not render', () => {
+        run({ pathname: '/foo/bar/' }, (html) => {
+          expect(html).toNotContain(TEXT)
+        })
+      })
+    })
+  })
+
   describe('when rendered in context of a location', () => {
     it('matches the location from context', () => {
       const TEXT = 'TEXT'

--- a/modules/__tests__/Match-test.js
+++ b/modules/__tests__/Match-test.js
@@ -301,6 +301,14 @@ describe('Match', () => {
         })
       })
     })
+
+    describe('when the trailing slash is missing', () => {
+      it('does not renders', () => {
+        run({ pathname: '/foo' }, (html) => {
+          expect(html).toNotContain(TEXT)
+        })
+      })
+    })
   })
 
   describe('`exactly` prop with a trailing slash', () => {
@@ -329,6 +337,14 @@ describe('Match', () => {
     describe('when matched partially', () => {
       it('does not render', () => {
         run({ pathname: '/foo/bar/' }, (html) => {
+          expect(html).toNotContain(TEXT)
+        })
+      })
+    })
+
+    describe('when the trailing slash is missing', () => {
+      it('does not renders', () => {
+        run({ pathname: '/foo' }, (html) => {
           expect(html).toNotContain(TEXT)
         })
       })

--- a/modules/matchPattern.js
+++ b/modules/matchPattern.js
@@ -7,7 +7,7 @@ const getMatcher = (pattern) => {
 
   if (!matcher) {
     const keys = []
-    const regex = pathToRegexp(pattern, keys)
+    const regex = pathToRegexp(pattern, keys, { strict: true })
     matcher = cache[pattern] = { keys, regex }
   }
 

--- a/modules/matchPattern.js
+++ b/modules/matchPattern.js
@@ -14,8 +14,16 @@ const getMatcher = (pattern) => {
   return matcher
 }
 
-const truncatePathnameToPattern = (pathname, pattern) =>
-  pathname.split('/').slice(0, pattern.split('/').length).join('/')
+const truncatePathnameToPattern = (pathname, pattern) => {
+  const patternSegments = pattern.split('/')
+  const pathnameSegments = pathname.split('/').slice(0, patternSegments.length)
+  // If pattern ends with a trailing slash, keep the corresponding slash in
+  // pathname but not the following segment.
+  if (patternSegments[patternSegments.length - 1] == ''
+      && pathnameSegments.length == patternSegments.length)
+    pathnameSegments[pathnameSegments.length - 1] = ''
+  return pathnameSegments.join('/')
+}
 
 const parseParams = (pattern, match, keys) =>
   match.slice(1).reduce((params, value, index) => {

--- a/modules/matchPattern.js
+++ b/modules/matchPattern.js
@@ -4,12 +4,13 @@ import pathToRegexp from 'path-to-regexp'
 const cache = {true: {}, false: {}}
 
 const getMatcher = (pattern, exactly) => {
-  let matcher = cache[exactly][pattern]
+  const exactlyStr = exactly ? 'true' : 'false'
+  let matcher = cache[exactlyStr][pattern]
 
   if (!matcher) {
     const keys = []
     const regex = pathToRegexp(pattern, keys, { end: exactly, strict: true })
-    matcher = cache[exactly][pattern] = { keys, regex }
+    matcher = cache[exactlyStr][pattern] = { keys, regex }
   }
 
   return matcher


### PR DESCRIPTION
Currently, in the v4 branch, `<Match pattern="/foo/" component={Foo} />` fails to match at `/foo/bar/`, because the URL is truncated to `/foo/bar` instead of `/foo/` prior to being matched.