### PR TITLE
Fix bug with encoded urls

### DIFF
--- a/modules/matchPattern.js
+++ b/modules/matchPattern.js
@@ -44,12 +44,13 @@ const matchPattern = (pattern, location, matchExactly, parent) => {
     }
 
     const matcher = getMatcher(pattern, matchExactly)
-    const match = matcher.regex.exec(location.pathname)
+    const decoded = decodeURIComponent(location.pathname)
+    const match = matcher.regex.exec(decoded)
 
     if (match) {
       const params = parseParams(pattern, match, matcher.keys)
       const pathname = match[0]
-      const isExact = pathname === location.pathname
+      const isExact = pathname === decoded
 
       return { params, isExact, pathname }
     } else {


### PR DESCRIPTION
On initial load in the browser, the window.location.pathname will sometimes be encoded and needs to be decoded to correctly match your routes (or else something like `/%C3%BCber-uns` will not match `/über-uns`);
