### PR TITLE
Export dummy proptypes for production.

### DIFF
--- a/modules/PropTypes.js
+++ b/modules/PropTypes.js
@@ -1,48 +1,61 @@
 import { PropTypes } from 'react'
 
-export const action = PropTypes.oneOf([
-  'PUSH',
-  'REPLACE',
-  'POP'
-])
+const placeholder = function() {}
+placeholder.isRequired = function() {}
 
-export const matchContext = PropTypes.shape({
-  addMatch: PropTypes.func.isRequired,
-  removeMatch: PropTypes.func.isRequired
-})
+export let action = placeholder
+export let history = placeholder
+export let location = placeholder
+export let matchContext = placeholder
+export let historyContext = placeholder
+export let routerContext = placeholder
 
-export const history = PropTypes.shape({
-  listen: PropTypes.func.isRequired,
-  listenBefore: PropTypes.func.isRequired,
-  push: PropTypes.func.isRequired,
-  replace: PropTypes.func.isRequired,
-  go: PropTypes.func.isRequired
-})
+if (__DEV__) {
 
-export const location = PropTypes.shape({
-  pathname: PropTypes.string.isRequired,
-  search: PropTypes.string.isRequired,
-  hash: PropTypes.string.isRequired,
-  state: PropTypes.any,
-  key: PropTypes.string
-})
+  action = PropTypes.oneOf([
+    'PUSH',
+    'REPLACE',
+    'POP'
+  ])
 
-export const historyContext = PropTypes.shape({
-  action: action.isRequired,
-  location: location.isRequired,
-  push: PropTypes.func.isRequired,
-  replace: PropTypes.func.isRequired,
-  go: PropTypes.func.isRequired,
-  goBack: PropTypes.func.isRequired,
-  goForward: PropTypes.func.isRequired,
-  canGo: PropTypes.func,
-  block: PropTypes.func.isRequired
-})
+  history = PropTypes.shape({
+    listen: PropTypes.func.isRequired,
+    listenBefore: PropTypes.func.isRequired,
+    push: PropTypes.func.isRequired,
+    replace: PropTypes.func.isRequired,
+    go: PropTypes.func.isRequired
+  })
 
-export const routerContext = PropTypes.shape({
-  transitionTo: PropTypes.func.isRequired,
-  replaceWith: PropTypes.func.isRequired,
-  blockTransitions: PropTypes.func.isRequired,
-  createHref: PropTypes.func.isRequired
-})
+  location = PropTypes.shape({
+    pathname: PropTypes.string.isRequired,
+    search: PropTypes.string.isRequired,
+    hash: PropTypes.string.isRequired,
+    state: PropTypes.any,
+    key: PropTypes.string
+  })
 
+  matchContext = PropTypes.shape({
+    addMatch: PropTypes.func.isRequired,
+    removeMatch: PropTypes.func.isRequired
+  })
+
+  historyContext = PropTypes.shape({
+    action: action.isRequired,
+    location: location.isRequired,
+    push: PropTypes.func.isRequired,
+    replace: PropTypes.func.isRequired,
+    go: PropTypes.func.isRequired,
+    goBack: PropTypes.func.isRequired,
+    goForward: PropTypes.func.isRequired,
+    canGo: PropTypes.func,
+    block: PropTypes.func.isRequired
+  })
+
+  routerContext = PropTypes.shape({
+    transitionTo: PropTypes.func.isRequired,
+    replaceWith: PropTypes.func.isRequired,
+    blockTransitions: PropTypes.func.isRequired,
+    createHref: PropTypes.func.isRequired
+  })
+
+}


### PR DESCRIPTION
Refs #4046

This doesn't eliminate the file, but it does make the file very small.

[My comment](https://github.com/ReactTraining/react-router/issues/4046#issuecomment-255253295) is not totally correct. I thought that `DescendantComponent.contextTypes.whatever` and the `AncestorComponent.childContextTypes.whatever` had to match. I used `npm pack` and installed my branch into a project of mine that imports and uses your proptypes. As long as `DescendantComponent.contextTypes.whatever` doesn't reject, it will accept any context using that key.

This also means that I don't actually have to import the proptypes from this project. Testing this forced an upgrade of `react-history` where `PropTypes` were removed. and I had to replace my code with:

```js
MyComponent.contextTypes = {
    history: function() {}
}
```