### PR TITLE
fix(Link): More strict matching

### DIFF
--- a/modules/Link.js
+++ b/modules/Link.js
@@ -131,8 +131,8 @@ if (__DEV__) {
 const createLocationDescriptor = (to) =>
   typeof to === 'object' ? to : { pathname: to }
 
-const pathIsActive = (to, pathname, activeOnlyWhenExact) =>
-  activeOnlyWhenExact ? pathname === to : pathname.indexOf(to) === 0
+const pathIsActive = (to = '', pathname, activeOnlyWhenExact) =>
+  activeOnlyWhenExact ? pathname === to : new RegExp(to.replace(/\//ig, '\\/') + '(\\/|$)').test(pathname)
 
 const queryIsActive = (query, activeQuery) => {
   if (activeQuery == null)

--- a/modules/__tests__/Link-test.js
+++ b/modules/__tests__/Link-test.js
@@ -234,6 +234,32 @@ describe('Link', () => {
         const a = div.querySelector('a')
         expect(a.className).toEqual('active')
       })
+      
+      it('isActive on complete matches location substring', () => {
+        const div = document.createElement('div')
+        render((
+          <LinkInContext
+            to='/foo-bar'
+            location={{ pathname: '/foo' }}
+            activeClassName="active"
+          />
+        ), div)
+        const a = div.querySelector('a')
+        expect(a.className).toNotEqual('active')
+      })
+      
+      it('isActive on complete matches "to" substring', () => {
+        const div = document.createElement('div')
+        render((
+          <LinkInContext
+            to='/foo'
+            location={{ pathname: '/foo-bar' }}
+            activeClassName="active"
+          />
+        ), div)
+        const a = div.querySelector('a')
+        expect(a.className).toNotEqual('active')
+      })
 
       it('isActive on exact matches', () => {
         const div = document.createElement('div')


### PR DESCRIPTION
Prevents Link passing isActive = true when URL is `/agent-code` and to value is `/agent`.

Fix for #4130