### PR TITLE
Prevent transitions for external links

### DIFF
--- a/modules/Link.js
+++ b/modules/Link.js
@@ -9,6 +9,10 @@ function isLeftClickEvent(event) {
   return event.button === 0
 }
 
+function isExternalLinkClickEvent(event) {
+  return event.currentTarget.host !== window.location.host
+}
+
 function isModifiedEvent(event) {
   return !!(event.metaKey || event.altKey || event.ctrlKey || event.shiftKey)
 }
@@ -84,7 +88,7 @@ const Link = React.createClass({
       '<Link>s rendered outside of a router context cannot navigate.'
     )
 
-    if (isModifiedEvent(event) || !isLeftClickEvent(event))
+    if (isModifiedEvent(event) || !isLeftClickEvent(event) || isExternalLinkClickEvent(event))
       return
 
     // If target prop is set (e.g. to "_blank"), let browser handle link.

--- a/modules/__tests__/Link-test.js
+++ b/modules/__tests__/Link-test.js
@@ -1,4 +1,4 @@
-import expect, { spyOn } from 'expect'
+import expect, { spyOn, createSpy } from 'expect'
 import React, { Component } from 'react'
 import { Simulate } from 'react-addons-test-utils'
 import { render } from 'react-dom'
@@ -8,7 +8,6 @@ import Router from '../Router'
 import Route from '../Route'
 import Link from '../Link'
 import execSteps from './execSteps'
-
 const { click } = Simulate
 
 describe('A <Link>', () => {
@@ -556,5 +555,35 @@ describe('A <Link>', () => {
         done()
       })
     })
+  })
+
+  describe('when the "to" prop contains external URL', function () {
+    it('should navigate to external page', function (done) {
+      const handleClick = createSpy().andCallThrough()
+      class App extends Component {
+        render() {
+          return (
+            <div>
+              <Link to="https://google.com/newpath" onClick={handleClick}>External link</Link>
+            </div>
+          )
+        }
+      }
+      const history = createHistory('/')
+      const spy = spyOn(history, 'push').andCallThrough()
+      render((
+        <Router history={createHistory('/')} >
+          <Route path="/" component={App}/>
+        </Router>
+      ), node, function () {
+        click(node.querySelector('a'), { button: 0 })
+        expect(spy).toNotHaveBeenCalled()
+        expect(handleClick).toHaveBeenCalled()
+        const event = handleClick.calls[0].arguments[0]
+        expect(event.isDefaultPrevented()).toEqual(false)
+        done()
+      })
+    })
+
   })
 })


### PR DESCRIPTION
Related issue https://github.com/ReactTraining/react-router/issues/1147
It seems like many people including myself are ending up creating custom wrapper around `<Link/>` to handle external link clicks.
I think, ideally that functionality should be handled by react-router as browser has access to current and link's hosts. It turned out that it's relatively easy to compare them on click and prevent router transitions.
Hope this PR will make it and looking forward for the feedback.
