### PR TITLE
Only nullify empty children array

### DIFF
--- a/packages/react-router/modules/Route.js
+++ b/packages/react-router/modules/Route.js
@@ -19,7 +19,7 @@ class Route extends React.Component {
     const { component, render, match } = props // eslint-disable-line react/prop-types
     let children = props.children  // eslint-disable-line react/prop-types
 
-    if (children && !children.length) children = null
+    if (Array.isArray(children) && !children.length) children = null
 
     warning(
       !(component && render),

--- a/packages/react-router/modules/__tests__/Route-test.js
+++ b/packages/react-router/modules/__tests__/Route-test.js
@@ -35,6 +35,57 @@ describe('A <Route>', () => {
     expect(node.innerHTML).toNotContain(TEXT)
   })
 
+  describe('component prop', () => {
+    const TEXT = 'Mrs. Kato'
+    const node = document.createElement('div')
+    const Home = () => <div>{TEXT}</div>
+    ReactDOM.render((
+      <MemoryRouter initialEntries={[ '/' ]}>
+        <Route path="/" component={Home} />
+      </MemoryRouter>
+    ), node)
+
+    expect(node.innerHTML).toContain(TEXT)
+  })
+
+  describe('render prop', () => {
+    const TEXT = 'Mrs. Kato'
+    const node = document.createElement('div')
+    ReactDOM.render((
+      <MemoryRouter initialEntries={[ '/' ]}>
+        <Route path="/" render={() => <div>{TEXT}</div>} />
+      </MemoryRouter>
+    ), node)
+
+    expect(node.innerHTML).toContain(TEXT)
+  })
+
+  describe('children function prop', () => {
+    const TEXT = 'Mrs. Kato'
+    const node = document.createElement('div')
+    ReactDOM.render((
+      <MemoryRouter initialEntries={[ '/' ]}>
+        <Route path="/" children={() => <div>{TEXT}</div>} />
+      </MemoryRouter>
+    ), node)
+
+    expect(node.innerHTML).toContain(TEXT)
+  })
+
+  describe('children element prop', () => {
+    const TEXT = 'Mrs. Kato'
+    const node = document.createElement('div')
+    ReactDOM.render((
+      <MemoryRouter initialEntries={[ '/' ]}>
+        <Route path="/">
+          <div>{TEXT}</div>
+        </Route>
+      </MemoryRouter>
+    ), node)
+
+    expect(node.innerHTML).toContain(TEXT)
+  })
+
   it('supports preact by nulling out children prop when empty array is passed', () => {
     const TEXT = 'Mrs. Kato'
     const node = document.createElement('div')


### PR DESCRIPTION
#4423 added Preact support by making `children` null if its length is zero.

[`Function.length`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/length) indicates how many arguments the function takes, so a function that takes no arguments has a length of 0.

```js
<Route path='/okay' children={() => <div>What?</div>} /> // this would set children to null
```

This PR will make sure that `children` is an array before setting it to `null` when it is empty.

I also took the liberty of adding some basic `<Route>` tests for its `component`, `render`, and `children` props.