### PR TITLE
preserve location.key only if it was present in the original input object

### DIFF
--- a/modules/LocationUtils.js
+++ b/modules/LocationUtils.js
@@ -1,6 +1,8 @@
 import { parsePath, createPath } from 'history/PathUtils'
 export { locationsAreEqual } from 'history/LocationUtils'
 
+const hasOwnProperty = (o, property) => Object.prototype.hasOwnProperty.call(o, property)
+
 export const createRouterLocation = (input, parseQueryString, stringifyQuery) => {
   if (typeof input === 'string') {
     const location = parsePath(input)
@@ -9,7 +11,7 @@ export const createRouterLocation = (input, parseQueryString, stringifyQuery) =>
     return location
   } else {
     // got a location descriptor
-    return {
+    let result = {
       pathname: input.pathname || '',
       search: input.search || (
         input.query ? `?${stringifyQuery(input.query)}` : ''
@@ -18,9 +20,12 @@ export const createRouterLocation = (input, parseQueryString, stringifyQuery) =>
       state: input.state || null,
       query: input.query || (
         input.search ? parseQueryString(input.search) : null
-      ),
-      key: input.key
+      )
     }
+    if (hasOwnProperty(input, 'key')){
+      result.key = input.key
+    }
+    return result
   }
 }
 

--- a/modules/__tests__/ServerRouter-test.js
+++ b/modules/__tests__/ServerRouter-test.js
@@ -28,8 +28,7 @@ describe('ServerRouter', () => {
       state: { status: 302 },
       query: null,
       search: '',
-      hash: '',
-      key: undefined
+      hash: ''
     })
   })
 


### PR DESCRIPTION
Don't add `key: undefined` to the location if the input does not have a `location` key.
See https://github.com/ReactTraining/react-router/commit/90d4832b57ce5a4f7e0c128923d93108173c6b61, https://github.com/ReactTraining/react-router/issues/3956
