### PR TITLE
Accept array as pattern

### DIFF
--- a/modules/Match.js
+++ b/modules/Match.js
@@ -107,7 +107,10 @@ class Match extends React.Component {
 
 if (__DEV__) {
   Match.propTypes = {
-    pattern: PropTypes.string,
+    pattern: PropTypes.oneOfType([
+      PropTypes.string,
+      PropTypes.arrayOf(PropTypes.string)
+    ]),
     exactly: PropTypes.bool,
 
     children: PropTypes.func,


### PR DESCRIPTION
path-to-regexp accepts an array (like in expressjs), but the match.js propTypes allow only for strings.