### PR TITLE
Initialize noMatchesInContext in Miss state with correct value

### DIFF
--- a/modules/Miss.js
+++ b/modules/Miss.js
@@ -35,7 +35,7 @@ class Miss extends React.Component {
     }
 
     this.state = {
-      noMatchesInContext: false
+      noMatchesInContext: context.match && !context.serverRouter ? !context.match.matches.length : false
     }
   }
 


### PR DESCRIPTION
Not sure if this is a permanent fix, but the subscribe callback was not being called in some situations leaving Miss in a bad state.

See https://github.com/ReactTraining/react-router/issues/3957