### PR TITLE
Coerce query params to string

### DIFF
--- a/modules/LocationUtils.js
+++ b/modules/LocationUtils.js
@@ -1,6 +1,14 @@
 import { parsePath, createPath } from 'history/PathUtils'
 export { locationsAreEqual } from 'history/LocationUtils'
 
+const coerceValuesToStrings = (query) => {
+  let transformedQuery = {}
+  Object.keys(query).forEach(key =>{
+    transformedQuery[key] = query[key].toString()
+  })
+  return transformedQuery
+}
+
 export const createRouterLocation = (input, parseQueryString, stringifyQuery) => {
   if (typeof input === 'string') {
     const location = parsePath(input)
@@ -16,7 +24,7 @@ export const createRouterLocation = (input, parseQueryString, stringifyQuery) =>
       ),
       hash: input.hash || '',
       state: input.state || null,
-      query: input.query || (
+      query: input.query ? coerceValuesToStrings(input.query) : (
         input.search ? parseQueryString(input.search) : null
       ),
       key: input.key

--- a/modules/LocationUtils.js
+++ b/modules/LocationUtils.js
@@ -4,7 +4,11 @@ export { locationsAreEqual } from 'history/LocationUtils'
 const coerceValuesToStrings = (query) => {
   let transformedQuery = {}
   Object.keys(query).forEach(key =>{
-    transformedQuery[key] = query[key].toString()
+    let value = query[key]
+    if (value != null){
+      value = value.toString()
+    }
+    transformedQuery[key] = value
   })
   return transformedQuery
 }

--- a/modules/__tests__/StaticRouter-test.js
+++ b/modules/__tests__/StaticRouter-test.js
@@ -188,13 +188,25 @@ describe('StaticRouter', () => {
 
       it('coerces query values to strings', () => {
         assertParsedDescriptor({
-          query: { a: 23 }
+          query: { a: 23, b: false }
         }, {
           pathname: '',
-          query: { a: '23' },
+          query: { a: '23', b: 'false' },
           hash: '',
           state: null,
-          search: '?a=23'
+          search: '?a=23&b=false'
+        })
+      })
+
+      it('does not try to coerce null or undefined to strings', () => {
+        assertParsedDescriptor({
+          query: { a: undefined, b: null }
+        }, {
+          pathname: '',
+          query: { a: undefined, b: null },
+          hash: '',
+          state: null,
+          search: '?b'
         })
       })
 

--- a/modules/__tests__/StaticRouter-test.js
+++ b/modules/__tests__/StaticRouter-test.js
@@ -186,6 +186,18 @@ describe('StaticRouter', () => {
         })
       })
 
+      it('coerces query values to strings', () => {
+        assertParsedDescriptor({
+          query: { a: 23 }
+        }, {
+          pathname: '',
+          query: { a: '23' },
+          hash: '',
+          state: null,
+          search: '?a=23'
+        })
+      })
+
     })
   })
 


### PR DESCRIPTION
See #3863:
On one of my pages, where I have a paging table, I store the page number as a query parameter. I use a number in the Link target, e.g. <Link to={{query:{page:2}}}>Page 2</Link>.
When the component re-renders after I click on the Link, props.location.query.page is a number. However, if I reload the page so that window.location.search is parsed again, props.location.query.page is a string.
