### PR TITLE
Use Link outside of a router

### DIFF
--- a/modules/Link.js
+++ b/modules/Link.js
@@ -36,7 +36,8 @@ class Link extends React.Component {
       !event.defaultPrevented && // onClick prevented default
       !this.props.target && // let browser handle "target=_blank" etc.
       !isModifiedEvent(event) &&
-      isLeftClickEvent(event)
+      isLeftClickEvent(event) &&
+      this.context.router
     ) {
       event.preventDefault()
       this.handleTransition()

--- a/modules/__tests__/Link-test.js
+++ b/modules/__tests__/Link-test.js
@@ -403,4 +403,101 @@ describe('Link', () => {
       expect(transitionSpy).toNotHaveBeenCalled()
     })
   })
+
+  describe('outside of a router', () => {
+    it('renders', () => {
+      const div = document.createElement('div')
+      const TEXT = 'TEXT'
+      render((
+        <Link to='/foo'>{TEXT}</Link>
+      ), div)
+      const a = div.querySelector('a')
+      expect(a.textContent).toContain(TEXT)
+    })
+
+    it('can be clicked', () => {
+      const div = document.createElement('div')
+      const preventDefaultSpy = createSpy().andCall(function () {
+        this.defaultPrevented = true
+      })
+      const clickEventData = {
+        button: 0,
+        defaultPrevented: false,
+        preventDefault: preventDefaultSpy
+      }
+
+      render((
+        <Link to='/other'>
+          Text
+        </Link>
+      ), div, () => {
+        const a = div.querySelector('a')
+        expect(() => {
+          click(a, clickEventData)
+        }).toNotThrow()
+      })
+      // when all handleClick checks passed,
+      // preventDefault is called before handleTransition
+      expect(preventDefaultSpy).toNotHaveBeenCalled()
+    })
+
+    describe('active', () => {
+      it('can use active props if provided location prop', () => {
+        const div = document.createElement('div')
+        const location = '/'
+        const className = () => {
+          render((
+            <Link to='/' location={{ pathname: location }} activeClassName='active'>Test</Link>
+          ), div)
+        }
+        const style = () => {
+          render((
+            <Link to='/' location={{ pathname: location }} activeStyle={{ color: 'red' }}>Test</Link>
+          ), div)
+        }
+        const children = () => {
+          render((
+            <Link to='/' location={{ pathname: location }}>
+              {(isActive, href) => (
+                <a href={href} className={isActive ? 'active link' : 'link'}>
+                  Foo
+                </a>
+              )}
+            </Link>
+          ), div)
+        }
+        [className, style, children].forEach(fn => {
+          expect(fn).toNotThrow()
+        })
+      })
+
+      it('throws if using active aware prop with no location', () => {
+        const div = document.createElement('div')
+        const className = () => {
+          render((
+            <Link to='/' activeClassName='active'>Test</Link>
+          ), div)
+        }
+        const style = () => {
+          render((
+            <Link to='/' activeStyle={{ color: 'red' }}>Test</Link>
+          ), div)
+        }
+        const children = () => {
+          render((
+            <Link to='/'>
+              {(isActive, href) => (
+                <a href={href} className={isActive ? 'active link' : 'link'}>
+                  Foo
+                </a>
+              )}
+            </Link>
+          ), div)
+        }
+        [className, style, children].forEach(fn => {
+          expect(fn).toThrow()
+        })
+      })
+    })
+  })
 })

--- a/website/api/Link.md
+++ b/website/api/Link.md
@@ -8,6 +8,11 @@ Provides declarative, accessible navigation around your application.
 </Link>
 ```
 
+**NOTE** The `<Link>` is designed to be used within a router component. However, it can be used outside of a router, but doing so comes with some restrictions:
+
+1. The `to` prop must be a string.
+2. If using any active aware props (`activeClassName`, `activeStyle`, or `children` as a function), you must include a `location` object prop on the `<Link>`.
+
 ## `children: node | func`
 
 The Link component also accepts a function as children.


### PR DESCRIPTION
This should resolve #3889.

I added a note to the documentation listing the restrictions on this, which are:

1. `to` must be a string. If `to` is an object, then the url will be `/[object%20Object]`.
2. If any active aware props are used, then a `location` prop must be included in the `<Link>`'s props.