### PR TITLE
Fix ambiguous Miss component not rendering (#3957)

### DIFF
--- a/modules/MatchProvider.js
+++ b/modules/MatchProvider.js
@@ -73,13 +73,8 @@ class MatchProvider extends React.Component {
     // React's contract is that cDM of descendants is called before cDM of
     // ancestors, so here we can safely check if we found a match
     if (this.subscribers.length) {
-      const hadMatches = this.hasMatches
       this.hasMatches = this.matches.length !== 0
-      // optimization, don't notify if nothing changed initial will be null, so
-      // we can get initial render correct
-      if (this.hasMatches !== hadMatches) {
-        this.subscribers.forEach(fn => fn(this.hasMatches))
-      }
+      this.subscribers.forEach(fn => fn(this.hasMatches))
     }
   }
 


### PR DESCRIPTION
Miss would not render in ambiguous match example after navigating away and returning to ambiguous path

closes #3957 