### PR TITLE
Fix nested exactly

### DIFF
--- a/modules/matchPattern.js
+++ b/modules/matchPattern.js
@@ -33,7 +33,7 @@ const matchPattern = (pattern, location, matchExactly, parent) => {
       pathname: '/'
     }
   } else {
-    if (!matchExactly && parent && pattern.charAt(0) !== '/') {
+    if (parent && pattern.charAt(0) !== '/') {
       pattern = parent.pathname +
         (parent.pathname.charAt(parent.pathname.length - 1) !== '/' ? '/' : '') +
         pattern


### PR DESCRIPTION
We should still add the parent pattern when `exactly` is enabled, unless the pattern starts with `/`.

[closes #3938]