### PR TITLE
decode path params

### DIFF
--- a/modules/__tests__/Match-test.js
+++ b/modules/__tests__/Match-test.js
@@ -59,6 +59,17 @@ describe('Match', () => {
             })
           })
         })
+        it('decodes props', () => {
+          run({ pathname: '/first%20name/second%20name' }, (props) => {
+            expect(props).toEqual({
+              params: { foo: 'first name', bar: 'second name' },
+              isExact: true,
+              pathname: '/first%20name/second%20name',
+              location: { pathname: '/first%20name/second%20name' },
+              pattern: '/:foo/:bar'
+            })
+          })
+        })
       })
 
       describe('when matched partially', () => {

--- a/modules/matchPattern.js
+++ b/modules/matchPattern.js
@@ -19,7 +19,7 @@ const truncatePathnameToPattern = (pathname, pattern) =>
 
 const parseParams = (pattern, match, keys) =>
   match.slice(1).reduce((params, value, index) => {
-    params[keys[index].name] = value
+    params[keys[index].name] = decodeURIComponent(value)
     return params
   }, {})
 


### PR DESCRIPTION
To fix the bug for #3970 

`<Match>` needs to call `decodeURIComponent` to properly pass parameters to its component.