### PR TITLE
Fix blockTransitions not returning teardown function

### DIFF
--- a/modules/StaticRouter.js
+++ b/modules/StaticRouter.js
@@ -40,8 +40,7 @@ class StaticRouter extends React.Component {
     this.props.onReplace(this.createLocation(location))
   }
 
-  blockTransitions = (prompt) =>
-    this.props.blockTransitions(prompt)
+  blockTransitions = (prompt) => this.props.blockTransitions(prompt)
 
   createHref = (to) => {
     let path = createRouterPath(to, this.props.stringifyQuery)

--- a/modules/StaticRouter.js
+++ b/modules/StaticRouter.js
@@ -40,9 +40,8 @@ class StaticRouter extends React.Component {
     this.props.onReplace(this.createLocation(location))
   }
 
-  blockTransitions = (prompt) => {
+  blockTransitions = (prompt) =>
     this.props.blockTransitions(prompt)
-  }
 
   createHref = (to) => {
     let path = createRouterPath(to, this.props.stringifyQuery)

--- a/modules/__tests__/StaticRouter-test.js
+++ b/modules/__tests__/StaticRouter-test.js
@@ -232,4 +232,24 @@ describe('StaticRouter', () => {
       )).toContain('/foo?a=1</div>')
     })
   })
+
+  describe('router prop', () => {
+    describe('`.blockTransitions()`', () => {
+      it('returns a teardown function', () => {
+        let teardownPrompt
+        renderToString(
+          <StaticRouter
+            {...requiredProps}
+            blockTransitions={() => () => {}}
+          >
+            {({ router }) => (
+              <div>{teardownPrompt = router.blockTransitions('Are you sure?')}</div>
+            )}
+          </StaticRouter>
+        )
+        expect(teardownPrompt).toExist()
+        expect(teardownPrompt).toBeA('function')
+      })
+    })
+  })
 })


### PR DESCRIPTION
The `blockTransitions` function on the `router` prop passed down from `<StaticRouter />` was not returning a function to tear down the blocking prompt.

This PR changes the `blockTransitions` function to return its result, which should be the teardown function returned from calling `history.block()`.