### PR TITLE
feat: render misses on first pass

### DIFF
--- a/modules/Match.js
+++ b/modules/Match.js
@@ -19,15 +19,7 @@ class RegisterMatch extends React.Component {
   }
 
   componentWillMount() {
-    if (this.context.serverRouter) {
-      this.registerMatch()
-    }
-  }
-
-  componentDidMount() {
-    if (!this.context.serverRouter) {
-      this.registerMatch()
-    }
+    this.registerMatch()
   }
 
   componentDidUpdate(prevProps) {

--- a/modules/MatchProvider.js
+++ b/modules/MatchProvider.js
@@ -40,6 +40,7 @@ class MatchProvider extends React.Component {
         serverRouterIndex: this.serverRouterIndex,
         subscribe: (fn) => {
           this.subscribers.push(fn)
+          fn(this.matches.length !== 0)
           return () => {
             this.subscribers.splice(this.subscribers.indexOf(fn), 1)
           }

--- a/modules/Miss.js
+++ b/modules/Miss.js
@@ -11,13 +11,8 @@ class Miss extends React.Component {
   constructor(props, context) {
     super(props, context)
 
-    // ignore if rendered out of context (probably for unit tests)
-    if (context.match && !context.serverRouter) {
-      this.unsubscribe = this.context.match.subscribe((matchesFound) => {
-        this.setState({
-          noMatchesInContext: !matchesFound
-        })
-      })
+    this.state = {
+      noMatchesInContext: false
     }
 
     if (context.serverRouter) {
@@ -25,9 +20,18 @@ class Miss extends React.Component {
         context.match.serverRouterIndex
       )
     }
+  }
 
-    this.state = {
-      noMatchesInContext: false
+  componentWillMount() {
+    const { match, serverRouter } = this.context
+
+    // ignore if rendered out of context (probably for unit tests)
+    if (match && !serverRouter) {
+      this.unsubscribe = match.subscribe((matchesFound) => {
+        this.setState({
+          noMatchesInContext: !matchesFound
+        })
+      })
     }
   }
 

--- a/modules/__tests__/ServerRouter-test.js
+++ b/modules/__tests__/ServerRouter-test.js
@@ -55,7 +55,7 @@ describe('ServerRouter', () => {
 
     const context = createServerRenderContext()
 
-    renderToString(
+    const markup = renderToString(
       <ServerRouter context={context} location={location}>
         <App/>
       </ServerRouter>
@@ -65,12 +65,6 @@ describe('ServerRouter', () => {
     expect(result.missed).toBe(true)
 
     if (result.missed) {
-      const markup = renderToString(
-        <ServerRouter context={context} location={location}>
-          <App/>
-        </ServerRouter>
-      )
-
       expect(markup).toContain(YES1)
       expect(markup).toContain(YES2)
       expect(markup).toNotContain(NO)


### PR DESCRIPTION
Render `Miss` components on the **first pass**, making server-rendering more optimal.

It depends on rendering order slightly, (not sure what everyone's thoughts are about this), because it **only** works if the `Miss` component renders *after* any sibling match components, otherwise it will take 2 passes - as it does currently.

So this will need **2** render passes to render the `Miss` (if no url's match):

```js
<Miss component={NotFound} />
<Match pattern='/todos' component={Todos} />
```

But this can now be done in **1** pass
```js
<Match pattern='/todos' component={Todos} />
<Miss component={NotFound} />
```

Let me know what your thoughts are about this solution :+1: 
 
---

Summary of changes:
- Moved registerMatch to componentWillMount of `Match` so matches can be
  registered before sibling `Miss` components mount, therefore `Miss` doesn't need to
  rerender after mounting
- Call listener function once synchronously in `MatchProvider` when `Miss` calls `match.subscribe`
- Move `match.subscribe` logic to componentWillMount of `Miss` so we can call
  `setState` synchronously right there. Needed due to the prevous point.
- Add Miss and Server rendering tests

Todo:
- [ ] Update docs