### PR TITLE
feat: cache matchers with simple cache

### DIFF
--- a/modules/MatcherCache.js
+++ b/modules/MatcherCache.js
@@ -1,0 +1,40 @@
+// Simple cache - NEW cached items are added to cachedKeys array. When cache is
+// full, oldest key is removed from array and item is removed from cache
+
+const DEFAULT_OPTIONS = {
+  limit: 200
+}
+
+export default class MatcherCache {
+  cache = {}
+  cachedKeys = []
+
+  constructor(options = {}) {
+    const mergedOptions = {
+      ...DEFAULT_OPTIONS,
+      ...options
+    }
+    this.options = mergedOptions
+  }
+
+  set(key, value) {
+    // If this key is not cached add key to cachedKeys array
+    if (this.cache[key] === undefined) {
+      this.cachedKeys.push(key)
+    }
+    this.cache[key] = value
+    this.checkCacheLimit()
+  }
+
+  get(key) {
+    return this.cache[key]
+  }
+
+  checkCacheLimit() {
+    // Clear a cache item if we are over limit
+    if (this.cachedKeys.length > this.options.limit) {
+      const keyToUncache = this.cachedKeys.shift()
+      delete this.cache[keyToUncache]
+    }
+  }
+}

--- a/modules/__tests__/MatcherCache-test.js
+++ b/modules/__tests__/MatcherCache-test.js
@@ -1,0 +1,29 @@
+import expect from 'expect'
+import MatcherCache from '../MatcherCache'
+
+describe('MatcherCache', () => {
+  let cache
+
+  beforeEach(() => {
+    cache = new MatcherCache({ limit: 1 })
+  })
+
+  it('can set and get an item', () => {
+    cache.set('/url', 1)
+    expect(cache.get('/url')).toEqual(1)
+  })
+
+  it('removes cached item when limit is reached', () => {
+    cache.set('/url-1', 1)
+    cache.set('/url-2', 2)
+    expect(cache.get('/url-1')).toEqual(undefined)
+    expect(cache.get('/url-2')).toEqual(2)
+  })
+
+  it('should override currently cached items', () => {
+    cache.set('/url-1', 1)
+    cache.set('/url-1', 2)
+    expect(cache.get('/url-1')).toEqual(2)
+    expect(cache.cachedKeys.length).toEqual(1)
+  })
+})

--- a/modules/matchPattern.js
+++ b/modules/matchPattern.js
@@ -1,16 +1,21 @@
 import pathToRegexp from 'path-to-regexp'
+import MatcherCache from './MatcherCache'
 
 // cache[exactly][pattern] contains getMatcher(pattern, exactly)
-const cache = {true: {}, false: {}}
+const cache = {
+  true: new MatcherCache(),
+  false: new MatcherCache()
+}
 
 const getMatcher = (pattern, exactly) => {
   const exactlyStr = exactly ? 'true' : 'false'
-  let matcher = cache[exactlyStr][pattern]
+  let matcher = cache[exactlyStr].get(pattern)
 
   if (!matcher) {
     const keys = []
     const regex = pathToRegexp(pattern, keys, { end: exactly, strict: true })
-    matcher = cache[exactlyStr][pattern] = { keys, regex }
+    matcher = { keys, regex }
+    cache[exactlyStr].set(pattern, matcher)
   }
 
   return matcher


### PR DESCRIPTION
Cache matchers by key of `pattern` up to a maximum of **50** matchers. (arbitrary number).

If anyone has a better idea of what number to use for the cache max, let me know.

Relates to issue #3875