### PR TITLE
update history version check  v3

### DIFF
--- a/modules/Router.js
+++ b/modules/Router.js
@@ -76,10 +76,10 @@ const Router = React.createClass({
     const { routes, children } = this.props
 
     invariant(
-      history.getCurrentLocation,
-      'You have provided a history object created with history v2.x or ' +
-      'earlier. This version of React Router is only compatible with v3 ' +
-      'history objects. Please upgrade to history v3.x.'
+      history.getCurrentLocation && history.transitionTo,
+      'You have provided a history object created with a no supported ' +
+      'history version. This version of React Router is only compatible with ' +
+      'v3 history objects. Plese use history v3.x'
     )
 
     return createTransitionManager(


### PR DESCRIPTION
Unfortunately there are a couple of history v4.x versions which still expose the `getCurrentLocation` function ([v4.0.0-0](https://github.com/mjackson/history/blob/v4.0.0-0/modules/createBrowserHistory.js#L275) and [v4.0.0-1](https://github.com/mjackson/history/blob/v4.0.0-1/modules/createBrowserHistory.js#L291)) so the current history check wasn't catching them. I updated the check to look for `transitionTo`  a function that is no longer exposed on any history object created with history v4.x, I also updated the message.