### PR TITLE
V4 fix Link Component

### DIFF
--- a/modules/Link.js
+++ b/modules/Link.js
@@ -62,6 +62,7 @@ class Link extends React.Component {
       activeOnlyWhenExact, // eslint-disable-line
       replace, // eslint-disable-line
       children,
+      onClick,
       ...rest
     } = this.props
 


### PR DESCRIPTION
I found an issue in my code where I use the onClick handler to close a navigational menu and found that my onClick was overriding the handleClick of the Link element as it wasn't being excluded from the props passed down.