### PR TITLE
Coerce query params to string - alternate solution

### DIFF
--- a/modules/LocationUtils.js
+++ b/modules/LocationUtils.js
@@ -16,7 +16,7 @@ export const createRouterLocation = (input, parseQueryString, stringifyQuery) =>
       ),
       hash: input.hash || '',
       state: input.state || null,
-      query: input.query || (
+      query: input.query ? parseQueryString(stringifyQuery(input.query)) : (
         input.search ? parseQueryString(input.search) : null
       )
     }

--- a/modules/__tests__/LocationUtils-test.js
+++ b/modules/__tests__/LocationUtils-test.js
@@ -121,10 +121,11 @@ describe('LocationUtils', () => {
 
       describe('query', () => {
         it('is the provided query', () => {
+          // create query object without a prototype because query-string will do that when parsing
+          const query = Object.create(null)
+          query.bar = 'baz'
           const descriptor = {
-            query: {
-              bar: 'baz'
-            }
+            query: query
           }
           const location = createRouterLocation(descriptor, parse, stringify)
           expect(location.query).toEqual(descriptor.query)

--- a/modules/__tests__/StaticRouter-test.js
+++ b/modules/__tests__/StaticRouter-test.js
@@ -186,6 +186,30 @@ describe('StaticRouter', () => {
         })
       })
 
+      it('coerces query values to strings', () => {
+        assertParsedDescriptor({
+          query: { a: 23, b: false }
+        }, {
+          pathname: '',
+          query: { a: '23', b: 'false' },
+          hash: '',
+          state: null,
+          search: '?a=23&b=false'
+        })
+      })
+
+      it('does not try to coerce null or undefined to strings', () => {
+        assertParsedDescriptor({
+          query: { a: undefined, b: null }
+        }, {
+          pathname: '',
+          query: { a: undefined, b: null },
+          hash: '',
+          state: null,
+          search: '?b'
+        })
+      })
+
     })
   })
 


### PR DESCRIPTION
See #3863:
On one of my pages, where I have a paging table, I store the page number as a query parameter. I use a number in the Link target, e.g. Page 2.
When the component re-renders after I click on the Link, props.location.query.page is a number. However, if I reload the page so that window.location.search is parsed again, props.location.query.page is a string.
Please review #4107 before this.
See also #4099.
