### PR TITLE
Require to prop on Link

### DIFF
--- a/packages/react-router-dom/modules/Link.js
+++ b/packages/react-router-dom/modules/Link.js
@@ -22,7 +22,7 @@ class Link extends React.Component {
     to: PropTypes.oneOfType([
       PropTypes.string,
       PropTypes.object
-    ])
+    ]).isRequired
   }
 
   static defaultProps = {


### PR DESCRIPTION
`to` is currently implicitly required. Might as well make it throw when it's not included.