### PR TITLE
Add addon-controlled to redux integration section

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,9 +136,10 @@ positions of window and individual elements.
 
 ### What about Redux?
 
-We have a `<ControlledRouter>` close to being published that makes redux
-integration with React Router the same as ... uh ... integrating an
-`<input>` with Redux.
+We have a `<ControlledRouter>` addon published as an experimental project
+over at https://github.com/ReactTraining/react-router-addons-controlled.
+ControlledRouter makes redux integration with React Router the same as 
+... uh ... integrating an `<input>` with Redux.
 
 ### What about route transition hooks? (example needed)
 


### PR DESCRIPTION
After a bit of searching I found that the addon has been released, via https://github.com/ReactTraining/react-router/issues/3879#issuecomment-255200425

Thought I'd help with others on the redux integration search.