### PR TITLE
build es modules in es directory

### DIFF
--- a/packages/react-router-dom/scripts/build.js
+++ b/packages/react-router-dom/scripts/build.js
@@ -21,7 +21,7 @@ exec('babel modules -d . --ignore __tests__', {
 
 console.log('\nBuilding ES modules ...')
 
-exec('babel modules -d . --ignore __tests__', {
+exec('babel modules -d es --ignore __tests__', {
   BABEL_ENV: 'es'
 })
 

--- a/packages/react-router/scripts/build.js
+++ b/packages/react-router/scripts/build.js
@@ -21,7 +21,7 @@ exec('babel modules -d . --ignore __tests__', {
 
 console.log('\nBuilding ES modules ...')
 
-exec('babel modules -d . --ignore __tests__', {
+exec('babel modules -d es --ignore __tests__', {
   BABEL_ENV: 'es'
 })
 


### PR DESCRIPTION
ES build was being placed in the root directory of the package. This was causing errors "unexpected token import" errors when trying to run the tests.