### PR TITLE
Add ES build to react-router and react-router-dom (#4425)

### DIFF
--- a/packages/react-router-dom/.gitignore
+++ b/packages/react-router-dom/.gitignore
@@ -1,3 +1,4 @@
+es
 umd
 node_modules
 /*.js

--- a/packages/react-router-dom/modules/.babelrc
+++ b/packages/react-router-dom/modules/.babelrc
@@ -1,6 +1,6 @@
 {
   "presets": [
-    [ "es2015", { "loose": true } ],
+    "../tools/es2015Preset",
     "stage-1",
     "react"
   ],

--- a/packages/react-router-dom/modules/BrowserRouter.js
+++ b/packages/react-router-dom/modules/BrowserRouter.js
@@ -1,6 +1,6 @@
 import React, { PropTypes } from 'react'
 import createHistory from 'history/createBrowserHistory'
-import Router from 'react-router/Router'
+import { Router } from 'react-router'
 
 /**
  * The public API for a <Router> that uses HTML5 history.

--- a/packages/react-router-dom/modules/HashRouter.js
+++ b/packages/react-router-dom/modules/HashRouter.js
@@ -1,6 +1,6 @@
 import React, { PropTypes } from 'react'
 import createHistory from 'history/createHashHistory'
-import Router from 'react-router/Router'
+import { Router } from 'react-router'
 
 /**
  * The public API for a <Router> that uses window.location.hash.

--- a/packages/react-router-dom/modules/MemoryRouter.js
+++ b/packages/react-router-dom/modules/MemoryRouter.js
@@ -1,1 +1,1 @@
-export default from 'react-router/MemoryRouter'
+export { MemoryRouter as default } from 'react-router'

--- a/packages/react-router-dom/modules/NavLink.js
+++ b/packages/react-router-dom/modules/NavLink.js
@@ -1,5 +1,5 @@
 import React, { PropTypes } from 'react'
-import Route from 'react-router/Route'
+import { Route } from 'react-router'
 import Link from './Link'
 
 /**

--- a/packages/react-router-dom/modules/Prompt.js
+++ b/packages/react-router-dom/modules/Prompt.js
@@ -1,1 +1,1 @@
-export default from 'react-router/Prompt'
+export { Prompt as default } from 'react-router'

--- a/packages/react-router-dom/modules/Redirect.js
+++ b/packages/react-router-dom/modules/Redirect.js
@@ -1,1 +1,1 @@
-export default from 'react-router/Redirect'
+export { Redirect as default } from 'react-router'

--- a/packages/react-router-dom/modules/Route.js
+++ b/packages/react-router-dom/modules/Route.js
@@ -1,1 +1,1 @@
-export default from 'react-router/Route'
+export { Route as default } from 'react-router'

--- a/packages/react-router-dom/modules/Router.js
+++ b/packages/react-router-dom/modules/Router.js
@@ -1,1 +1,1 @@
-export default from 'react-router/Router'
+export { Router as default } from 'react-router'

--- a/packages/react-router-dom/modules/StaticRouter.js
+++ b/packages/react-router-dom/modules/StaticRouter.js
@@ -1,1 +1,1 @@
-export default from 'react-router/StaticRouter'
+export { StaticRouter as default } from 'react-router'

--- a/packages/react-router-dom/modules/Switch.js
+++ b/packages/react-router-dom/modules/Switch.js
@@ -1,1 +1,1 @@
-export default from 'react-router/Switch'
+export { Switch as default } from 'react-router'

--- a/packages/react-router-dom/modules/matchPath.js
+++ b/packages/react-router-dom/modules/matchPath.js
@@ -1,1 +1,1 @@
-export default from 'react-router/matchPath'
+export { matchPath as default } from 'react-router'

--- a/packages/react-router-dom/modules/withRouter.js
+++ b/packages/react-router-dom/modules/withRouter.js
@@ -1,1 +1,1 @@
-export default from 'react-router/withRouter'
+export { withRouter as default } from 'react-router'

--- a/packages/react-router-dom/package.json
+++ b/packages/react-router-dom/package.json
@@ -24,11 +24,14 @@
     "matchPath.js",
     "withRouter.js",
     "README.md",
+    "es",
     "umd"
   ],
   "main": "index.js",
+  "module": "es/index.js",
   "scripts": {
-    "build-lib": "babel ./modules -d . --ignore __tests__",
+    "build-es": "BABEL_ENV=es babel modules -d es --ignore __tests__",
+    "build-lib": "BABEL_ENV=cjs babel modules -d . --ignore __tests__",
     "build-umd": "webpack modules/index.js umd/react-router-dom.js",
     "build-min": "webpack -p modules/index.js umd/react-router-dom.min.js",
     "build": "node ./scripts/build.js",

--- a/packages/react-router-dom/scripts/build.js
+++ b/packages/react-router-dom/scripts/build.js
@@ -15,6 +15,7 @@ const webpackEnv = Object.assign({}, process.env, {
   NODE_ENV: 'production'
 })
 
+exec('npm run build-es')
 exec('npm run build-lib')
 exec('npm run build-umd', webpackEnv)
 exec('npm run build-min', webpackEnv)

--- a/packages/react-router-dom/tools/es2015Preset.js
+++ b/packages/react-router-dom/tools/es2015Preset.js
@@ -1,0 +1,12 @@
+const buildPreset = require('babel-preset-es2015').buildPreset
+
+const BABEL_ENV = process.env.BABEL_ENV
+
+module.exports = {
+  presets: [
+    [ buildPreset, {
+      loose: true,
+      modules: BABEL_ENV === 'es' ? false : 'commonjs'
+    } ]
+  ]
+}

--- a/packages/react-router/.gitignore
+++ b/packages/react-router/.gitignore
@@ -1,3 +1,4 @@
+es
 umd
 node_modules
 /*.js

--- a/packages/react-router/modules/.babelrc
+++ b/packages/react-router/modules/.babelrc
@@ -1,6 +1,6 @@
 {
   "presets": [
-    [ "es2015", { "loose": true } ],
+    "../tools/es2015Preset",
     "stage-1",
     "react"
   ],

--- a/packages/react-router/package.json
+++ b/packages/react-router/package.json
@@ -20,11 +20,14 @@
     "matchPath.js",
     "withRouter.js",
     "README.md",
+    "es",
     "umd"
   ],
   "main": "index.js",
+  "module": "es/index.js",
   "scripts": {
-    "build-lib": "babel ./modules -d . --ignore __tests__",
+    "build-es": "BABEL_ENV=es babel modules -d es --ignore __tests__",
+    "build-lib": "BABEL_ENV=cjs babel modules -d . --ignore __tests__",
     "build-umd": "webpack modules/index.js umd/react-router.js",
     "build-min": "webpack -p modules/index.js umd/react-router.min.js",
     "build": "node ./scripts/build.js",

--- a/packages/react-router/scripts/build.js
+++ b/packages/react-router/scripts/build.js
@@ -15,6 +15,7 @@ const webpackEnv = Object.assign({}, process.env, {
   NODE_ENV: 'production'
 })
 
+exec('npm run build-es')
 exec('npm run build-lib')
 exec('npm run build-umd', webpackEnv)
 exec('npm run build-min', webpackEnv)

--- a/packages/react-router/tools/es2015Preset.js
+++ b/packages/react-router/tools/es2015Preset.js
@@ -1,0 +1,12 @@
+const buildPreset = require('babel-preset-es2015').buildPreset
+
+const BABEL_ENV = process.env.BABEL_ENV
+
+module.exports = {
+  presets: [
+    [ buildPreset, {
+      loose: true,
+      modules: BABEL_ENV === 'es' ? false : 'commonjs'
+    } ]
+  ]
+}


### PR DESCRIPTION
This creates an ES build (still transpiled, but with ES2015 import/exports left in tact to enable tree-shaking) inside `es/`, updates the relevant gitignores & npm inclusions, and adds a "module" entry point to package.json of react-router and react-router-dom.

Please see https://github.com/ReactTraining/react-router/issues/4425#issuecomment-276717662 before merging, as this also updates the react-router imports from react-router-dom to be top-level rather than cherry-picked (necessary to enable descendent tree-shaking). As-is, this increases the bundle size of cherry-picked CJS imports from react-router-dom, since they now include the entire react-router package.

IMO, this is fine -- if people care about bundle size, they should be using a tree-shaking bundler -- but if you disagree, I can add [this babel plugin](https://github.com/lodash/babel-plugin-lodash) which would transpile the top-level imports back to cherry-picked ones during the CJS build.