### PR TITLE
Add shared history example

### DIFF
--- a/website/components/FakeBrowser/index.js
+++ b/website/components/FakeBrowser/index.js
@@ -53,7 +53,7 @@ const Button = (props) => (
     background="none"
     fontSize="200%"
     marginTop="-3px"
-    {...props}
+    props={props}
   />
 )
 
@@ -133,15 +133,17 @@ class FakeBrowser extends React.Component {
                   paddingLeft={`${PAD*1.25}px`}
                   color={GRAY}
                   type="text"
-                  value={createPathWithQuery(this.state.location || location)}
-                  onChange={(e) => {
-                    this.setState({
-                      location: e.target.value
-                    })
-                  }}
-                  onKeyDown={(e) => {
-                    if (e.key === 'Enter') {
-                      history.push(e.target.value)
+                  props={{
+                    value: createPathWithQuery(this.state.location || location),
+                    onChange: (e) => {
+                      this.setState({
+                        location: e.target.value
+                      })
+                    },
+                    onKeyDown: (e) => {
+                      if (e.key === 'Enter') {
+                        history.push(e.target.value)
+                      }
                     }
                   }}
                 />

--- a/website/components/FakeBrowserRouter.js
+++ b/website/components/FakeBrowserRouter.js
@@ -1,11 +1,11 @@
 import { PropTypes } from 'react'
 
-const ExampleRouter = ({ children, ...rest }, context) => (
+const ExampleBrowserRouter = ({ children, ...rest }, context) => (
   typeof children === 'function' ? children({ ...rest, router: context.router }) : children
 )
 
-ExampleRouter.contextTypes = {
+ExampleBrowserRouter.contextTypes = {
   router: PropTypes.object
 }
 
-export default ExampleRouter
+export default ExampleBrowserRouter

--- a/website/examples/SharedHistory.js
+++ b/website/examples/SharedHistory.js
@@ -1,0 +1,46 @@
+import React from 'react'
+import BrowserRouter from 'react-router/BrowserRouter'
+import Router from 'react-router/Router'
+import Match from 'react-router/Match'
+import Link from 'react-router/Link'
+import { createMemoryHistory } from 'history'
+
+class SharedHistoryExample extends React.Component {
+  componentWillMount() {
+    this.otherHistory = createMemoryHistory();
+  }
+  render() {
+    return (
+      <div>
+        <BrowserRouter>
+          <div>
+            <ul>
+              <li><Link to="/">Home</Link></li>
+              <li><Link to="/about">About</Link></li>
+            </ul>
+            <Match exactly pattern="/" component={() => <h2>Home</h2>}/>
+            <Match pattern="/about" component={() => <h2>About</h2>}/>
+          </div>
+        </BrowserRouter>
+        <hr/>
+
+        <Router history={this.otherHistory}>
+          <ul>
+            <li><Link to="/">Home</Link></li>
+            <li><Link to="/one">One</Link></li>
+            <li><Link to="/two">Two</Link></li>
+          </ul>
+        </Router>
+        <Router history={this.otherHistory}>
+          <div>
+            <Match exactly pattern="/" component={() => <h2>Home</h2>}/>
+            <Match pattern="/one" component={() => <h2>One</h2>}/>
+            <Match pattern="/two" component={() => <h2>Two</h2>}/>
+          </div>
+        </Router>
+      </div>
+    )
+  }
+}
+
+export default SharedHistoryExample

--- a/website/routes.js
+++ b/website/routes.js
@@ -59,10 +59,14 @@ export const EXAMPLES = [
     load: require('bundle?lazy!babel!./examples/Ambiguous'),
     loadSource: require('bundle?lazy!!prismjs?lang=jsx!./examples/Ambiguous.js')
   },
+  { name: 'Shared History',
+    path: '/examples/shared-history',
+    load: require('bundle?lazy!babel!./examples/SharedHistory'),
+    loadSource: require('bundle?lazy!!prismjs?lang=jsx!./examples/SharedHistory.js')
+  },
   { name: 'Route Config',
     path: '/examples/route-config',
     load: require('bundle?lazy!babel!./examples/RouteConfig'),
     loadSource: require('bundle?lazy!!prismjs?lang=jsx!./examples/RouteConfig.js')
   }
 ]
-

--- a/website/webpack.config.js
+++ b/website/webpack.config.js
@@ -38,7 +38,8 @@ module.exports = {
       'react-router/Link': path.join(ROUTER_SRC, 'Link'),
       'react-router/Redirect': path.join(ROUTER_SRC, 'Redirect'),
       'react-router/NavigationPrompt': path.join(ROUTER_SRC, 'NavigationPrompt'),
-      'react-router/BrowserRouter': path.join(__dirname, 'components', 'ExampleRouter')
+      'react-router/BrowserRouter': path.join(__dirname, 'components', 'FakeBrowserRouter'),
+      'react-router/Router': path.join(ROUTER_SRC, 'Router')
     }
   },
 


### PR DESCRIPTION
Just added an example for my use case: I have multiple React Apps living in the same page and I like to use React Router v4 within both of them. Afaik I need a shared instance of `createBrowserHistory()` that both React Apps can use. The new v4 API exposes a BrowserRouter that creates a new history object, so I use the underlying Router instead.

Imagine something like:

```
const history = createBrowserHistory()
ReactDOM.render(<Router history={history}><AppOne /></Router>, document.getElementById('app-one'))
ReactDOM.render(<Router history={history}><AppTwo /></Router>, document.getElementById('app-two'))
```

