### PR TITLE
Switch children should only be Routes

### DIFF
--- a/packages/react-router-website/modules/api/Switch.md
+++ b/packages/react-router-website/modules/api/Switch.md
@@ -51,4 +51,4 @@ This is also useful for animated transitions since the matched `<Route>` is rend
 
 ## children: node _`<Switch>`_ {id=switch.children}
 
-The first `<Route>` in `children` to match the current location will be rendered.
+All children of a `<Switch>` should be `<Route>` elements. Only the first child to match the current location will be rendered.


### PR DESCRIPTION
Update docs to state that the elements passed to a `<Switch>` should be `<Route>`s. I used "should" instead of "must" because technically any component with the correct props will work.