### PR TITLE
Render <Miss> component when added after first render pass

### DIFF
--- a/modules/Miss.js
+++ b/modules/Miss.js
@@ -26,7 +26,7 @@ class Miss extends React.Component {
     }
 
     this.state = {
-      noMatchesInContext: false
+      noMatchesInContext: context.match && !context.match.matches.length
     }
   }
 

--- a/modules/__tests__/Miss-test.js
+++ b/modules/__tests__/Miss-test.js
@@ -76,4 +76,54 @@ describe('Miss', () => {
       })
     })
   })
+
+  describe('when added subsequently', () => {
+    const Page = () => <div>{TEXT}</div>
+
+    class DelayedMiss extends React.Component {
+      constructor(props) {
+        super(props)
+        this.state = { renderMiss: false }
+      }
+
+      componentDidMount() {
+        this.setState({ renderMiss: true }) // eslint-disable-line react/no-did-mount-set-state
+      }
+
+      render() {
+        return this.state.renderMiss && <Miss component={Page} />
+      }
+    }
+
+    it('renders without a match', (done) => {
+      const div = document.createElement('div')
+
+      render((
+        <MemoryRouter initialEntries={[ loc ]}>
+          <DelayedMiss />
+        </MemoryRouter>
+      ), div, () => {
+        expect(div.innerHTML).toContain(TEXT)
+        unmountComponentAtNode(div)
+        done()
+      })
+    })
+
+    it('does not render on match', (done) => {
+      const div = document.createElement('div')
+
+      render((
+        <MemoryRouter initialEntries={[loc]}>
+          <div>
+            <Match pattern="/" component={() => <div />}/>
+            <DelayedMiss />
+          </div>
+        </MemoryRouter>
+      ), div, () => {
+        expect(div.innerHTML).toNotContain(TEXT)
+        unmountComponentAtNode(div)
+        done()
+      })
+    })
+  })
 })


### PR DESCRIPTION
Still new to v4, so apologies if I missed something :)

This adds a test to check if `Miss` renders when added after the first render pass. The simplest fix I found was to check the current match state from context for the initial state.

Btw, as I see it, #4127 is not a dupe of #4104, since it's about `Miss` *never* rendering, while #4127 is about `Miss` only briefly rendering `null`.

Also, there seem to be more issues when subsequently adding a (matching) `Match`, or changing the `pattern` prop. I'd look into it, but perhaps there's already someone working on it or a discussion that I missed?