### PR TITLE
Prevent replace prop from being passed to <a ... />

### DIFF
--- a/modules/Link.js
+++ b/modules/Link.js
@@ -64,6 +64,7 @@ class Link extends React.Component {
             location:propLocation,
             isActive: getIsActive,
             activeOnlyWhenExact, // eslint-disable-line
+            replace, // eslint-disable-line
             ...rest
           } = this.props
 


### PR DESCRIPTION
The new `replace` prop on `Link` introduced in v4 yesterday (eac82172a04287501b5c4a2668fcfdbe7059f227) was being passed down to the `<a>` tag during rendering. This was causing a warning from React:

> Warning: Unknown prop `replace` on <a> tag. Remove this prop from the element. For details, see https://fb.me/react-unknown-prop
    in a (created by Subscriber)
    in Subscriber (created by LocationSubscriber)
    in LocationSubscriber (created by Link)