### PR TITLE
Remove some warnings emitted during tests

### DIFF
--- a/packages/react-router/modules/Route.js
+++ b/packages/react-router/modules/Route.js
@@ -25,7 +25,7 @@ class Route extends React.Component {
       PropTypes.func,
       PropTypes.node
     ]),
-    location: PropTypes.location
+    location: PropTypes.object
   }
 
   static childContextTypes = {

--- a/packages/react-router/modules/__tests__/StaticRouter-test.js
+++ b/packages/react-router/modules/__tests__/StaticRouter-test.js
@@ -172,7 +172,7 @@ describe('A <StaticRouter>', () => {
       expect(() => {
         ReactDOM.render((
           <StaticRouter context={context}>
-            <Prompt />
+            <Prompt message="this is only a test"/>
           </StaticRouter>
         ), node)
       }).toNotThrow()


### PR DESCRIPTION
Some little fixes for things that were causing warning errors in the Travis builds.

No idea who could have missed adding a `<Prompt message>` :innocent: