### PR TITLE
Account for children being an empty array

### DIFF
--- a/packages/react-router/modules/Route.js
+++ b/packages/react-router/modules/Route.js
@@ -17,6 +17,7 @@ class Route extends React.Component {
   static render = (props) => {
     // TODO: eslint-plugin-react thinks this is a missing propType. File a bug.
     const { component, render, children, match } = props // eslint-disable-line react/prop-types
+    if (children && !children.length) children = null;
 
     warning(
       !(component && render),


### PR DESCRIPTION
I'm not really sure what cases can lead to this in React, but I believe there are some. It also eliminates the need for [the only hack I had to do](https://github.com/developit/react-router-4-test/blob/master/src/lib/react.js#L11-L15) to make RRv4 work with Preact.