### PR TITLE
Add missing dependencies

### DIFF
--- a/packages/react-router-dom/package.json
+++ b/packages/react-router-dom/package.json
@@ -34,6 +34,7 @@
     "react": "15.x"
   },
   "dependencies": {
+    "history": "^4.5.1",
     "react-router": "4.0.0-alpha.6"
   },
   "devDependencies": {

--- a/packages/react-router-website/package.json
+++ b/packages/react-router-website/package.json
@@ -21,6 +21,7 @@
     "markdown-it": "^7.0.0",
     "markdown-it-anchor": "^2.5.1",
     "postcss-loader": "0.9.1",
+    "prismjs": "^1.6.0",
     "prismjs-loader": "0.0.3",
     "react": "15.3.2",
     "react-dom": "15.3.2",


### PR DESCRIPTION
It seems that react-router/v4 misses 2 dependencies, history in react-router-dom/package.json and prismjs in react-router-website/package.json. Without them I was not able to run the website locally.