### PR TITLE
Fix Link {...rest} overwriting used properties like onClick

### DIFF
--- a/modules/Link.js
+++ b/modules/Link.js
@@ -75,12 +75,12 @@ class Link extends React.Component {
     if (apatheticToIsActive) {
       return (
         <a
+          {...rest}
           href={router ? router.createHref(to) : to}
           onClick={this.handleClick}
           style={style}
           className={className}
           children={children}
-          {...rest}
         />
       )
     }
@@ -114,6 +114,7 @@ class Link extends React.Component {
           // any attempt at changing to use <Match>
           return (
             <a
+              {...rest}
               href={router ? router.createHref(to) : to}
               onClick={this.handleClick}
               style={isActive ? { ...style, ...activeStyle } : style }
@@ -121,7 +122,6 @@ class Link extends React.Component {
                 [ className, activeClassName ].join(' ').trim() : className
               }
               children={children}
-              {...rest}
             />
           )
         }}


### PR DESCRIPTION
Issue:
`onClick={() => null} to="test">` => Clicking this link with v4-alpha5 causes a page refresh in the browser. That is because the internal onClick was overwritten by the this.props.onClick due to first applying the own props and then applying the ...rest props.

Alternative: Strip out onClick and all other properties that should not be overridden. 