### PR TITLE
Remove extra StaticRouter createHref leading slash

### DIFF
--- a/packages/react-router/modules/StaticRouter.js
+++ b/packages/react-router/modules/StaticRouter.js
@@ -77,7 +77,7 @@ class StaticRouter extends React.Component {
   }
 
   createHref = (path) =>
-    addLeadingSlash(this.props.basename) + createURL(path)
+    addLeadingSlash(this.props.basename + createURL(path))
 
   handlePush = (location) => {
     const { basename, context } = this.props

--- a/packages/react-router/modules/__tests__/StaticRouter-test.js
+++ b/packages/react-router/modules/__tests__/StaticRouter-test.js
@@ -1,6 +1,7 @@
 import expect from 'expect'
 import React, { PropTypes } from 'react'
 import ReactDOMServer from 'react-dom/server'
+import ReactDOM from 'react-dom'
 import StaticRouter from '../StaticRouter'
 import Redirect from '../Redirect'
 import Route from '../Route'
@@ -137,6 +138,28 @@ describe('A <StaticRouter>', () => {
 
       expect(context.action).toBe('REPLACE')
       expect(context.url).toBe('/the-base/somewhere-else')
+    })
+  })
+
+  describe('no basename', () => {
+    it('createHref does not append extra leading slash', () => {
+      const context = {}
+      const node = document.createElement('div')
+      const pathname = '/test-path-please-ignore'
+
+      const Link = ({ to, children }) => (
+        <Route children={({ createHref }) => (
+          <a href={createHref(to)}>{children}</a>
+        )} />
+      )
+
+      ReactDOM.render((
+        <StaticRouter context={context}>
+          <Link to={pathname} />
+        </StaticRouter>
+      ), node)
+      const a = node.getElementsByTagName('a')[0]
+      expect(a.getAttribute('href')).toEqual(pathname)
     })
   })
 })


### PR DESCRIPTION
Fixes #4480 Add a leading slash after concatenating `this.props.basename` and `createURL(path)`.

```js
// before
addLeadingSlash('') + '/my-path' = '//my-path'
// after
addLeadingSlash('' + '/my-path') = '/my-path'
```