### PR TITLE
Update description of strict

### DIFF
--- a/packages/react-router-website/modules/api/Route.md
+++ b/packages/react-router-website/modules/api/Route.md
@@ -110,26 +110,37 @@ Routes without a `path` _always_ match.
 
 When `true`, will only match if the path matches the `location.pathname` _exactly_.
 
-| path | location.pathname | exact | matches? |
-|---|---|---|---|---|
-| `/one`  | `/one/two`  | `true` | no |
-| `/one`  | `/one/two`  | `false` | yes |
-
 ```js
 <Route exact path="/one" component={About}/>
 ```
 
+| path | location.pathname | exact | matches? |   
+|---|---|---|---|---|   
+| `/one`  | `/one/two`  | `true` | no |   
+| `/one`  | `/one/two`  | `false` | yes |   
+
 ## strict: bool _`<Route>`_ {id=route.strict}
 
-When `true`, enforces strict matching of trailing slashes on `location.pathname`.
-
-| path | location.pathname | strict | matches? |
-|---|---|---|---|---|
-| `/one/two`  | `/one/two/`  | `false` | yes |
-| `/one/two`  | `/one/two/`  | `true` | no |
-| `/one/two/`  | `/one/two/`  | `false` | yes |
-| `/one/two/`  | `/one/two/`  | `true` | yes |
+When `true`, a `path` that has a trailing slash will only match a `location.pathname` with a trailing slash. This has no effect when there are additional URL segments in the `location.pathname`.
 
 ```js
-<Route strict path="/one/two/" component={About}/>
+<Route strict path="/one/" component={About}/>
 ```
+
+| path | location.pathname | matches? |
+| --- | --- | --- |
+| `/one/` | `/one` | no |
+| `/one/` | `/one/` | yes |
+| `/one/` | `/one/two` | yes |
+
+**NOTE:** `strict` can be used to enforce that a `location.pathname` has no trailing slash, but in order to do this both `strict` and `exact` must be `true`.
+
+```js
+<Route exact strict path="/one" component={About}/>
+```
+
+| path | location.pathname | matches? |
+| --- | --- | --- |
+| `/one` | `/one` | yes |
+| `/one` | `/one/` | no |
+| `/one` | `/one/two` | no |


### PR DESCRIPTION
This adds tables showing how the different combinations of a `<Route>`'s `exact` and `strict` props match a `path` against `location.pathname`.

I also removed the tables that were previously included under the `strict` and `exact` props because they were now redundant (and in the case of `strict`, not completely accurate).

closes #4441 