### PR TITLE
fix scripts on windows

### DIFF
--- a/packages/react-router-dom/package.json
+++ b/packages/react-router-dom/package.json
@@ -30,8 +30,8 @@
   "main": "index.js",
   "module": "es/index.js",
   "scripts": {
-    "build-es": "BABEL_ENV=es babel modules -d es --ignore __tests__",
-    "build-lib": "BABEL_ENV=cjs babel modules -d . --ignore __tests__",
+    "build-es": "cross-env BABEL_ENV=es babel modules -d es --ignore __tests__",
+    "build-lib": "cross-env BABEL_ENV=cjs babel modules -d . --ignore __tests__",
     "build-umd": "webpack modules/index.js umd/react-router-dom.js",
     "build-min": "webpack -p modules/index.js umd/react-router-dom.min.js",
     "build": "node ./scripts/build.js",
@@ -57,6 +57,7 @@
     "babel-preset-es2015": "^6.14.0",
     "babel-preset-react": "^6.5.0",
     "babel-preset-stage-1": "^6.5.0",
+    "cross-env": "^3.1.4",
     "eslint": "^2.13.1",
     "eslint-plugin-import": "^1.15.0",
     "eslint-plugin-react": "^5.2.2",

--- a/packages/react-router/package.json
+++ b/packages/react-router/package.json
@@ -26,8 +26,8 @@
   "main": "index.js",
   "module": "es/index.js",
   "scripts": {
-    "build-es": "BABEL_ENV=es babel modules -d es --ignore __tests__",
-    "build-lib": "BABEL_ENV=cjs babel modules -d . --ignore __tests__",
+    "build-es": "cross-env BABEL_ENV=es babel modules -d es --ignore __tests__",
+    "build-lib": "cross-env BABEL_ENV=cjs babel modules -d . --ignore __tests__",
     "build-umd": "webpack modules/index.js umd/react-router.js",
     "build-min": "webpack -p modules/index.js umd/react-router.min.js",
     "build": "node ./scripts/build.js",
@@ -57,6 +57,7 @@
     "babel-preset-es2015": "^6.14.0",
     "babel-preset-react": "^6.5.0",
     "babel-preset-stage-1": "^6.5.0",
+    "cross-env": "^3.1.4",
     "eslint": "^2.13.1",
     "eslint-plugin-import": "^1.15.0",
     "eslint-plugin-react": "^5.2.2",


### PR DESCRIPTION
Use `cross-env` to add Windows support for setting environment variables in a script.