### PR TITLE
Route Testing Example

### DIFF
--- a/packages/react-router-website/modules/api/Route.md
+++ b/packages/react-router-website/modules/api/Route.md
@@ -13,6 +13,8 @@ import { BrowserRouter as Router, Route } from 'react-router-dom'
 </Router>
 ```
 
+You can test out a `<Route>` configuration using the [Test Route Props](examples/test-route-props) example.
+
 There are 3 ways to render something with a `<Route>`:
 
 - [`<Route component>`](#route.component)

--- a/packages/react-router-website/modules/components/Examples.js
+++ b/packages/react-router-website/modules/components/Examples.js
@@ -61,6 +61,11 @@ const EXAMPLES = [
     path: '/examples/route-config',
     load: require('bundle?lazy!babel!../examples/RouteConfig'),
     loadSource: require('bundle?lazy!!prismjs?lang=jsx!../examples/RouteConfig.js')
+  },
+  { name: 'Test Route Props',
+    path: '/examples/test-route-props',
+    load: require('bundle?lazy!babel!../examples/TestRouteProps'),
+    loadSource: require('bundle?lazy!!prismjs?lang=jsx!../examples/TestRouteProps.js')
   }
 ]
 

--- a/packages/react-router-website/modules/components/FakeBrowser/index.js
+++ b/packages/react-router-website/modules/components/FakeBrowser/index.js
@@ -111,6 +111,9 @@ class FakeBrowser extends React.Component {
                     onChange: (e) => {
                       this.setState({ url: e.target.value })
                     },
+                    onBlur: (e) => {
+                      this.setState({ url: null})
+                    },
                     onKeyDown: (e) => {
                       if (e.key === 'Enter') {
                         this.setState({ url: null })

--- a/packages/react-router-website/modules/examples/TestRouteProps.js
+++ b/packages/react-router-website/modules/examples/TestRouteProps.js
@@ -10,17 +10,7 @@ const PathExample = () => (
   </Router>
 )
 
-const MatchIndicator = ({ color }) => (
-  <span style={{
-    background: color,
-    width: 25,
-    height: 25,
-    borderRadius: 15,
-    display: 'inline-block'
-  }}></span>
-)
-
-class App extends React.Component {
+class TestRoute extends React.Component {
   state = {
     path: '',
     exact: false,
@@ -41,56 +31,105 @@ class App extends React.Component {
       strict
     } = this.state
     return (
-      <div>
-        <pre style={{ background: '#efefef' }}>
-          <code>
-            {'<Route'}
-            <br />
-            <label>{'  path="'}
-              <input
-                type='text'
-                name='path'
-                value={path}
-                onChange={this.handleInput.bind(this)}
-                />{'"'}
-            </label>
-            <br />
-            <label>{'  exact={'}
-              <input
-                type='checkbox'
-                name='exact'
-                value={exact}
-                onChange={this.handleInput.bind(this)}
-                />
-              {'}'}
-            </label>
-            <br />
-            <label>{'  strict={'}
-              <input
-                type='checkbox'
-                name='strict'
-                value={strict}
-                onChange={this.handleInput.bind(this)}
-                />
-              {'}'}
-            </label>
-            <br />
-            {'  />'}
-          </code>
-        </pre>
-        <Route path={path} strict={strict} exact={exact} children={({ match }) => (
-          <div>  
-            <MatchIndicator color={match ? 'green' : 'red'} />
-            <pre>
-              <code>
-                { JSON.stringify(match, null, 2) }
-              </code>
-            </pre>
-          </div>
-        )} />
-      </div>
+      <Route path={path} strict={strict} exact={exact} children={({ match }) => (
+        <div>
+          <pre style={{ background: '#efefef' }}>
+            <code>
+              {'<Route'}
+              <br />
+              <label>{'  path="'}
+                <input
+                  type='text'
+                  name='path'
+                  value={path}
+                  title='A path should begin with a forward slash (/)'
+                  onChange={this.handleInput.bind(this)}
+                  />{'"'}
+              </label>
+              <br />
+              <label>{'  exact={'}
+                <input
+                  type='checkbox'
+                  name='exact'
+                  value={exact}
+                  onChange={this.handleInput.bind(this)}
+                  />
+                {'}'}
+              </label>
+              <br />
+              <label>{'  strict={'}
+                <input
+                  type='checkbox'
+                  name='strict'
+                  value={strict}
+                  onChange={this.handleInput.bind(this)}
+                  />
+                {'}'}
+              </label>
+              <br />
+              {'  />'}
+            </code>
+          </pre>
+          <pre style={{
+            color: match ? 'green' : 'red',
+          }}>
+            <code>
+              { JSON.stringify(match, null, 2) }
+            </code>
+          </pre>
+        </div>
+      )} />
     )
   }
 }
 
+const MatchIndicator = ({ color }) => (
+  <span style={{
+    background: color,
+    width: 25,
+    height: 25,
+    borderRadius: 15,
+    display: 'inline-block'
+  }}></span>
+)
+
+const URLInput = () => (
+  <Route render={({ location, replace }) => (
+    <div>
+      <h2>Pathname:</h2>
+      <div>
+        <input
+          type='text'
+          placeholder='Pathname'
+          value={location.pathname}
+          style={{ width: '100%' }}
+          onChange={(event) => { replace(event.target.value) }}
+          />
+      </div>
+    </div>
+    )}
+    />
+)
+
+const App = () => (
+  <div>
+    <p>
+      Test &lt;Route&gt; configuration by setting the <a href='#route.path'>path</a>,
+      {' '}<a href='#route.exact'>exact</a> and <a href='#route.strict'>strict</a> props.
+      The &lt;Route&gt; will be matched against the current URL's pathname.
+    </p>
+    <br />
+    <p>
+      To change URLs, type in the Pathname text input below and the address bar
+      will be automatically updated. The URL's pathname will then be compared
+      against the current &lt;Route&gt; configuration. When a &lt;Route&gt;
+      matches the current location, its <a href='#match'>match</a> object
+      will be displayed below.
+    </p>
+    <br />
+    <URLInput />
+    <TestRoute />
+  </div>
+)
+  
 export default PathExample

--- a/packages/react-router-website/modules/examples/TestRouteProps.js
+++ b/packages/react-router-website/modules/examples/TestRouteProps.js
@@ -1,0 +1,96 @@
+import React from 'react'
+import {
+  BrowserRouter as Router,
+  Route
+} from 'react-router-dom'
+
+const PathExample = () => (
+  <Router>
+    <App />
+  </Router>
+)
+
+const MatchIndicator = ({ color }) => (
+  <span style={{
+    background: color,
+    width: 25,
+    height: 25,
+    borderRadius: 15,
+    display: 'inline-block'
+  }}></span>
+)
+
+class App extends React.Component {
+  state = {
+    path: '',
+    exact: false,
+    strict: false
+  }
+
+  handleInput(event) {
+    const target = event.target
+    this.setState({
+      [target.name]: target.type === 'checkbox' ? target.checked : target.value
+    })
+  }
+
+  render() {
+    const {
+      path,
+      exact,
+      strict
+    } = this.state
+    return (
+      <div>
+        <pre style={{ background: '#efefef' }}>
+          <code>
+            {'<Route'}
+            <br />
+            <label>{'  path="'}
+              <input
+                type='text'
+                name='path'
+                value={path}
+                onChange={this.handleInput.bind(this)}
+                />{'"'}
+            </label>
+            <br />
+            <label>{'  exact={'}
+              <input
+                type='checkbox'
+                name='exact'
+                value={exact}
+                onChange={this.handleInput.bind(this)}
+                />
+              {'}'}
+            </label>
+            <br />
+            <label>{'  strict={'}
+              <input
+                type='checkbox'
+                name='strict'
+                value={strict}
+                onChange={this.handleInput.bind(this)}
+                />
+              {'}'}
+            </label>
+            <br />
+            {'  />'}
+          </code>
+        </pre>
+        <Route path={path} strict={strict} exact={exact} children={({ match }) => (
+          <div>  
+            <MatchIndicator color={match ? 'green' : 'red'} />
+            <pre>
+              <code>
+                { JSON.stringify(match, null, 2) }
+              </code>
+            </pre>
+          </div>
+        )} />
+      </div>
+    )
+  }
+}
+
+export default PathExample


### PR DESCRIPTION
Added an example that lets you test how a `<Route>`'s props match against a URL

**Edit:** Updated gif for updated example
![route-path-update](https://cloud.githubusercontent.com/assets/1127037/22531188/162b69ac-e8a5-11e6-9900-9855ba30a7b4.gif)
