### PR TITLE
withRouter higher order component 

### DIFF
--- a/modules/__tests__/withRouter-test.js
+++ b/modules/__tests__/withRouter-test.js
@@ -1,0 +1,58 @@
+import expect from 'expect'
+import React from 'react'
+import { render } from 'react-dom'
+import MemoryRouter from '../MemoryRouter'
+import withRouter from '../withRouter'
+import Redirect from '../Redirect'
+
+describe('withRouter', () => {
+  const App = ({ location, Component }) => (
+    <MemoryRouter initialEntries={[location]} initialIndex={0}>
+      <Component />
+    </MemoryRouter>
+  )
+
+  it('passes history, router, and location as props', (done) => {
+    const div = document.createElement('div')
+    const location = { pathname: '/url-1' }
+
+    const component = (props) => {
+      expect(props.history).toNotBe(undefined)
+      expect(props.router).toNotBe(undefined)
+      expect(props.location).toNotBe(undefined)
+
+      expect(props.location).toInclude({ pathname: '/url-1' })
+      expect(props.history).toExcludeKey('location')
+      return <div />
+    }
+
+    render(
+      <App location={location} Component={withRouter(component)} />,
+      div,
+      () => done()
+    )
+  })
+
+  it('re-renders and passes down new props when location changes', (done) => {
+    const div = document.createElement('div')
+    const location = { pathname: '/url-1' }
+    let redirected = false
+
+    const component = (props) => {
+      if (redirected) {
+        expect(props.location.pathname).toBe('/url-2')
+        redirected = true
+        return <Redirect to='/url-2' />
+      } else {
+        expect(props.location.pathname).toBe('/url-1')
+        return null
+      }
+    }
+
+    render(
+      <App location={location} Component={withRouter(component)} />,
+      div,
+      () => done()
+    )
+  })
+})

--- a/modules/__tests__/withRouter-test.js
+++ b/modules/__tests__/withRouter-test.js
@@ -12,11 +12,16 @@ describe('withRouter', () => {
     </MemoryRouter>
   )
 
-  it('passes history, router, and location as props', (done) => {
-    const div = document.createElement('div')
-    const location = { pathname: '/url-1' }
+  let div, location
 
-    const component = (props) => {
+  beforeEach(() => {
+    div = document.createElement('div')
+  })
+
+  it('passes history, router, and location as props', (done) => {
+    location = { pathname: '/url-1' }
+
+    const Component = (props) => {
       expect(props.history).toNotBe(undefined)
       expect(props.router).toNotBe(undefined)
       expect(props.location).toNotBe(undefined)
@@ -27,18 +32,17 @@ describe('withRouter', () => {
     }
 
     render(
-      <App location={location} Component={withRouter(component)} />,
+      <App location={location} Component={withRouter(Component)} />,
       div,
       () => done()
     )
   })
 
   it('re-renders and passes down new props when location changes', (done) => {
-    const div = document.createElement('div')
-    const location = { pathname: '/url-1' }
+    location = { pathname: '/url-1' }
     let redirected = false
 
-    const component = (props) => {
+    const Component = (props) => {
       if (redirected) {
         expect(props.location.pathname).toBe('/url-2')
         redirected = true
@@ -50,9 +54,59 @@ describe('withRouter', () => {
     }
 
     render(
-      <App location={location} Component={withRouter(component)} />,
+      <App location={location} Component={withRouter(Component)} />,
       div,
       () => done()
     )
+  })
+
+  it('can be used with or without options', () => {
+    const Component = () => <div />
+    const withOptions = withRouter({})(Component)
+    const withoutOptions = withRouter(Component)
+    expect(typeof withOptions).toBe('function')
+    expect(typeof withoutOptions).toBe('function')
+  })
+
+  it('hoists statics', () => {
+    class Component extends React.Component {
+      static Test = 'test'
+      render() { return null }
+    }
+
+    expect(withRouter(Component).Test).toBe('test')
+  })
+
+  it('exposes a displayName property', () => {
+    class MyComponent extends React.Component {
+      static displayName = 'MyComponent'
+      render() { return null }
+    }
+    expect(withRouter(MyComponent).displayName).toBe('withRouter(MyComponent)')
+  })
+
+  it('exposes a WrappedComponent property', () => {
+    class MyComponent extends React.Component {
+      render() { return null }
+    }
+    expect(withRouter(MyComponent).WrappedComponent).toBe(MyComponent)
+  })
+
+  it('can expose a wrappedInstance property on the instance', (done) => {
+    class MyComponent extends React.Component {
+      render() { return null }
+    }
+    const EnhancedComponent = withRouter({ withRef: true })(MyComponent)
+
+    class App extends React.Component {
+      checkRef(ref) {
+        expect(ref.wrappedInstance instanceof MyComponent).toBe(true)
+      }
+      render() {
+        return <EnhancedComponent ref={e => this.checkRef(e)} />
+      }
+    }
+
+    render(<App />, div, () => done())
   })
 })

--- a/modules/index.js
+++ b/modules/index.js
@@ -4,6 +4,9 @@ export Miss from './Miss'
 export NavigationPrompt from 'react-history/Prompt'
 export Redirect from './Redirect'
 
+// withRouter higher order component
+export withRouter from './withRouter'
+
 // High-level wrappers
 export BrowserRouter from './BrowserRouter'
 export HashRouter from './HashRouter'

--- a/modules/withRouter.js
+++ b/modules/withRouter.js
@@ -1,35 +1,78 @@
 import React, { Component } from 'react'
+import invariant from 'invariant'
+import hoistStatics from 'hoist-non-react-statics'
 import { historyContext } from 'react-history/PropTypes'
 import { routerContext } from './PropTypes'
 import { LocationSubscriber } from './Broadcasts'
 
-const withRouter = (WrappedComponent) => {
-  class WithRouter extends Component {
-    static contextTypes = {
-      history: historyContext,
-      router: routerContext
+function getDisplayName(WrappedComponent) {
+  return WrappedComponent.displayName || WrappedComponent.name || 'Component'
+}
+
+const withRouter = (options) => {
+  const hoc = (WrappedComponent) => {
+    const withRef = options && options.withRef
+
+    class WithRouter extends Component {
+      static contextTypes = {
+        history: historyContext,
+        router: routerContext
+      }
+
+      getWrappedInstance() {
+        invariant(
+          withRef,
+          'To access the wrapped instance, you need to specify ' +
+          '`{ withRef: true }` as an option to withRouter - ' +
+          '@withRouter(opts) OR withRouter(opts)(Component)'
+        )
+
+        return this.wrappedInstance
+      }
+
+      render() {
+        const { router, history } = this.context
+        const modifiedHistory = { ...history }
+        delete modifiedHistory.location
+        const props = {
+          ...this.props,
+          history: modifiedHistory,
+          router
+        }
+        if (withRef) {
+          props.ref = (c) => { this.wrappedInstance = c }
+        }
+
+        return (
+          <LocationSubscriber>
+            {(locationContext) => {
+              return (
+                <WrappedComponent
+                  {...props}
+                  location={locationContext}
+                />
+              )
+            }}
+          </LocationSubscriber>
+        )
+      }
     }
 
-    render() {
-      return (
-        <LocationSubscriber>
-          {(locationContext) => {
-            const history = { ...this.context.history }
-            delete history.location
-            return (
-              <WrappedComponent
-                {...this.props}
-                location={locationContext}
-                history={history}
-                router={this.context.router}
-              />
-            )
-          }}
-        </LocationSubscriber>
-      )
-    }
+    WithRouter.displayName = `withRouter(${getDisplayName(WrappedComponent)})`
+    WithRouter.WrappedComponent = WrappedComponent
+
+    return hoistStatics(WithRouter, WrappedComponent)
   }
-  return WithRouter
+
+  // Allow using decorator with or without options
+  // @withRouter **OR** @withRouter(opts)
+  // withRouter(Component) **OR** withRouter(opts)(Component)
+  if (typeof options === 'function') {
+    // Calling like: withRouter(Component)
+    return hoc(options)
+  } else {
+    return hoc
+  }
 }
 
 export default withRouter

--- a/modules/withRouter.js
+++ b/modules/withRouter.js
@@ -1,0 +1,35 @@
+import React, { Component } from 'react'
+import { historyContext } from 'react-history/PropTypes'
+import { routerContext } from './PropTypes'
+import { LocationSubscriber } from './Broadcasts'
+
+const withRouter = (WrappedComponent) => {
+  class WithRouter extends Component {
+    static contextTypes = {
+      history: historyContext,
+      router: routerContext
+    }
+
+    render() {
+      return (
+        <LocationSubscriber>
+          {(locationContext) => {
+            const history = { ...this.context.history }
+            delete history.location
+            return (
+              <WrappedComponent
+                {...this.props}
+                location={locationContext}
+                history={history}
+                router={this.context.router}
+              />
+            )
+          }}
+        </LocationSubscriber>
+      )
+    }
+  }
+  return WithRouter
+}
+
+export default withRouter

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "lint": "eslint modules"
   },
   "dependencies": {
+    "hoist-non-react-statics": "^1.2.0",
     "path-to-regexp": "^1.5.3",
     "query-string": "4.2.3",
     "react-broadcast": "^0.1.1",


### PR DESCRIPTION
For #3847

Currently passes down the following props:
- `location`
- `history` _(excluding location_) - includes history methods (push, go, listen etc...)
- `router`

Just thought I'd get a PR created to start a discussion on the specifics (or if we want one at all).

Todo:
- [x] Add `withRef`, `displayName`, `hoistStatics` functionality
- [x] Add tests
- [ ] Update docs
