### PR TITLE
fix: <Match exactly> takes parent into account

### DIFF
--- a/modules/__tests__/Miss-test.js
+++ b/modules/__tests__/Miss-test.js
@@ -1,8 +1,10 @@
 import expect from 'expect'
 import React from 'react'
 import Miss from '../Miss'
+import Match from '../Match'
 import { render, unmountComponentAtNode } from 'react-dom'
 import MatchProvider from '../MatchProvider'
+import MemoryRouter from '../MemoryRouter'
 
 describe('Miss', () => {
   const TEXT = 'TEXT'
@@ -55,6 +57,45 @@ describe('Miss', () => {
       expect(div.innerHTML).toNotContain(TEXT)
       unmountComponentAtNode(div)
       done()
+    })
+  })
+
+  describe('with a nested pattern', () => {
+    const MATCH = 'MATCH'
+
+    const App = ({ location }) => (
+      <MemoryRouter initialEntries={[location]} initialIndex={0}>
+        <Match pattern='/parent' component={Parent} />
+      </MemoryRouter>
+    )
+
+    const Parent = () => (
+      <div>
+        <Match pattern='child' exactly={true} component={() => <div>{MATCH}</div>} />
+        <Miss component={() => <div>{TEXT}</div>} />
+      </div>
+    )
+
+    it('does not render on match', (done) => {
+      const div = document.createElement('div')
+      const nestedLoc = { pathname: '/parent/child' }
+
+      render(<App location={nestedLoc} />, div, () => {
+        expect(div.innerHTML).toNotContain(TEXT)
+        expect(div.innerHTML).toContain(MATCH)
+        done()
+      })
+    })
+
+    it('does render on non-exact match', (done) => {
+      const div = document.createElement('div')
+      const nestedLoc = { pathname: '/parent/child/foobar' }
+
+      render(<App location={nestedLoc} />, div, () => {
+        expect(div.innerHTML).toContain(TEXT)
+        expect(div.innerHTML).toNotContain(MATCH)
+        done()
+      })
     })
   })
 })

--- a/modules/matchPattern.js
+++ b/modules/matchPattern.js
@@ -33,7 +33,7 @@ const matchPattern = (pattern, location, matchExactly, parent) => {
       pathname: '/'
     }
   } else {
-    if (!matchExactly && parent && pattern.charAt(0) !== '/') {
+    if (parent && pattern.charAt(0) !== '/') {
       pattern = parent.pathname +
         (parent.pathname.charAt(parent.pathname.length - 1) !== '/' ? '/' : '') +
         pattern


### PR DESCRIPTION
Provide fix and tests for #3938 

Applied the same fix as in #3939, but added a couple tests to prove the case