### PR TITLE
Spec for Malformed URI Handling in Match Function

### DIFF
--- a/modules/__tests__/serverRendering-test.js
+++ b/modules/__tests__/serverRendering-test.js
@@ -183,6 +183,13 @@ describe('server rendering', function () {
     })
   })
 
+  it('gracefully handles invalid urls', function (done) {
+    match({ routes, location: '/foo?18924%2S%24' }, function (error) {
+      expect(error).to.not.be(undefined)
+      done()
+    })
+  })
+
   describe('server/client consistency', () => {
     // Just render to static markup here to avoid having to normalize markup.
 


### PR DESCRIPTION
# Spec for Malformed URI Handling in Match Function

I encountered an issue in my server-side rendering code where if a user comes in at an invalid route, there is an uncaught `URIError: URI malformed` exception.  I guess I could wrap my `match` call in a try catch, but I would rather not do that.

I expect that if there is a URI Error then the callback should be called with an error, but this doesn't seem to happen.  Does it seem like a good idea to catch these errors and pass them to the callback?

Thanks!