### PR TITLE
Add block to StaticRouter's history

### DIFF
--- a/packages/react-router/modules/StaticRouter.js
+++ b/packages/react-router/modules/StaticRouter.js
@@ -96,6 +96,9 @@ class StaticRouter extends React.Component {
   handleListen = () =>
     noop
 
+  handleBlock = () =>
+    noop
+
   render() {
     const { basename, context, location, ...props } = this.props
 
@@ -109,7 +112,8 @@ class StaticRouter extends React.Component {
       go: staticHandler('go'),
       goBack: staticHandler('goBack'),
       goForward: staticHandler('goForward'),
-      listen: this.handleListen
+      listen: this.handleListen,
+      block: this.handleBlock
     }
 
     return <Router {...props} history={history}/>

--- a/packages/react-router/modules/__tests__/StaticRouter-test.js
+++ b/packages/react-router/modules/__tests__/StaticRouter-test.js
@@ -5,6 +5,7 @@ import ReactDOM from 'react-dom'
 import StaticRouter from '../StaticRouter'
 import Redirect from '../Redirect'
 import Route from '../Route'
+import Prompt from '../Prompt'
 
 describe('A <StaticRouter>', () => {
   it('puts a router on context', () => {
@@ -160,6 +161,22 @@ describe('A <StaticRouter>', () => {
       ), node)
       const a = node.getElementsByTagName('a')[0]
       expect(a.getAttribute('href')).toEqual(pathname)
+    })
+  })
+
+  describe('render a <Prompt />', () => {
+    it('does nothing', () => {
+      const context = {}
+      const node = document.createElement('div')
+      const pathname = '/test-path-please-ignore'
+
+      expect(() => {
+        ReactDOM.render((
+          <StaticRouter context={context}>
+            <Prompt />
+          </StaticRouter>
+        ), node)
+      }).toNotThrow()
     })
   })
 })


### PR DESCRIPTION
The `<StaticRouter>`'s history object is missing the `block` method. Fixes #4543.