### PR TITLE
Make Routers history prop required

### DIFF
--- a/modules/Router.js
+++ b/modules/Router.js
@@ -18,7 +18,7 @@ const { func, object } = React.PropTypes
 const Router = React.createClass({
 
   propTypes: {
-    history: object,
+    history: object.isRequired,
     children: routes,
     routes, // alias for children
     render: func,


### PR DESCRIPTION
Currently, if a user forgets to pass a `history` prop to `Router`, they get the following error:

```
Uncaught TypeError: Cannot read property 'getCurrentLocation' of undefined(…)
```
This error is generated by a call to `this.props.history` in `createTransitionManager`.

By making the prop required, the user gets a helpful warning instead.

```
warning.js:36Warning: Failed prop type: The prop `history` is marked as required in `Router`, but its value is `undefined`.
```

Is this something that would be desirable?

