### PR TITLE
Updated History Error Message

### DIFF
--- a/modules/Router.js
+++ b/modules/Router.js
@@ -77,9 +77,9 @@ const Router = React.createClass({
 
     invariant(
       history.getCurrentLocation,
-      'You have provided a history object created with history v2.x or ' +
-      'earlier. This version of React Router is only compatible with v3 ' +
-      'history objects. Please upgrade to history v3.x.'
+      'You have provided a history object created with history v4.x or v2.x ' +
+        'and earlier. This version of React Router is only compatible with v3 ' +
+        'history objects. Please change to history v3.x.'
     )
 
     return createTransitionManager(


### PR DESCRIPTION
React-router uses a check on the existence of history.getCurrentLocation to determine the current version of the history object. [(seen here)](https://github.com/ReactTraining/react-router/blob/master/modules/Router.js#L79)  If there is no history.getCurrentLocation it assumes that version 2.x or lower is being used and throws an error.

As of version [4.0.0-2](https://github.com/ReactTraining/react-router/blob/master/modules/Router.js#L79) `history' no longer uses `history.getCurrentLocation`, so this error will also trigger as a result of history's version being too high (4.x)

I've updated the wording in the error message to make it clearer that the error may be a result of having `history` that is v4.x as well as 2.x or lower.