### PR TITLE
do not persist location after the app restart

### DIFF
--- a/packages/react-router-native/NativeRouter.js
+++ b/packages/react-router-native/NativeRouter.js
@@ -1,13 +1,45 @@
-import React, { PropTypes, Component } from 'react'
+import React, { PropTypes } from 'react'
 import MemoryRouter from 'react-router/MemoryRouter'
-import Route from 'react-router/Route'
 import { AsyncStorage, Alert } from 'react-native'
+
+class StoreHistory extends React.Component {
+  static contextTypes = {
+    router: PropTypes.object.isRequired
+  }
+
+  static propTypes = {
+    initialIndex: PropTypes.number,
+    initialEntries: PropTypes.array
+  }
+
+  static defaultProps = {
+    initialIndex: 0,
+    initialEntries: [ '/' ]
+  }
+
+  componentDidMount() {
+    this.store()
+  }
+
+  componentDidUpdate() {
+    this.store()
+  }
+
+  store() {
+    const { router: { entries, index } } = this.context
+    AsyncStorage.setItem('history', JSON.stringify({ entries, index }))
+  }
+
+  render() {
+    return this.props.children
+  }
+}
 
 /**
  * The public API for a <Router> designed for React Native. Stores
  * locations using AsyncStorage and prompts using Alert.
  */
-class NativeRouter extends Component {
+class NativeRouter extends React.Component {
   static propTypes = {
     getUserConfirmation: PropTypes.func,
     keyLength: PropTypes.number,
@@ -23,66 +55,21 @@ class NativeRouter extends Component {
     }
   }
 
-  state = {
-    savedHistory: null
-  }
-
-  componentDidMount() {
-    AsyncStorage.getItem('history', (err, history) => {
-      this.setState({
-        savedHistory: history ? JSON.parse(history) : {
-          entries: this.props.initialEntries,
-          index: this.props.initialIndex
-        }
-      })
-    })
-  }
-
   render() {
     const { getUserConfirmation, keyLength, children } = this.props
-    const { savedHistory } = this.state
 
-    return savedHistory != null ? (
+    return (
       <MemoryRouter
-        initialEntries={savedHistory.entries}
-        initialIndex={savedHistory.index}
+        initialEntries={this.props.initialEntries}
+        initialIndex={this.props.initialIndex}
         getUserConfirmation={getUserConfirmation}
         keyLength={keyLength}
       >
-        <Route render={({ entries, index }) => (
-          <StoreHistory entries={entries} index={index}>
-            {React.Children.only(children)}
-          </StoreHistory>
-        )}/>
+        <StoreHistory>
+          {React.Children.only(children)}
+        </StoreHistory>
       </MemoryRouter>
-    ) : null
-  }
-}
-
-class StoreHistory extends Component {
-  static propTypes = {
-    index: PropTypes.number.isRequired,
-    entries: PropTypes.array.isRequired
-  }
-
-  componentDidMount() {
-    this.store()
-  }
-
-  componentDidUpdate() {
-    this.store()
-  }
-
-  store() {
-    const { entries, index } = this.props
-    AsyncStorage.setItem(
-      'history',
-      JSON.stringify({ entries, index })
     )
-  }
-
-  render() {
-    return this.props.children
   }
 }
 


### PR DESCRIPTION
This still does not block anyone to actually do it, as the developer can actually take care of persisting the history and then passing it as `initialEntries` and `initialIndex` props to `<NativeRouter />`, but I don't know of any app actually doing it.