### PR TITLE
feat: cancel pending enter/change hooks on location change

### DIFF
--- a/modules/TransitionUtils.js
+++ b/modules/TransitionUtils.js
@@ -12,22 +12,20 @@ const enterHooks = new PendingHooks()
 const changeHooks = new PendingHooks()
 
 function createTransitionHook(hook, route, asyncArity, pendingHooks) {
+  const isSync = hook.length < asyncArity
+
   const transitionHook = (...args) => {
     hook.apply(route, args)
 
-    if (hook.length < asyncArity) {
+    if (isSync) {
       let callback = args[args.length - 1]
-      // Add synchronous hook to pendingHooks (gets removed instantly later)
-      pendingHooks.add(transitionHook)
       // Assume hook executes synchronously and
       // automatically call the callback.
       callback()
     }
   }
 
-  if (hook.length >= asyncArity) {
-    pendingHooks.add(transitionHook)
-  }
+  pendingHooks.add(transitionHook)
 
   return transitionHook
 }

--- a/package.json
+++ b/package.json
@@ -16,8 +16,8 @@
   "bugs": "https://github.com/ReactTraining/react-router/issues",
   "scripts": {
     "build": "npm run build-cjs && npm run build-es",
-    "build-cjs": "rimraf lib && cross-env BABEL_ENV=cjs babel ./modules -d lib --ignore '__tests__'",
-    "build-es": "rimraf es && cross-env BABEL_ENV=es babel ./modules -d es --ignore '__tests__'",
+    "build-cjs": "rimraf lib && cross-env BABEL_ENV=cjs babel ./modules -d lib --ignore __tests__",
+    "build-es": "rimraf es && cross-env BABEL_ENV=es babel ./modules -d es --ignore __tests__",
     "build-umd": "cross-env NODE_ENV=development webpack modules/index.js umd/ReactRouter.js",
     "build-min": "cross-env NODE_ENV=production webpack -p modules/index.js umd/ReactRouter.min.js",
     "lint": "eslint examples modules scripts tools *.js",


### PR DESCRIPTION
Fix for #3220.

- Transition manager keeps track of pending **async** (or sync) hooks (for `onEnter` and `onChange`).
- When new transition starts, redirects from pending async hooks are ignored, fixing the unexpected behaviour in #3220 
- When the hook completes, it is removed from the pending list

This prevents a redirect from *old* transitions happening. If a new transition occurs **after** an async hook with a redirect starts, the *new* location should take precedence, so the redirect is ignored.

See new tests for situations where this might occur

> Also fixed npm tasks on windows again whilst I was there :smile: 

