### PR TITLE
Failing <MatchGroup /> Tests

### DIFF
--- a/modules/__tests__/MatchGroup-test.js
+++ b/modules/__tests__/MatchGroup-test.js
@@ -47,5 +47,42 @@ describe('MatchGroup', () => {
       expect(div.innerHTML).toContain(NO_MATCH)
     })
   })
+
+  it('ignores non-Match/Miss components', () => {
+   const App = ({ pathname }) => (
+      <Router initialEntries={[{ pathname }]}>
+        <MatchGroup>
+          <Match exactly pattern="/" component={Home} />
+          <Match pattern="/foo" component={Foo} />
+          <Miss component={NoMatch} />
+          <div />
+        </MatchGroup>
+      </Router>
+    ) 
+
+    render(<App pathname="/"/>, div, () => {
+      expect(div.innerHTML).toContain(HOME)
+    })
+  })
+
+  it('isn\'t affected by parallel matches', () => {
+    const OTHER = 'OTHER'
+    const Other = () => <div>{OTHER}</div>
+    const App = ({ pathname }) => (
+      <Router initialEntries={[{ pathname }]}>
+        <div>
+          <MatchGroup>
+            <Match exactly pattern="/" component={Home} />
+            <Match pattern="/foo" component={Foo} />
+            <Miss component={NoMatch} />
+          </MatchGroup>
+          <Match pattern="/other" component={Other} />
+        </div>
+      </Router>
+    )    
+
+    render(<App pathname="/other"/>, div)
+    expect(div.innerHTML).toContain(NO_MATCH)
+  })
 })
 


### PR DESCRIPTION
### Bug 1:

Non `<Match>`/`<Miss>` components in `<MatchGroup>` causes errors
#### Possible Solution:

enforce that the child's type is either `Miss` or `Match`

``` js
if (matchedIndex || (child.type !== Miss && child.type !== Match))
```
### Bug 2:

Matches outside of `<MatchGroup` break `<Miss>`
#### Possible Solution:

Expanding on bug 1, enforce that all of a `<MatchGroup>`'s children must be `<Match>` components. In order to deal with misses, add a `miss` prop to `<MatchGroup>` which is a component to render when none of the `<Match>`es matched.

This avoids subscribing a `<Miss>` to the parent `<MatchProvider>` and the possibility of someone including multiple `<Miss>` components to a `<MatchGroup>` (I'm not sure _why_ someone would do this, but currently they _can_ and only the last one would render)

``` js
<MatchGroup miss={NoMatch} >
  <Match exactly pattern="/" component={Home} />
  <Match pattern="/foo" component={Foo} />
</MatchGroup>
```
