### PR TITLE
do not persist location after the app restart

### DIFF
--- a/packages/react-router-native/NativeRouter.js
+++ b/packages/react-router-native/NativeRouter.js
@@ -23,29 +23,13 @@ class NativeRouter extends Component {
     }
   }
 
-  state = {
-    savedHistory: null
-  }
-
-  componentDidMount() {
-    AsyncStorage.getItem('history', (err, history) => {
-      this.setState({
-        savedHistory: history ? JSON.parse(history) : {
-          entries: this.props.initialEntries,
-          index: this.props.initialIndex
-        }
-      })
-    })
-  }
-
   render() {
-    const { getUserConfirmation, keyLength, children } = this.props
-    const { savedHistory } = this.state
+    const { initialEntries, initialIndex, getUserConfirmation, keyLength, children } = this.props
 
-    return savedHistory != null ? (
+    return (
       <MemoryRouter
-        initialEntries={savedHistory.entries}
-        initialIndex={savedHistory.index}
+        initialEntries={initialEntries}
+        initialIndex={initialIndex}
         getUserConfirmation={getUserConfirmation}
         keyLength={keyLength}
       >
@@ -55,7 +39,7 @@ class NativeRouter extends Component {
           </StoreHistory>
         )}/>
       </MemoryRouter>
-    ) : null
+    )
   }
 }
 

--- a/packages/react-router-native/NativeRouter.js
+++ b/packages/react-router-native/NativeRouter.js
@@ -1,7 +1,7 @@
 import React, { PropTypes, Component } from 'react'
 import MemoryRouter from 'react-router/MemoryRouter'
 import Route from 'react-router/Route'
-import { AsyncStorage, Alert } from 'react-native'
+import { Alert } from 'react-native'
 
 /**
  * The public API for a <Router> designed for React Native. Stores
@@ -33,40 +33,9 @@ class NativeRouter extends Component {
         getUserConfirmation={getUserConfirmation}
         keyLength={keyLength}
       >
-        <Route render={({ entries, index }) => (
-          <StoreHistory entries={entries} index={index}>
-            {React.Children.only(children)}
-          </StoreHistory>
-        )}/>
+        <Route render={() => React.Children.only(children)} />
       </MemoryRouter>
     )
-  }
-}
-
-class StoreHistory extends Component {
-  static propTypes = {
-    index: PropTypes.number.isRequired,
-    entries: PropTypes.array.isRequired
-  }
-
-  componentDidMount() {
-    this.store()
-  }
-
-  componentDidUpdate() {
-    this.store()
-  }
-
-  store() {
-    const { entries, index } = this.props
-    AsyncStorage.setItem(
-      'history',
-      JSON.stringify({ entries, index })
-    )
-  }
-
-  render() {
-    return this.props.children
   }
 }
 

--- a/packages/react-router-native/NativeRouter.js
+++ b/packages/react-router-native/NativeRouter.js
@@ -1,6 +1,5 @@
 import React, { PropTypes, Component } from 'react'
 import MemoryRouter from 'react-router/MemoryRouter'
-import Route from 'react-router/Route'
 import { Alert } from 'react-native'
 
 /**
@@ -33,7 +32,7 @@ class NativeRouter extends Component {
         getUserConfirmation={getUserConfirmation}
         keyLength={keyLength}
       >
-        <Route render={() => React.Children.only(children)} />
+        {React.Children.only(children)}
       </MemoryRouter>
     )
   }


### PR DESCRIPTION
This still does not block anyone to actually do it, as the developer can actually take care of persisting the history and then passing it as `initialEntries` and `initialIndex` props, but I don't know of any app actually doing it.