### PR TITLE
Fix Link component conflicting with Angular router

### DIFF
--- a/modules/Link.js
+++ b/modules/Link.js
@@ -61,7 +61,8 @@ const Link = React.createClass({
     activeClassName: string,
     onlyActiveOnIndex: bool.isRequired,
     onClick: func,
-    target: string
+    target: string,
+    noHref: bool
   },
 
   getDefaultProps() {
@@ -98,7 +99,7 @@ const Link = React.createClass({
   },
 
   render() {
-    const { to, activeClassName, activeStyle, onlyActiveOnIndex, ...props } = this.props
+    const { to, activeClassName, activeStyle, onlyActiveOnIndex, noHref, ...props } = this.props
 
     // Ignore if rendered outside the context of router to simplify unit testing.
     const { router } = this.context
@@ -108,7 +109,8 @@ const Link = React.createClass({
       if (!to) { return <a {...props} /> }
 
       const toLocation = resolveToLocation(to, router)
-      props.href = router.createHref(toLocation)
+      if (!noHref)
+        props.href = router.createHref(toLocation)
 
       if (activeClassName || (activeStyle != null && !isEmptyObject(activeStyle))) {
         if (router.isActive(toLocation, onlyActiveOnIndex)) {

--- a/modules/__tests__/Link-test.js
+++ b/modules/__tests__/Link-test.js
@@ -512,7 +512,7 @@ describe('A <Link>', () => {
         <Router history={createHistory('/hello')} onUpdate={execNextStep}>
           <Route path="/hello" component={LinkWrapper} />
         </Router>
-      ), node, execSteps)
+      ), node, execNextStep)
     })
   })
 
@@ -555,6 +555,50 @@ describe('A <Link>', () => {
         expect(link3.className).toEqual('kitten-link')
         done()
       })
+    })
+  })
+
+  describe('when the "noHref" prop is specified', () => {
+    class App extends Component {
+      render() {
+        return (
+          <div>
+            <Link to="/hello?the=query#hash" noHref>Link with noHref</Link>
+          </div>
+        )
+      }
+    }
+
+    it('returns an anchor tag without an href', done => {
+      render((
+        <Router history={createHistory('/')}>
+          <Route path="/" component={App} />
+        </Router>
+      ), node, () => {
+        const link = node.querySelectorAll('a')[0]
+        expect(link.href).toEqual('')
+        done()
+      })
+    })
+
+    it('transitions to specified path on click', done => {
+      const steps = [
+        () => {
+          click(node.querySelector('a'), { button: 0 })
+        },
+        ({ location }) => {
+          expect(location.pathname).toEqual('/hello')
+          expect(location.hash).toEqual('#hash')
+        }
+      ]
+
+      const execNextStep = execSteps(steps, done)
+
+      render((
+        <Router history={createHistory('/hello')} onUpdate={execNextStep}>
+          <Route path="/hello" component={App} />
+        </Router>
+      ), node, execNextStep)
     })
   })
 })


### PR DESCRIPTION
This allows to create `<a>` tag without an href property.
The necessity of `noHref` property comes from the fact that angular router is in conflict with react-router's Link component. To be more precise, Angular is [listening to all click events](https://github.com/angular/angular/blob/cf269d9ff43b913dbac4ba0ed6932c708ae58512/modules/angular1_router/src/ng_route_shim.js#L285) and if the click is on an <a> tag with an href that it [recognizes as one of its routes](https://github.com/angular/angular/blob/cf269d9ff43b913dbac4ba0ed6932c708ae58512/modules/angular1_router/src/ng_route_shim.js#L294) and it calls preventDefault() on the event. The Link implementation [checks for default being prevented](https://github.com/ReactTraining/react-router/blob/master/modules/Link.js#L78) and does nothing if it has.