### PR TITLE
Fix doc links to history

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -644,9 +644,9 @@ For more details, please see the [histories guide](/docs/guides/Histories.md).
 `useRouterHistory` is a `history` enhancer that configures a given `createHistory` factory to work with React Router. This allows using custom histories in addition to the bundled singleton histories.
 
 It also pre-enhances the history with the
-[useQueries](https://github.com/ReactTraining/history/blob/master/docs/QuerySupport.md)
+[useQueries](https://github.com/mjackson/history/blob/v2.x/docs/QuerySupport.md)
 and
-[useBasename](https://github.com/ReactTraining/history/blob/master/docs/BasenameSupport.md)
+[useBasename](https://github.com/mjackson/history/blob/v2.x/docs/BasenameSupport.md)
 enhancers from `history`
 
 #### Example

--- a/docs/guides/Histories.md
+++ b/docs/guides/Histories.md
@@ -139,11 +139,11 @@ render(
 
 If you'd like to further customize the history options or use other
 enhancers from
-[history](https://github.com/ReactTraining/history/) you can use
+[history](https://github.com/mjackson/history/) you can use
 `useRouterHistory`.
 
 Be aware that `useRouterHistory` already pre-enhances your history
-factory with the [useQueries](https://github.com/ReactTraining/history/blob/master/docs/QuerySupport.md) and [useBasename](https://github.com/ReactTraining/history/blob/master/docs/BasenameSupport.md) enhancers from `history`.
+factory with the [useQueries](https://github.com/mjackson/history/blob/v2.x/docs/QuerySupport.md) and [useBasename](https://github.com/mjackson/history/blob/v2.x/docs/BasenameSupport.md) enhancers from `history`.
 
 ### Examples:
 
@@ -159,7 +159,7 @@ const history = useRouterHistory(createHistory)({
 ```
 
 Using the
-[useBeforeUnload](https://github.com/mjackson/history/blob/master/docs/ConfirmingNavigation.md)
+[useBeforeUnload](https://github.com/mjackson/history/blob/v2.x/docs/ConfirmingNavigation.md)
 enhancer:
 
 ```js


### PR DESCRIPTION
Change link urls from master branch to v2.x branch. This also changes links from ReactTraining/history to mjackson/history

[fixes #3971]