### PR TITLE
<Link> -- replace state instead of pushing to history when location does not change

### DIFF
--- a/packages/react-router-dom/modules/Link.js
+++ b/packages/react-router-dom/modules/Link.js
@@ -1,7 +1,22 @@
 import React, { PropTypes } from 'react'
+import valueEqual from 'value-equal'
 
 const isModifiedEvent = (event) =>
   !!(event.metaKey || event.altKey || event.ctrlKey || event.shiftKey)
+	
+const locationsAreMostlyEqual = (current, next)  => {
+	if (typeof next === "string") {
+		if (current.state !== undefined) return false
+
+		const { pathname, search, hash } = current
+		return pathname + search + hash === next
+	}
+
+	return current.pathname === next.pathname &&
+	current.search === next.search &&
+	current.hash === next.hash &&
+	valueEqual(current.state, next.state)
+}
 
 /**
  * The public API for rendering a router-aware <a>.
@@ -43,10 +58,8 @@ class Link extends React.Component {
 
       const { router } = this.context
       const { replace, to } = this.props
-			const { pathname, search, hash } = router.location
-      const toUrl = typeof to === 'string' ? to : to.pathname + to.search + to.hash
 
-      if (replace || pathname + search + hash === toUrl) {
+      if (replace || locationsAreMostlyEqual(router.location, to)) {
         router.replace(to)
       } else {
         router.push(to)

--- a/packages/react-router-dom/modules/Link.js
+++ b/packages/react-router-dom/modules/Link.js
@@ -43,8 +43,10 @@ class Link extends React.Component {
 
       const { router } = this.context
       const { replace, to } = this.props
+			const { pathname, search, hash } = router.location
+      const toUrl = typeof to === 'string' ? to : to.pathname + to.search + to.hash
 
-      if (replace) {
+      if (replace || pathname + search + hash === toUrl) {
         router.replace(to)
       } else {
         router.push(to)

--- a/packages/react-router-dom/modules/__tests__/Link-test.js
+++ b/packages/react-router-dom/modules/__tests__/Link-test.js
@@ -44,7 +44,7 @@ describe('When a <Link> is clicked', () => {
 
   const extractCurrentLocation = () => {
     const { pathname, search, hash } = window.location
-		const { state } = window.history.state
+    const { state } = window.history.state
     return { pathname, search, hash, state }
   }
 

--- a/packages/react-router-dom/modules/__tests__/Link-test.js
+++ b/packages/react-router-dom/modules/__tests__/Link-test.js
@@ -9,7 +9,7 @@ describe('A <Link>', () => {
   it('accepts a location "to" prop', () => {
     const location = {
       pathname: '/the/path',
-      search: 'the=query',
+      search: '?the=query',
       hash: '#the-hash'
     }
     const node = document.createElement('div')
@@ -21,8 +21,9 @@ describe('A <Link>', () => {
     ), node)
 
     const href = node.querySelector('a').getAttribute('href')
+    const { pathname, search, hash } = location
 
-    expect(href).toEqual('/the/path?the=query#the-hash')
+    expect(href).toEqual(pathname + search + hash)
   })
 })
 

--- a/packages/react-router-dom/modules/__tests__/Link-test.js
+++ b/packages/react-router-dom/modules/__tests__/Link-test.js
@@ -37,13 +37,15 @@ describe('When a <Link> is clicked', () => {
     {
       pathname: '/the/path' + ++locationInd,
       search: '?the=query' + locationInd,
-      hash: '#the-hash' + locationInd
+      hash: '#the-hash' + locationInd,
+      state: { locationInd }
     }
   )
 
   const extractCurrentLocation = () => {
     const { pathname, search, hash } = window.location
-    return { pathname, search, hash }
+		const { state } = window.history.state
+    return { pathname, search, hash, state }
   }
 
   const createLinkAndClick = ({to = generateNextLocation(), ...props} = {}) => {


### PR DESCRIPTION
Right now given something like:

```jsx
<Link to="/the/path">the path</Link>
```
and assuming this `<Link>` is always displayed. Then starting at `example.com/`, each click on the link (to got to path or, for example, refresh the page) adds to browser history. And if user later wants to go back to `/` he has to click browser's back button as many times as he clicked the link.

That wasn't the case with reac-router v3.

I changed:

```diff
// Link.js
+ const { pathname, search, hash } = router.location
+ const toUrl = typeof to === 'string' ? to : to.pathname + to.search + to.hash

- if (replace) {
+ if (replace || pathname + search + hash === toUrl) {
    router.replace(to)
```

Thus, going from `/same/path/` to `/same/path` would not add to `history`, but any difference in `pathname`, `search` or `hash` would.

I also added tests for this and other behaviours for `Link`.