### PR TITLE
Use strict equality (comparison with `===`)

### DIFF
--- a/modules/__tests__/StaticRouter-test.js
+++ b/modules/__tests__/StaticRouter-test.js
@@ -12,7 +12,7 @@ const expectDeepEquality = (actual, expected) => {
     if (typeof actual[key] === 'object' && actual[key] != null) {
       expectDeepEquality(actual[key], expected[key])
     } else {
-      expect(actual[key]).toEqual(expected[key])
+      expect(actual[key]).toBe(expected[key])
     }
   })
 }


### PR DESCRIPTION
Values should be compared using strict equality so types are compared too, e.g. `23 == '23'` but `23 !== '23'`.