### PR TITLE
Failing test for Miss passing unexpected location

### DIFF
--- a/modules/__tests__/Miss-test.js
+++ b/modules/__tests__/Miss-test.js
@@ -4,6 +4,7 @@ import Miss from '../Miss'
 import Match from '../Match'
 import { render, unmountComponentAtNode } from 'react-dom'
 import MemoryRouter from '../MemoryRouter'
+import { routerContext as routerContextType } from '../PropTypes'
 
 describe('Miss', () => {
   const TEXT = 'TEXT'
@@ -74,6 +75,43 @@ describe('Miss', () => {
         expect(div.innerHTML).toNotContain(MATCH)
         done()
       })
+    })
+  })
+
+  it('does not update children with wrong location', (done) => {
+    const div = document.createElement('div')
+    let router = null
+
+    class Test extends React.Component {
+      static contextTypes = {
+        router: routerContextType
+      }
+
+      constructor(props, context) {
+        super(props, context)
+        router = context.router
+      }
+
+      componentDidUpdate() {
+        expect(this.props.location.pathname).toNotBe('/matched')
+      }
+
+      render() {
+        return null
+      }
+    }
+
+    render((
+      <MemoryRouter initialEntries={[ loc ]}>
+        <div>
+          <Miss component={Test} />
+          <Match pattern="/matched" component={() => <div />} />
+        </div>
+      </MemoryRouter>
+    ), div, () => {
+      router.transitionTo('/matched')
+      unmountComponentAtNode(div)
+      done()
     })
   })
 })


### PR DESCRIPTION
Not sure if anyone has though of that yet, but here's another issue related to the technical intricacies of `<Miss>`: When the router transitions to a URL that causes the content of `<Miss>` to unmount, the content will be updated once with the new `location` object, even though there is an active `<Match>`.

The same could happen when the change of the match state is initiated by the user, e.g.:

```js
{ state.loaded && <Match pattern="/" /> } {/* matches once state.loaded turns true */}
<Miss />
```

Like with the initial mounting (#4104), it seems there's no way for `<Miss>` to know of the current match state before everything has updated, so the only workaround I can think of would be to delay the update until everything has re-rendered by exploiting `shouldComponentUpdate` and `componentDidUpdate`, which doesn't feel right..