### PR TITLE
[WIP] manage location through MatchProvider

### DIFF
--- a/modules/Match.js
+++ b/modules/Match.js
@@ -64,8 +64,8 @@ class Match extends React.Component {
     }
   }
 
-  componentWillReceiveProps(newProps) {
-    const location = newProps.location || this.context.location
+  componentWillReceiveProps(nextProps, nextContext) {
+    const location = nextProps.location || nextContext.location
     const match = this.matchCurrent(location)
     this.setState({
       match

--- a/modules/Match.js
+++ b/modules/Match.js
@@ -1,7 +1,6 @@
 import React, { PropTypes } from 'react'
 import MatchProvider from './MatchProvider'
 import matchPattern from './matchPattern'
-import { LocationSubscriber } from './Broadcasts'
 
 class Match extends React.Component {
   static defaultProps = {
@@ -79,29 +78,23 @@ class Match extends React.Component {
   }
 
   render() {
+    const { children, render, component:Component,
+      pattern } = this.props
+    const { match } = this.state
+    const location = this.props.location || this.context.location
+    const props = { ...match, location, pattern }
     return (
-      <LocationSubscriber>
-        {(locationContext) => {
-          const { children, render, component:Component,
-            pattern, location } = this.props
-          const { match } = this.state
-          const loc = location || locationContext
-          const props = { ...match, location: loc, pattern }
-          return (
-            <MatchProvider location={loc} match={match}>
-              {children ? (
-                children({ matched: !!match, ...props })
-              ) : match ? (
-                render ? (
-                  render(props)
-                ) : (
-                  <Component {...props}/>
-                )
-              ) : null}
-            </MatchProvider>
+      <MatchProvider location={location} match={match}>
+        {children ? (
+          children({ matched: !!match, ...props })
+        ) : match ? (
+          render ? (
+            render(props)
+          ) : (
+            <Component {...props}/>
           )
-        }}
-      </LocationSubscriber>
+        ) : null}
+      </MatchProvider>
     )
   }
 }

--- a/modules/Miss.js
+++ b/modules/Miss.js
@@ -3,7 +3,7 @@ import { location as locationType } from './PropTypes'
 
 class Miss extends React.Component {
   static contextTypes = {
-    match: PropTypes.object,
+    provider: PropTypes.object,
     location: PropTypes.object,
     serverRouter: PropTypes.object
   }
@@ -12,8 +12,8 @@ class Miss extends React.Component {
     super(props, context)
 
     // ignore if rendered out of context (probably for unit tests)
-    if (context.match && !context.serverRouter) {
-      this.unsubscribe = this.context.match.subscribe((matchesFound) => {
+    if (context.provider && !context.serverRouter) {
+      this.unsubscribe = this.context.provider.addMiss((matchesFound) => {
         this.setState({
           noMatchesInContext: !matchesFound
         })
@@ -22,7 +22,7 @@ class Miss extends React.Component {
 
     if (context.serverRouter) {
       context.serverRouter.registerMissPresence(
-        context.match.serverRouterIndex
+        context.provider.serverRouterIndex
       )
     }
 
@@ -40,11 +40,10 @@ class Miss extends React.Component {
   render() {
     const { render, component:Component } = this.props
     const { noMatchesInContext } = this.state
-    const { location:locationProp } = this.props
-    const location = locationProp || this.context.location
-    const { serverRouter, match } = this.context
+    const location = this.props.location || this.context.location
+    const { serverRouter, provider } = this.context
     const noMatchesOnServerContext = serverRouter &&
-      serverRouter.missedAtIndex(match.serverRouterIndex)
+      serverRouter.missedAtIndex(provider.serverRouterIndex)
     if (noMatchesInContext || noMatchesOnServerContext) {
       return (
         render ? (

--- a/modules/PropTypes.js
+++ b/modules/PropTypes.js
@@ -6,9 +6,9 @@ export const action = PropTypes.oneOf([
   'POP'
 ])
 
-export const matchContext = PropTypes.shape({
+export const providerContext = PropTypes.shape({
   addMatch: PropTypes.func.isRequired,
-  removeMatch: PropTypes.func.isRequired
+  addMiss: PropTypes.func.isRequired
 })
 
 export const history = PropTypes.shape({

--- a/modules/StaticRouter.js
+++ b/modules/StaticRouter.js
@@ -91,10 +91,9 @@ class StaticRouter extends React.Component {
   render() {
     const { location } = this.state
     const { action, children } = this.props
-
     return (
       <LocationBroadcast value={location}>
-        <MatchProvider>
+        <MatchProvider location={location}>
           {typeof children === 'function' ? (
             children({ action, location, router: this.getRouterContext() })
           ) : (

--- a/modules/__tests__/Match-test.js
+++ b/modules/__tests__/Match-test.js
@@ -1,6 +1,7 @@
 import expect from 'expect'
 import React from 'react'
 import Match from '../Match'
+import MatchProvider from '../MatchProvider'
 import { renderToString } from 'react-dom/server'
 import { render } from 'react-dom'
 import { LocationBroadcast } from '../Broadcasts'
@@ -368,9 +369,11 @@ describe('Match', () => {
       const location = { pathname: '/', state: { test: TEXT } }
       const html = renderToString(
         <LocationBroadcast value={location}>
-          <Match pattern="/" render={({ location }) => (
-            <div>{location.state.test}</div>
-          )}/>
+          <MatchProvider location={location}>
+            <Match pattern="/" render={({ location }) => (
+              <div>{location.state.test}</div>
+            )}/>
+          </MatchProvider>
         </LocationBroadcast>
       )
       expect(html).toContain(TEXT)

--- a/modules/__tests__/ServerRouter-test.js
+++ b/modules/__tests__/ServerRouter-test.js
@@ -32,11 +32,11 @@ describe('ServerRouter', () => {
     })
   })
 
-  it('doesn\'t render misses on first pass', () => {
+  it('doesn\'t render misses located before matches', () => {
     const NO = 'NO'
     const YES1 = 'YES1'
     const YES2 = 'YES2'
-    const NEVER = 'NEVER'
+    const NOWHERE = 'NOWHERE'
     const location = '/nowhere'
     const App = () => (
       <div>
@@ -48,9 +48,44 @@ describe('ServerRouter', () => {
             <Miss render={() => (
               <div>{YES2}</div>
             )}/>
-            <Match pattern='/never-renders' render={() => (
-              <div>{NEVER}</div>
+            <Match pattern='/nowhere' render={() => (
+              <div>{NOWHERE}</div>
             )} />
+          </div>
+        )}/>
+        <Miss render={() => <div>{NO}</div>}/>
+      </div>
+    )
+
+    const context = createServerRenderContext()
+
+    const firstRender = renderToString(
+      <ServerRouter context={context} location={location}>
+        <App/>
+      </ServerRouter>
+    )
+
+    const result = context.getResult()
+    expect(result.missed).toBe(false)
+    expect(firstRender).toNotContain(YES1)
+    expect(firstRender).toNotContain(YES2)
+  })
+
+  it('doesn\'t render misses on first pass', () => {
+    const NO = 'NO'
+    const YES1 = 'YES1'
+    const YES2 = 'YES2'
+    const location = '/nowhere'
+    const App = () => (
+      <div>
+        <Match pattern="/" render={() => (
+          <div>
+            <Miss render={() => (
+              <div>{YES1}</div>
+            )}/>
+            <Miss render={() => (
+              <div>{YES2}</div>
+            )}/>
           </div>
         )}/>
         <Miss render={() => <div>{NO}</div>}/>

--- a/modules/__tests__/ServerRouter-test.js
+++ b/modules/__tests__/ServerRouter-test.js
@@ -32,10 +32,11 @@ describe('ServerRouter', () => {
     })
   })
 
-  it('renders misses on second pass with server render context result', (done) => {
+  it('doesn\'t render misses on first pass', () => {
     const NO = 'NO'
     const YES1 = 'YES1'
     const YES2 = 'YES2'
+    const NEVER = 'NEVER'
     const location = '/nowhere'
     const App = () => (
       <div>
@@ -47,6 +48,48 @@ describe('ServerRouter', () => {
             <Miss render={() => (
               <div>{YES2}</div>
             )}/>
+            <Match pattern='/never-renders' render={() => (
+              <div>{NEVER}</div>
+            )} />
+          </div>
+        )}/>
+        <Miss render={() => <div>{NO}</div>}/>
+      </div>
+    )
+
+    const context = createServerRenderContext()
+
+    const firstRender = renderToString(
+      <ServerRouter context={context} location={location}>
+        <App/>
+      </ServerRouter>
+    )
+
+    const result = context.getResult()
+    expect(result.missed).toBe(true)
+    expect(firstRender).toNotContain(YES1)
+    expect(firstRender).toNotContain(YES2)
+  })
+
+  it('renders misses on second pass with server render context result', (done) => {
+    const NO = 'NO'
+    const YES1 = 'YES1'
+    const YES2 = 'YES2'
+    const NEVER = 'NEVER'
+    const location = '/nowhere'
+    const App = () => (
+      <div>
+        <Match pattern="/" render={() => (
+          <div>
+            <Miss render={() => (
+              <div>{YES1}</div>
+            )}/>
+            <Miss render={() => (
+              <div>{YES2}</div>
+            )}/>
+            <Match pattern='/never-renders' render={() => (
+              <div>{NEVER}</div>
+            )} />
           </div>
         )}/>
         <Miss render={() => <div>{NO}</div>}/>
@@ -74,6 +117,7 @@ describe('ServerRouter', () => {
       expect(markup).toContain(YES1)
       expect(markup).toContain(YES2)
       expect(markup).toNotContain(NO)
+      expect(markup).toNotContain(NEVER)
       done()
     }
   })

--- a/modules/createServerRenderContext.js
+++ b/modules/createServerRenderContext.js
@@ -1,34 +1,36 @@
-const k = () => {}
-
 const createServerRenderContext = () => {
   let flushed = false
+  let flushedIndex = 0
   let redirect = null
   let matchContexts = [
-    /* { hasMissComponent: bool, matchesByIdentity: [] } */
+    /* { hasMissComponent: bool, hasMatches: bool } */
   ]
 
-  const setRedirect = flushed ? k : (location) => {
+  const setRedirect = (location) => {
     if (!redirect)
       redirect = location
   }
 
-  const registerMatchContext = flushed ? k : (matchesByIdentity) => {
-    return matchContexts.push({
-      hasMissComponent: false,
-      matchesByIdentity
-    }) - 1
+  // on the second pass, index is determined by render order
+  const registerMatchProvider = () => {
+    return flushed ? flushedIndex++ : (
+      matchContexts.push({
+        hasMissComponent: false,
+        hasMatches: false
+      }) - 1
+    )
   }
 
   // We need to know there is a potential to miss, if there are no Miss
   // components under a Match, then we need to not worry about it
-  const registerMissPresence = flushed ? k : (index) => {
+  const registerMissPresence = (index) => {
     matchContexts[index].hasMissComponent = true
   }
 
   const getResult = () => {
     flushed = true
-    const missed = matchContexts.some((context, index) => {
-      return missedAtIndex(index)
+    const missed = matchContexts.some((context) => {
+      return context.hasMissComponent && !context.hasMatches
     })
 
     return {
@@ -39,17 +41,23 @@ const createServerRenderContext = () => {
 
   const missedAtIndex = (index) => {
     const context = matchContexts[index]
-    return (
-      context.matchesByIdentity.length === 0 &&
-      context.hasMissComponent
-    )
+    // only return true once we have flushed to prevent accidental
+    // render on first pass
+    return flushed && !context.hasMatches && context.hasMissComponent
+  }
+
+  const updateMatchStatus = (index, matches) => {
+    const context = matchContexts[index]
+    // only need one Match to match
+    context.hasMatches = context.hasMatches || matches
   }
 
   return {
     setRedirect,
-    registerMatchContext,
+    registerMatchProvider,
     registerMissPresence,
     getResult,
+    updateMatchStatus,
     missedAtIndex
   }
 }


### PR DESCRIPTION
This is a way to manage location changes that is resistant to `shouldComponentUpdate`.

The main change is that `<MatchProvider>` components are kept updated about the current location. All `<Match>` and `<Miss>` children of a `<MatchProvider>` provide it with update functions. The `<Match>` update functions return a boolean indicating whether they match against the current location. The `<Miss>` update function is the same as the current one.

`<Match>` maintains a `match` state, which is the result of `matchPattern` and is set whenever the component updates naturally (through `componentWillReceiveProps`) or when its `update` function is called.

This passes the failing miss test that @alisd23 wrote in #4047, but may need additional tests to verify its correctness.

Related issue: #4035
