### PR TITLE
don't incude a trailing slash in the href for pathname='/' if the basename is not empty

### DIFF
--- a/modules/StaticRouter.js
+++ b/modules/StaticRouter.js
@@ -48,7 +48,12 @@ class StaticRouter extends React.Component {
     let path = createRouterPath(to, this.props.stringifyQuery)
 
     if (this.props.basename)
-      path = this.props.basename + path
+      if (path === '/')
+        path = this.props.basename
+      else if (path.length >= 2 && path.charAt(0) === '/' && path.charAt(1) === '?')
+        path = this.props.basename + path.substring(1)
+      else
+        path = this.props.basename + path
 
     return this.props.createHref(path)
   }

--- a/modules/__tests__/StaticRouter-test.js
+++ b/modules/__tests__/StaticRouter-test.js
@@ -196,7 +196,7 @@ describe('StaticRouter', () => {
       }
 
       render() {
-        return <div>{this.context.router.createHref('/bar')}</div>
+        return <div>{this.context.router.createHref(this.props.to)}</div>
       }
     }
 
@@ -211,9 +211,25 @@ describe('StaticRouter', () => {
     it('uses the basename when creating hrefs', () => {
       expect(renderToString(
         <StaticRouter {...routerProps} basename={BASENAME}>
-          <Test />
+          <Test to='/bar' />
         </StaticRouter>
       )).toContain(BASENAME)
+    })
+
+    it('does not append a trailing slash to the root path', () => {
+      expect(renderToString(
+        <StaticRouter {...routerProps} basename={BASENAME}>
+        <Test to='/' />
+        </StaticRouter>
+      )).toContain('/foo</div>')
+    })
+
+    it('does not append a trailing slash to the root path if a query is specified', () => {
+      expect(renderToString(
+        <StaticRouter {...routerProps} basename={BASENAME}>
+        <Test to={{pathname:'/', query:{a:1}}} />
+        </StaticRouter>
+      )).toContain('/foo?a=1</div>')
     })
   })
 })


### PR DESCRIPTION
I use `<Router basename="/foo">`. If I call `transitionTo('/')`, I end up at `http://host/foo/` but I expect to land on `http://host/foo`. I also tried passing `{pathname:null}` but that doesn't help either.