### PR TITLE
Clean task fails silently

### DIFF
--- a/scripts/clean.js
+++ b/scripts/clean.js
@@ -8,6 +8,9 @@ const files = fs.readdirSync(root('modules'))
 
 const promises = Promise.all(
   files.map(file => new Promise((resolve, reject) => {
+    if (!fs.existsSync(root(file))) {
+      return resolve()
+    }
     try {
       fs.unlinkSync(root(file))
       resolve()


### PR DESCRIPTION
Clean task failed if files didn't exist (my fault), so now it fails silently if a file doesn't exist or an error occurs.