### PR TITLE
Simplify StaticRouter render().

### DIFF
--- a/modules/StaticRouter.js
+++ b/modules/StaticRouter.js
@@ -78,12 +78,11 @@ class StaticRouter extends React.Component {
 
   render() {
     const { children } = this.props
-    const location = this.getLocation()
 
     return (
       <MatchProvider>
         {typeof children === 'function' ? (
-          children({ location, router: this.getChildContext().router })
+          children(this.getChildContext())
         ) : (
           React.Children.only(children)
         )}


### PR DESCRIPTION
I don't think getLocation() needs to be called twice per render.