### PR TITLE
Resolve relative paths

### DIFF
--- a/modules/Link.js
+++ b/modules/Link.js
@@ -1,4 +1,5 @@
 import React, { PropTypes } from 'react'
+import { resolveLocation } from './LocationUtils'
 
 class Link extends React.Component {
   static defaultProps = {
@@ -56,8 +57,8 @@ class Link extends React.Component {
       event.preventDefault()
 
       const { router } = this.context
-      const { to, replace } = this.props
-
+      const { replace } = this.props
+      const to = this.absoluteLocation()
       if (replace) {
         router.replaceWith(to)
       } else {
@@ -66,8 +67,21 @@ class Link extends React.Component {
     }
   }
 
+  absoluteLocation = () => {
+    const { router } = this.context
+    let { to } = this.props
+    let base
+    // use the context.router's match if it exists
+    if (router.match) {
+      const matchState = router.match.getState()
+      base = matchState && matchState.match.pathname
+    }
+    return resolveLocation(to, base)
+  }
+
   getIsActive() {
-    const { to, isActive } = this.props
+    const { isActive } = this.props
+    const to = this.absoluteLocation()
 
     return isActive(
       this.context.router.getState().location,
@@ -79,7 +93,7 @@ class Link extends React.Component {
   render() {
     const { isActive } = this.state
     const {
-      to,
+      to: undefTo, // eslint-disable-line
       style, activeStyle,
       className, activeClassName,
       activeOnlyWhenExact, // eslint-disable-line
@@ -87,6 +101,8 @@ class Link extends React.Component {
       isActive:_, // eslint-disable-line
       ...rest
     } = this.props
+
+    const to = this.absoluteLocation()
 
     return (
       <a

--- a/modules/LocationUtils.js
+++ b/modules/LocationUtils.js
@@ -32,3 +32,111 @@ export const createRouterPath = (input, stringifyQuery) => {
     )
   })
 }
+
+export const resolveLocation = (location, base) => {
+  if (!isRelative(location)) {
+    return location
+  }
+
+  if (typeof location === 'string') {
+    return resolve(location, base)
+  } else {
+    location.pathname = resolve(location.pathname, base)
+    return location
+  }
+}
+
+const isRelative = (location) => {
+  if (typeof location === 'string') {
+    return location.charAt(0) !== '/'
+  } else {
+    const { pathname, query, search, hash } = location
+    // If there is no pathname, the location should still be
+    // considered relative if it has a query, search, or hash
+    // (but not an empty query)
+    if (!pathname) {
+      return (query && Object.keys(query).length) || !!search || !!hash
+    }
+    return pathname.charAt(0) !== '/'
+  }
+}
+
+// works similarly, but not exactly the same as RFC 1808
+// https://tools.ietf.org/html/rfc1808#section-4
+// base is the base URL and path is the URL to resolve.
+// this differentiates from the RFC because it treats
+// the url pattern "foo/bar" the same as "foo/bar/" where the
+// relative path will be joined after "bar"
+const resolve = (path, base = '') => {
+  if (path === undefined) {
+    return base
+  } else if (base === '') {
+    return '/' + path
+  }
+
+  // RFC 1808 drops the last base segment (step 6) and joins off
+  // of its parent. This does not happen in here because the last
+  // segment of the base because we want to join off of the last
+  // segment. If the base ends in a forward slash, strip it so that
+  // we join off of the segment before that instead.
+  if (base[base.length-1] === '/') {
+    base = base.slice(0,-1)
+  }
+
+  const baseSegments = splitSegments(base)
+  const { pathname, extra } = removeExtra(path)
+  // don't need to resolve if there is no pathname
+  if (pathname === '') {
+    return base + extra
+  }
+
+  // filter out all ./ segments (step 6.a)
+  const relativeSegments = splitSegments(pathname).filter(s => s !== '.')
+  return joinSegments([...baseSegments, ...relativeSegments]) + extra
+}
+
+// remove any '//' from the path because this doesn't mean anything
+// and will interfere in replacement
+const splitSegments = (path) => path.replace('//','/').split('/')
+
+// if the original location was a string (not a descriptor), then the search
+// or hash can still be attached to the path, so remove it before resolving
+const removeExtra = (path) => {
+  const hashIndex = path.indexOf('#')
+  const searchIndex = path.indexOf('?')
+  let splitIndex
+  if (searchIndex >= 0 && hashIndex >= 0) {
+    splitIndex = Math.min(searchIndex, hashIndex)
+  } else if (searchIndex >=0) {
+    splitIndex = searchIndex
+  } else if (hashIndex >= 0) {
+    splitIndex = hashIndex
+  }
+
+  return {
+    pathname: splitIndex !== undefined ? path.slice(0, splitIndex) : path,
+    extra: splitIndex !== undefined ? path.slice(splitIndex) : ''
+  }
+}
+
+const joinSegments = (segments) => {
+  // (step 6.c)
+  return segments
+    .reduce((acc, segment) => {
+      if (segment !== '..') {
+        return acc.concat(segment)
+      }
+      // remove <segment>/.. but not ../.. (or /.., but the only empty
+      // string segment should be the root segment). To do this,
+      // we want to verify that the last kept item is not a '..' or a ''.
+      // If it is a '..', that means that we already failed to match
+      // (['', 'foo', '..'] will never occur)
+      const last = acc[acc.length-1]
+      if (last !== '..' && last !== '') {
+        return acc.slice(0, -1)
+      } else {
+        return acc.concat('..')
+      }
+    }, [])
+    .join('/')
+}

--- a/modules/LocationUtils.js
+++ b/modules/LocationUtils.js
@@ -121,22 +121,25 @@ const removeExtra = (path) => {
 
 const joinSegments = (segments) => {
   // (step 6.c)
-  return segments
-    .reduce((acc, segment) => {
-      if (segment !== '..') {
-        return acc.concat(segment)
-      }
-      // remove <segment>/.. but not ../.. (or /.., but the only empty
-      // string segment should be the root segment). To do this,
-      // we want to verify that the last kept item is not a '..' or a ''.
-      // If it is a '..', that means that we already failed to match
-      // (['', 'foo', '..'] will never occur)
-      const last = acc[acc.length-1]
-      if (last !== '..' && last !== '') {
-        return acc.slice(0, -1)
-      } else {
-        return acc.concat('..')
-      }
-    }, [])
-    .join('/')
+  const output = []
+  const length = segments.length
+  for (let i=0; i<length; i++) {
+    const curr = segments[i]
+    if (curr !== '..') {
+      output.push(curr)
+      continue
+    }
+    // remove <segment>/.. but not ../.. (or /.., but the only empty
+    // string segment should be the root segment). To do this,
+    // we want to verify that the last kept item is not a '..' or a ''.
+    // If it is a '..', that means that we already failed to match
+    // (['', 'foo', '..'] will never occur in the output array)
+    const last = output[output.length-1]
+    if (last !== '..' && last !== '') {
+      output.pop()
+    } else {
+      output.push('..')
+    }
+  }
+  return output.join('/')
 }

--- a/modules/Redirect.js
+++ b/modules/Redirect.js
@@ -1,4 +1,5 @@
 import React, { PropTypes } from 'react'
+import { resolveLocation } from './LocationUtils'
 
 class Redirect extends React.Component {
   static defaultProps = {
@@ -34,7 +35,13 @@ class Redirect extends React.Component {
 
   redirect() {
     const { router } = this.context
-    const { to, push } = this.props
+    let { to } = this.props
+    const { push } = this.props
+    
+    const routerState = router && router.getState()
+    const matchState = routerState && routerState.match
+    const base = matchState && matchState.pathname
+    to = resolveLocation(to, base)
     const navigate = push ? router.transitionTo : router.replaceWith
     navigate(to)
   }

--- a/modules/Redirect.js
+++ b/modules/Redirect.js
@@ -37,10 +37,11 @@ class Redirect extends React.Component {
     const { router } = this.context
     let { to } = this.props
     const { push } = this.props
-    
-    const routerState = router && router.getState()
-    const matchState = routerState && routerState.match
-    const base = matchState && matchState.pathname
+    let base
+    if (router.match) {
+      const matchState = router.match.getState()
+      base = matchState && matchState.match.pathname
+    }
     to = resolveLocation(to, base)
     const navigate = push ? router.transitionTo : router.replaceWith
     navigate(to)

--- a/modules/__tests__/HashRouter-test.js
+++ b/modules/__tests__/HashRouter-test.js
@@ -8,6 +8,7 @@ describe('HashRouter', () => {
   const div = document.createElement('div')
 
   afterEach(() => {
+    history.replaceState(null, document.title, '#')
     unmountComponentAtNode(div)
   })
 

--- a/modules/__tests__/Link-test.js
+++ b/modules/__tests__/Link-test.js
@@ -4,6 +4,7 @@ import Link from '../Link'
 import MemoryRouter from '../MemoryRouter'
 import StaticRouter from '../StaticRouter'
 import { render, unmountComponentAtNode } from 'react-dom'
+import Match from '../Match'
 import { Simulate } from 'react-addons-test-utils'
 
 const { click } = Simulate
@@ -27,6 +28,40 @@ describe('Link', () => {
       const div = document.createElement('div')
       render(<LinkInContext {...requiredProps} to="/foo"/>, div)
       expect(div.querySelector('a').getAttribute('href')).toEqual('/foo')
+    })
+
+    describe('relative path', () => {
+      it('works with search/hash pathnames', () => {
+        const pathname = 'test?this/../isfine'
+        const div = document.createElement('div')
+        render(<LinkInContext {...requiredProps} to={pathname}/>, div)
+        expect(div.querySelector('a').getAttribute('href')).toEqual(`/${pathname}`)
+      })
+
+      describe('with context.match', () => {
+        const BASE = '/a/b'
+        const LinkInMatch = ({pattern = BASE, ...props}) => (
+          <MemoryRouter initialEntries={[ pattern ]}>
+            <Match pattern={pattern} render={() => (
+              <Link {...props}/>
+            )} />
+          </MemoryRouter>
+        )
+
+        it('resolves using parent pathname', () => {
+          const div = document.createElement('div')
+          render(<LinkInMatch to="foo"/>, div)
+          expect(div.querySelector('a').getAttribute('href')).toEqual('/a/b/foo')  
+        })
+      })
+
+      describe('without context.match', () => {
+        it('resolves using root', () => {
+          const div = document.createElement('div')
+          render(<LinkInContext {...requiredProps} to="foo"/>, div)
+          expect(div.querySelector('a').getAttribute('href')).toEqual('/foo')
+        })
+      })
     })
 
     describe('with context.router', () => {
@@ -216,6 +251,19 @@ describe('Link', () => {
         render((
           <LinkInContext
             to='/foo'
+            location={{ pathname: '/foo' }}
+            activeClassName="active"
+          />
+        ), div)
+        const a = div.querySelector('a')
+        expect(a.className).toEqual('active')
+      })
+
+      it('works with relative links', () => {
+        const div = document.createElement('div')
+        render((
+          <LinkInContext
+            to='foo'
             location={{ pathname: '/foo' }}
             activeClassName="active"
           />

--- a/modules/__tests__/integration-test.js
+++ b/modules/__tests__/integration-test.js
@@ -484,3 +484,44 @@ describe('Integration Tests', () => {
     })
   })
 })
+
+describe('Link with relative to', () => {
+  it('navigates', () => {
+    const leftClickEvent = {
+      defaultPrevented: false,
+      preventDefault() { this.defaultPrevented = true },
+      metaKey: null,
+      altKey: null,
+      ctrlKey: null,
+      shiftKey: null,
+      button: 0
+    }
+    const div = document.createElement('div')
+    const TEXT1 = 'I AM PAGE 1'
+    const TEXT2 = 'I AM PAGE 2'
+    render((
+      <MemoryRouter initialEntries={[ '/' ]}>
+        <div>
+          <Link id="one" to="one">One</Link>
+          <Match pattern="/one" render={() => (
+            <div>
+              <h1>{TEXT1}</h1>
+              <Link id="two" to="two">Two</Link>
+              <Match pattern="two" render={() => (
+                <h2>{TEXT2}</h2>
+              )}/>
+            </div>
+          )}/>
+        </div>
+      </MemoryRouter>
+    ), div)
+    expect(div.innerHTML).toNotContain(TEXT1)
+
+    Simulate.click(div.querySelector('#one'), leftClickEvent)
+    expect(div.innerHTML).toContain(TEXT1)
+    expect(div.innerHTML).toNotContain(TEXT2)
+
+    Simulate.click(div.querySelector('#two'), leftClickEvent)
+    expect(div.innerHTML).toContain(TEXT2)
+  })
+})

--- a/modules/index.js
+++ b/modules/index.js
@@ -17,3 +17,6 @@ export StaticRouter from './StaticRouter'
 
 // Util for creating who-knows-what!
 export matchPattern from './matchPattern'
+
+// Util for resolving relative paths
+export { resolveLocation } from './LocationUtils'


### PR DESCRIPTION
I know that @ryanflorence has mentioned some work on relative URLs in other threads, but I thought that I'd make a pull request with a possible working option based on RFC 1808.

I left in comments so that hopefully it should be understandable, but you might also need to reference the [RFC 1808](https://tools.ietf.org/html/rfc1808#section-4) steps. It passes the tests described by 1808, albeit with one modification:

In 1808, anything after the final forward slash in the base url is removed before resolving URLs. However, in React Router, the content after the final forward slash is the base for its children, so it should not be stripped. The tests have been updated to reflect this.

Note: I'm exporting the `makeRootRelative` function because it was convenient while I was writing this, but the tests for it should just be folded into the `createRouterPath` tests.

Currently the only tests are the examples from the RFC, so those will probably need to be expanded to ensure correctness, but hopefully this can be a good starting point for addressing the issue (mostly because I dislike writing ```to={`${pathname}/bar`}```).