### PR TITLE
Add react(-native) as devDeps

### DIFF
--- a/packages/react-router-native/package.json
+++ b/packages/react-router-native/package.json
@@ -24,6 +24,8 @@
     "babel-jest": "18.0.0",
     "babel-preset-react-native": "1.9.1",
     "jest": "18.1.0",
+    "react": ">=15",
+    "react-native": ">=0.40",
     "react-test-renderer": "~15.4.0-rc.4"
   },
   "jest": {


### PR DESCRIPTION
These aren't being installed when they are just peer dependencies, so the react-router-native tests fails.

I _think_ that this will fix the tests, but I'll let Travis be the judge :sweat_smile: