### PR TITLE
bug(hashHistory): example of failing test

### DIFF
--- a/failing-test/app.js
+++ b/failing-test/app.js
@@ -1,0 +1,5 @@
+import { hashHistory } from '../lib' // simulate react-router as a package
+
+export default function app() {
+  hashHistory.push('./foo')
+}

--- a/failing-test/app.spec.js
+++ b/failing-test/app.spec.js
@@ -1,0 +1,11 @@
+import { hashHistory } from '../lib' // simulate react-router as a package
+import expect, { spyOn } from 'expect'
+import app from './app'
+
+describe('hashHistory: failing test', () => {
+  it('should call hashHistory.push(./foo)', () => {
+    const spy = spyOn(hashHistory, 'push')
+    app()
+    expect(spy).toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
BUG REPORT

## Version
3.0.0

## Test Case
failing-test/app.spec.js

## Steps to reproduce
checkout PR
```bash
$ npm run build
$ node_modules/.bin/mocha --compilers js:babel-register failing-test/app.spec.js
```

## Expected Behavior
test pass

## Actual Behavior
```bash
$ node_modules/.bin/mocha --compilers js:babel-register failing-test/app.spec.js

  hashHistory: failing test
    1) should call hashHistory.push(./foo)

  0 passing (54ms)
  1 failing

  1) hashHistory: failing test should call hashHistory.push(./foo):
     TypeError: Cannot read property 'push' of undefined
      at spyOn (node_modules/expect/lib/SpyUtils.js:110:24)
      at Context.<anonymous> (failing-test/app.spec.js:7:17)
```