### PR TITLE
Use boolean strings for cache keys

### DIFF
--- a/packages/react-router/modules/__tests__/matchPath-test.js
+++ b/packages/react-router/modules/__tests__/matchPath-test.js
@@ -33,4 +33,22 @@ describe('matchPath', () => {
       expect(match.url).toBe('/somewhere')
     })
   })
+
+  describe('cache', () => {
+    it('creates a cache entry for each exact/strict pair', () => {
+      // true/false and false/true will collide when adding booleans
+      const trueFalse = matchPath(
+        '/one/two',
+        '/one/two/',
+        { exact : true, strict: false }
+      )
+      const falseTrue = matchPath(
+        '/one/two',
+        '/one/two/',
+        { exact : false, strict: true }
+      )
+      expect(!!trueFalse).toBe(true)
+      expect(!!falseTrue).toBe(false)
+    })
+  })
 })

--- a/packages/react-router/modules/matchPath.js
+++ b/packages/react-router/modules/matchPath.js
@@ -5,7 +5,7 @@ const cacheLimit = 10000
 let cacheCount = 0
 
 const compilePath = (pattern, options) => {
-  const cacheKey = options.end + options.strict
+  const cacheKey = `${options.end}${options.strict}`
   const cache = patternCache[cacheKey] || (patternCache[cacheKey] = {})
 
   if (cache[pattern])


### PR DESCRIPTION
Previously, the cache keys for compiled `path-to-regexp` patterns was being computed using:

```js
const cacheKey = options.end + options.strict
```

However, this meant that `{ end: true, strict: false }` created the same key as `{ end: false, strict: true }`.