### PR TITLE
Fix createBrowserHistory in documentation.

### DIFF
--- a/packages/react-router-website/modules/api/Router.md
+++ b/packages/react-router-website/modules/api/Router.md
@@ -12,7 +12,7 @@ Use a `<Router>` directly if you already have a `history` object.
 
 ```js
 import { Router } from 'react-router'
-import createHistory from 'history/createBrowserHistory'
+import createBrowserHistory from 'history/createBrowserHistory'
 
 const history = createBrowserHistory()
 


### PR DESCRIPTION
Update v4 docs so that the function call for `createBrowserHistory()` lines up with the import of `createBrowserHistory`.