### PR TITLE
Pass extra props provided to match to component

### DIFF
--- a/modules/Match.js
+++ b/modules/Match.js
@@ -75,12 +75,12 @@ class Match extends React.Component {
       <LocationSubscriber>
         {(locationContext) => {
           const { children, render, component:Component,
-            pattern, location, exactly } = this.props
+            pattern, location, exactly, ...rest } = this.props
           const { match:matchContext } = this.context
           const loc = location || locationContext
           const parent = matchContext && matchContext.parent
           const match = matchPattern(pattern, loc, exactly, parent)
-          const props = { ...match, location: loc, pattern }
+          const props = { ...match, location: loc, pattern, ...rest }
           return (
             <RegisterMatch match={match}>
               <MatchProvider match={match}>


### PR DESCRIPTION
The described way to create custom match component, for instance providing a `MatchWhenAuthorized` is to render using a anonymous function using the render props, and embed the component using this construct. This is fine when rendering a simple component, but can run into all kinds of problems with re-rendering if there is a large component tree provided (usual for top level matches). (Because the function is re-created every render). If you would like specific problems, check out this thread of redux-form: https://github.com/erikras/redux-form/issues/961.

This can easily resolved by using the component property of `Match`, and pass another component as a different property to the match function (that get's passed as a property to the component specified in `Match` as I implemented in this pull-request.