### PR TITLE
Fix faulty createHashHistory path

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -652,7 +652,7 @@ enhancers from `history`
 
 #### Example
 ```js
-import createHashHistory from 'history/lib/createHashHistory'
+import createHashHistory from 'history/createHashHistory'
 const history = useRouterHistory(createHashHistory)({ queryKey: false })
 ```
 


### PR DESCRIPTION
'history' package does not seem to have a 'lib' anymore. 'history/createHashHistory' is the right path now.