### PR TITLE
Update API.md to mention routes as part of injected props

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -546,6 +546,9 @@ The route that rendered this component.
 #### `router`
 Contains methods relevant to routing. Most useful for imperatively transitioning around the application.
 
+#### `routes`
+The routes registered with the router.
+
 #### `routeParams`
 A subset of `this.props.params` that were directly specified in this component's route. For example, if the route's path is `users/:userId` and the URL is `/users/123/portfolios/345` then `this.props.routeParams` will be `{userId: '123'}`, and `this.props.params` will be `{userId: '123', portfolioId: '345'}`.
 


### PR DESCRIPTION
There is no mention of the following in the Injected Props docs at present:

#### `routes`
The registered routes.

Although when I'm debugging react-router 3.0.2 I can certainly see it there (and have been using with react-router 2.0 and 3.0).  So I've added it - hope that's helpful.