### PR TITLE
Don't pass `'undefined'` for missing optional parameters

### DIFF
--- a/modules/__tests__/Match-test.js
+++ b/modules/__tests__/Match-test.js
@@ -70,14 +70,14 @@ describe('Match', () => {
             })
           })
         })
-        it('passes undefined for missing optional props', () => {
+        it('does not pass optinal parameters if they do not occur in the URL', () => {
           renderToString(
             <Match
               pattern="/:foo/:bar?"
               location={{ pathname: '/foo' }}
               component={(props) => {
                 expect(props).toEqual({
-                  params: { foo: 'foo', bar: undefined },
+                  params: { foo: 'foo' },
                   isExact: true,
                   pathname: '/foo',
                   location: { pathname: '/foo' },

--- a/modules/__tests__/Match-test.js
+++ b/modules/__tests__/Match-test.js
@@ -70,6 +70,24 @@ describe('Match', () => {
             })
           })
         })
+        it('passes undefined for missing optional props', () => {
+          renderToString(
+            <Match
+              pattern="/:foo/:bar?"
+              location={{ pathname: '/foo' }}
+              component={(props) => {
+                expect(props).toEqual({
+                  params: { foo: 'foo', bar: undefined },
+                  isExact: true,
+                  pathname: '/foo',
+                  location: { pathname: '/foo' },
+                  pattern: '/:foo/:bar?'
+                })
+                return <div />
+              }}
+            />
+          )
+        })
       })
 
       describe('when matched partially', () => {

--- a/modules/matchPattern.js
+++ b/modules/matchPattern.js
@@ -22,8 +22,8 @@ const getMatcher = (pattern, exactly) => {
 }
 
 const parseParams = (pattern, match, keys) =>
-  match.slice(1).reduce((params, value, index) => {
-    params[keys[index].name] = value === undefined ? undefined : decodeURIComponent(value)
+  match.slice(1).filter(value => value !== undefined).reduce((params, value, index) => {
+    params[keys[index].name] = decodeURIComponent(value)
     return params
   }, {})
 

--- a/modules/matchPattern.js
+++ b/modules/matchPattern.js
@@ -23,7 +23,7 @@ const getMatcher = (pattern, exactly) => {
 
 const parseParams = (pattern, match, keys) =>
   match.slice(1).reduce((params, value, index) => {
-    params[keys[index].name] = decodeURIComponent(value)
+    params[keys[index].name] = value === undefined ? undefined : decodeURIComponent(value)
     return params
   }, {})
 


### PR DESCRIPTION
`decodeURIComponent(undefined)` is `"undefined"`