### PR TITLE
Pass state to StaticRouter from Redirect

### DIFF
--- a/packages/react-router/modules/Redirect.js
+++ b/packages/react-router/modules/Redirect.js
@@ -18,7 +18,8 @@ class Redirect extends React.Component {
     to: PropTypes.oneOfType([
       PropTypes.string,
       PropTypes.object
-    ])
+    ]),
+    state: PropTypes.object
   }
 
   static defaultProps = {

--- a/packages/react-router/modules/StaticRouter.js
+++ b/packages/react-router/modules/StaticRouter.js
@@ -28,7 +28,6 @@ const stripBasename = (basename, location) => {
     return location
 
   const base = addLeadingSlash(basename)
-  const { pathname } = location
 
   if (location.pathname.indexOf(base) !== 0)
     return location

--- a/packages/react-router/modules/StaticRouter.js
+++ b/packages/react-router/modules/StaticRouter.js
@@ -84,6 +84,7 @@ class StaticRouter extends React.Component {
     context.action = 'PUSH'
     context.location = addBasename(basename, createLocation(location))
     context.url = createURL(context.location)
+    context.state = Object.assign({}, context.state, location.state)
   }
 
   handleReplace = (location) => {
@@ -91,6 +92,7 @@ class StaticRouter extends React.Component {
     context.action = 'REPLACE'
     context.location = addBasename(basename, createLocation(location))
     context.url = createURL(context.location)
+    context.state = Object.assign({}, context.state, location.state)
   }
 
   handleListen = () =>

--- a/packages/react-router/modules/__tests__/StaticRouter-test.js
+++ b/packages/react-router/modules/__tests__/StaticRouter-test.js
@@ -71,6 +71,29 @@ describe('A <StaticRouter>', () => {
     expect(context.url).toBe('/somewhere-else')
   })
 
+  it('sets state on context', () => {
+    const context = {
+      state: {
+        value: 'something'
+      }
+    }
+
+    ReactDOMServer.renderToStaticMarkup(
+      <StaticRouter context={context}>
+        <Redirect to={{
+          pathname: '/somewhere-else',
+          state: {
+            status: 303
+          }
+        }} />
+      </StaticRouter>
+    )
+
+    expect(context.url).toBe('/somewhere-else')
+    expect(context.state.status).toBe(303)
+    expect(context.state.value).toBe('something')
+  })
+
   it('knows how to parse raw URLs', () => {
     let location
     const LocationChecker = (props) => {


### PR DESCRIPTION
Currently it seems there's no way pass the http status for redirecting up to the `StaticRouter` context for server side renders.

This PR passes up the `state` (as indicated in the docs) to the `context` so we can pick it up and set the status. 

I'm not sure if this should also apply to `BrowserRouter` or somewhere else. Happy to update the PR in case in missed something.

https://github.com/ReactTraining/react-router/pull/4528/commits/3be72c92b9f12e3a84507058173bcf8c8e485653 fixes a `npm lint` issue that caused lint not to pass. The line isn't otherwise part of this PR.