### PR TITLE
bugfix #4292 

### DIFF
--- a/modules/__tests__/withRouter-test.js
+++ b/modules/__tests__/withRouter-test.js
@@ -128,4 +128,17 @@ describe('withRouter', function () {
       done()
     })
   })
+
+  it('should render Component even without Router context', function (done) {
+    const MyComponent = withRouter(({ router }) => {
+      expect(router).toNotExist()
+
+      return <h1>Hello</h1>
+    })
+
+    render((<MyComponent />), node, function () {
+      expect(node.firstChild.textContent).toEqual('Hello')
+      done()
+    })
+  })
 })

--- a/modules/withRouter.js
+++ b/modules/withRouter.js
@@ -29,7 +29,9 @@ export default function withRouter(WrappedComponent, options) {
 
     render() {
       const router = this.props.router || this.context.router
-      if (!router) return <WrappedComponent {...props} />
+      if (!router) {
+        return <WrappedComponent {...this.props} />
+      }
 
       const { params, location, routes } = router
       const props = { ...this.props, router, params, location, routes }

--- a/modules/withRouter.js
+++ b/modules/withRouter.js
@@ -29,6 +29,8 @@ export default function withRouter(WrappedComponent, options) {
 
     render() {
       const router = this.props.router || this.context.router
+      if (!router) return <WrappedComponent {...props} />
+
       const { params, location, routes } = router
       const props = { ...this.props, router, params, location, routes }
 


### PR DESCRIPTION
withRouter() return wrapped Component if router is not present ([#4292])