### PR TITLE
Warn when `Router` is given >1 children

### DIFF
--- a/packages/react-router/modules/Router.js
+++ b/packages/react-router/modules/Router.js
@@ -24,7 +24,7 @@ class Router extends React.Component {
     const { children } = this.props
     invariant(
       children == undefined || React.Children.count(children) === 1,
-      'A <Router> must have at most one child element.'
+      'A <Router> may have only one child element'
     )
 
     return children ? React.Children.only(children) : null

--- a/packages/react-router/modules/Router.js
+++ b/packages/react-router/modules/Router.js
@@ -1,4 +1,5 @@
 import React, { PropTypes } from 'react'
+import invariant from 'invariant'
 
 /**
  * The public API for putting history on context.router.
@@ -21,6 +22,11 @@ class Router extends React.Component {
 
   render() {
     const { children } = this.props
+    invariant(
+      children == undefined || React.Children.count(children) === 1,
+      'A <Router> must have at most one child element.'
+    )
+
     return children ? React.Children.only(children) : null
   }
 }

--- a/packages/react-router/modules/__tests__/Router-test.js
+++ b/packages/react-router/modules/__tests__/Router-test.js
@@ -1,0 +1,50 @@
+import expect from 'expect'
+import React from 'react'
+import Router from '../Router'
+import ReactDOM from 'react-dom'
+
+describe('A <Router>', () => {
+  const node = document.createElement('div')
+
+  afterEach(() => {
+    ReactDOM.unmountComponentAtNode(node)
+  })
+
+  describe('when it has more than one child', () => {
+    it('throws an error explaining a Router can only have one child', () => {
+      expect(() => {
+        ReactDOM.render(
+          <Router history={{}}>
+            <p>Foo</p>
+            <p>Bar</p>
+          </Router>,
+          node
+        )
+      }).toThrow(/A <Router> must have at most one child element/)
+    })
+  })
+
+  describe('with exactly one child', () => {
+    it('does not throw an error', () => {
+      expect(() => {
+        ReactDOM.render(
+          <Router history={{}}>
+            <p>Bar</p>
+          </Router>,
+          node
+        )
+      }).toNotThrow()
+    })
+  })
+
+  describe('with no children', () => {
+    it('does not throw an error', () => {
+      expect(() => {
+        ReactDOM.render(
+          <Router history={{}} />,
+          node
+        )
+      }).toNotThrow()
+    })
+  })
+})

--- a/packages/react-router/modules/__tests__/Router-test.js
+++ b/packages/react-router/modules/__tests__/Router-test.js
@@ -20,7 +20,7 @@ describe('A <Router>', () => {
           </Router>,
           node
         )
-      }).toThrow(/A <Router> must have at most one child element/)
+      }).toThrow(/A <Router> may have only one child element/)
     })
   })
 


### PR DESCRIPTION
As per issue #4444, this PR adds an invariant which provides a nicer
error message from `Router` if it is given multiple children.

Any feedback on the approach, etc, is very welcome! I hope it's OK :)