### PR TITLE
Pass to prop to NavLink's isActive function

### DIFF
--- a/packages/react-router-dom/docs/NavLink.md
+++ b/packages/react-router-dom/docs/NavLink.md
@@ -42,11 +42,11 @@ When `true`, the trailing slash on a location's `pathname` will be taken into co
 
 ## isActive: func
 
-A function to add extra logic for determining whether the link is active. This should be used if you want to do more than verify that the link's pathname matches the current URL's `pathname`.
+A function to add extra logic for determining whether the link is active. This should be used if you want to do more than verify that the link's pathname matches the current URL's `pathname`. The function will be passed its `match`, the current `location`, and the `<NavLink>`'s `to` prop.
 
 ```js
 // only consider an event active if its event id is an odd number
-const oddEvent = (match, location) => {
+const oddEvent = (match, location, to) => {
   if (!match) {
     return false
   }

--- a/packages/react-router-dom/modules/NavLink.js
+++ b/packages/react-router-dom/modules/NavLink.js
@@ -21,7 +21,7 @@ const NavLink = ({
     exact={exact}
     strict={strict}
     children={({ location, match }) => {
-      const isActive = !!(getIsActive ? getIsActive(match, location) : match)
+      const isActive = !!(getIsActive ? getIsActive(match, location, to) : match)
 
       return (
         <Link

--- a/packages/react-router-dom/modules/__tests__/NavLink-test.js
+++ b/packages/react-router-dom/modules/__tests__/NavLink-test.js
@@ -105,6 +105,23 @@ describe('NavLink', () => {
       const a = node.getElementsByTagName('a')[0]
       expect(a.className).toNotContain('active')
     })
+
+    it('can use the to prop that is passed to the NavLink', () => {
+      const matchSearch = (match, location, to) => match && location.search === to.search
+      ReactDOM.render((
+        <MemoryRouter initialEntries={['/pizza?size=large&toppings=pepperoni']}>
+          <NavLink
+            to={{ pathname: '/pizza', search: '?size=medium&toppings=olives' }}
+            activeClassName='active'
+            isActive={matchSearch}
+            >
+            Pizza!
+          </NavLink>
+        </MemoryRouter>
+      ), node)
+      const a = node.getElementsByTagName('a')[0]
+      expect(a.className).toNotContain('active')
+    })
   })
 
   describe('exact', () => {


### PR DESCRIPTION
Currently, the `isActive` prop only receives the `match` object and the current `location` object. This doesn't allow for more interesting active comparisons, like checking whether the `search` prop of a `<NavLink>`'s `to` matches the `search` value of the current `location`.

This PR adds the `to` prop as an argument to the `isActive` function call.