### PR TITLE
Remove react-router as webpack external

### DIFF
--- a/packages/react-router-dom/webpack.config.js
+++ b/packages/react-router-dom/webpack.config.js
@@ -12,12 +12,6 @@ module.exports = {
       commonjs2: 'react',
       commonjs: 'react',
       amd: 'react'
-    },
-    'react-router': {
-      root: 'ReactRouter',
-      commonjs2: 'react-router',
-      commonjs: 'react-router',
-      amd: 'react-router'
     }
   },
 


### PR DESCRIPTION
Remove the `react-router` external from `react-router-dom`'s `webpack.config.js`. This was preventing `react-router`'s modules from being bundled into the UMD builds.

I used the `react-router-dom.js` and `react-router-dom.min.js` files in a mini project and the modules from `react-router` imported as expected. The file sizes are also similar to the beta 4 build, so it appears that everything is being included as expected.