### PR TITLE
Add root match to context.router

### DIFF
--- a/packages/react-router/modules/Router.js
+++ b/packages/react-router/modules/Router.js
@@ -16,17 +16,30 @@ class Router extends React.Component {
 
   getChildContext() {
     return {
-      router: this.props.history
+      router: this.router
     }
   }
 
   componentWillMount() {
-    const { children } = this.props
+    const { children, history } = this.props
 
     invariant(
       children == null || React.Children.count(children) === 1,
       'A <Router> may have only one child element'
     )
+
+    this.router = {
+      ...history,
+      match: {
+        path: '/',
+        url: '/',
+        params: {}
+      }
+    }
+
+    history.listen(() => {
+      Object.assign(this.router, history)
+    })
   }
 
   render() {

--- a/packages/react-router/modules/Router.js
+++ b/packages/react-router/modules/Router.js
@@ -39,10 +39,9 @@ class Router extends React.Component {
     }
 
     history.listen(() => {
-      Object.assign(this.router, history, {
-        match: Object.assign(this.router.match, {
-          isExact: history.location.pathname === '/'
-        })
+      Object.assign(this.router, history)
+      Object.assign(this.router.match, {
+        isExact: history.location.pathname === '/'
       })
     })
   }

--- a/packages/react-router/modules/Router.js
+++ b/packages/react-router/modules/Router.js
@@ -33,12 +33,16 @@ class Router extends React.Component {
       match: {
         path: '/',
         url: '/',
-        params: {}
+        params: {},
+        isExact: history.location.pathname === '/'
       }
     }
 
     history.listen(() => {
       Object.assign(this.router, history)
+      Object.assign(this.router.match, {
+        isExact: history.location.pathname === '/'
+      })
     })
   }
 

--- a/packages/react-router/modules/Router.js
+++ b/packages/react-router/modules/Router.js
@@ -39,9 +39,10 @@ class Router extends React.Component {
     }
 
     history.listen(() => {
-      Object.assign(this.router, history)
-      Object.assign(this.router.match, {
-        isExact: history.location.pathname === '/'
+      Object.assign(this.router, history, {
+        match: Object.assign(this.router.match, {
+          isExact: history.location.pathname === '/'
+        })
       })
     })
   }

--- a/packages/react-router/modules/__tests__/Router-test.js
+++ b/packages/react-router/modules/__tests__/Router-test.js
@@ -62,7 +62,7 @@ describe('A <Router>', () => {
     })
 
     it('sets a root match', () => {
-      const history = createMemoryHistory()
+      const history = createMemoryHistory({ initialEntries: ['/'] })
       ReactDOM.render(
         <Router history={history}>
           <ContextChecker />
@@ -72,7 +72,8 @@ describe('A <Router>', () => {
       expect(rootContext.match).toEqual({
         path: '/',
         url: '/',
-        params: {}
+        params: {},
+        isExact: true
       })
     })
 
@@ -90,7 +91,7 @@ describe('A <Router>', () => {
       })
     })
 
-    it('listens to history and updates history properties upon navigation', () => {
+    it('updates history properties upon navigation', () => {
       const history = createMemoryHistory()
       ReactDOM.render(
         <Router history={history}>
@@ -108,6 +109,22 @@ describe('A <Router>', () => {
       })
       expect(rootContext.action).toBe('PUSH')
       expect(rootContext.length).toBe(2)
+    })
+
+    it('updates match.isExact upon navigation', () => {
+      const history = createMemoryHistory({ initialEntries: ['/'] })
+      ReactDOM.render(
+        <Router history={history}>
+          <ContextChecker />
+        </Router>,
+        node
+      )
+      expect(rootContext.match.isExact).toBe(true)
+
+      const newLocation = { pathname: '/new' }
+      history.push(newLocation)
+
+      expect(rootContext.match.isExact).toBe(false)
     })
   })
 })

--- a/packages/react-router/modules/__tests__/Router-test.js
+++ b/packages/react-router/modules/__tests__/Router-test.js
@@ -2,7 +2,7 @@ import expect from 'expect'
 import React from 'react'
 import Router from '../Router'
 import ReactDOM from 'react-dom'
-import { createMemoryHistory } from 'history'
+import createHistory from 'history/createMemoryHistory'
 
 describe('A <Router>', () => {
   const node = document.createElement('div')
@@ -15,7 +15,7 @@ describe('A <Router>', () => {
     it('throws an error explaining a Router can only have one child', () => {
       expect(() => {
         ReactDOM.render(
-          <Router history={createMemoryHistory()}>
+          <Router history={createHistory()}>
             <p>Foo</p>
             <p>Bar</p>
           </Router>,
@@ -29,7 +29,7 @@ describe('A <Router>', () => {
     it('does not throw an error', () => {
       expect(() => {
         ReactDOM.render(
-          <Router history={createMemoryHistory()}>
+          <Router history={createHistory()}>
             <p>Bar</p>
           </Router>,
           node
@@ -42,7 +42,7 @@ describe('A <Router>', () => {
     it('does not throw an error', () => {
       expect(() => {
         ReactDOM.render(
-          <Router history={createMemoryHistory()} />,
+          <Router history={createHistory()} />,
           node
         )
       }).toNotThrow()
@@ -62,7 +62,7 @@ describe('A <Router>', () => {
     })
 
     it('sets a root match', () => {
-      const history = createMemoryHistory({ initialEntries: ['/'] })
+      const history = createHistory({ initialEntries: ['/'] })
       ReactDOM.render(
         <Router history={history}>
           <ContextChecker />
@@ -78,7 +78,7 @@ describe('A <Router>', () => {
     })
 
     it('spreads the history object\'s properties', () => {
-      const history = createMemoryHistory()
+      const history = createHistory()
       ReactDOM.render(
         <Router history={history}>
           <ContextChecker />
@@ -92,7 +92,7 @@ describe('A <Router>', () => {
     })
 
     it('updates history properties upon navigation', () => {
-      const history = createMemoryHistory()
+      const history = createHistory()
       ReactDOM.render(
         <Router history={history}>
           <ContextChecker />
@@ -112,7 +112,7 @@ describe('A <Router>', () => {
     })
 
     it('updates match.isExact upon navigation', () => {
-      const history = createMemoryHistory({ initialEntries: ['/'] })
+      const history = createHistory({ initialEntries: ['/'] })
       ReactDOM.render(
         <Router history={history}>
           <ContextChecker />

--- a/packages/react-router/modules/__tests__/Router-test.js
+++ b/packages/react-router/modules/__tests__/Router-test.js
@@ -2,6 +2,7 @@ import expect from 'expect'
 import React from 'react'
 import Router from '../Router'
 import ReactDOM from 'react-dom'
+import { createMemoryHistory } from 'history'
 
 describe('A <Router>', () => {
   const node = document.createElement('div')
@@ -14,7 +15,7 @@ describe('A <Router>', () => {
     it('throws an error explaining a Router can only have one child', () => {
       expect(() => {
         ReactDOM.render(
-          <Router history={{}}>
+          <Router history={createMemoryHistory()}>
             <p>Foo</p>
             <p>Bar</p>
           </Router>,
@@ -28,7 +29,7 @@ describe('A <Router>', () => {
     it('does not throw an error', () => {
       expect(() => {
         ReactDOM.render(
-          <Router history={{}}>
+          <Router history={createMemoryHistory()}>
             <p>Bar</p>
           </Router>,
           node
@@ -41,10 +42,72 @@ describe('A <Router>', () => {
     it('does not throw an error', () => {
       expect(() => {
         ReactDOM.render(
-          <Router history={{}} />,
+          <Router history={createMemoryHistory()} />,
           node
         )
       }).toNotThrow()
+    })
+  })
+
+  describe('context.router', () => {
+    let rootContext
+    const ContextChecker = (props, context) => {
+      rootContext = context.router
+      return null
+    }
+    ContextChecker.contextTypes = { router: React.PropTypes.object }
+
+    afterEach(() => {
+      rootContext = undefined
+    })
+
+    it('sets a root match', () => {
+      const history = createMemoryHistory()
+      ReactDOM.render(
+        <Router history={history}>
+          <ContextChecker />
+        </Router>,
+        node
+      )
+      expect(rootContext.match).toEqual({
+        path: '/',
+        url: '/',
+        params: {}
+      })
+    })
+
+    it('spreads the history object\'s properties', () => {
+      const history = createMemoryHistory()
+      ReactDOM.render(
+        <Router history={history}>
+          <ContextChecker />
+        </Router>,
+        node
+      )
+
+      Object.keys(history).forEach(key => {
+        expect(rootContext[key]).toEqual(history[key])
+      })
+    })
+
+    it('listens to history and updates history properties upon navigation', () => {
+      const history = createMemoryHistory()
+      ReactDOM.render(
+        <Router history={history}>
+          <ContextChecker />
+        </Router>,
+        node
+      )
+      expect(rootContext.length).toBe(1)
+
+      const newLocation = { pathname: '/new' }
+      history.push(newLocation)
+
+      Object.keys(newLocation).forEach(key => {
+        expect(rootContext.location[key]).toEqual(newLocation[key])
+      })
+      expect(rootContext.action).toBe('PUSH')
+      expect(rootContext.length).toBe(2)
     })
   })
 })


### PR DESCRIPTION
**Edited** :scissors:

Right now, a component that is rendered within a `<Route>` has a `context.router.match` object that it can use to determine "where" it is. A photo album link may be in `{ url: '/albums' }` while a photo link may be in `{ url: '/albums/123' }`. This is great for resolving relative paths.

The exception is components that are rendered inside of a `<Router>` but not within a `<Route>`. The `context.router` object created by a `<Router>` provides no initial `match` object, so if one of these components wants to know "where" it is, is has to use default values. A root match would allow those components to know "where" they are without resorting to default values.

```js
const url = match && match.url  ? match.url : '/'
```

This isn't the only situation where `match` is falsy, though. A `match` can also be `null` when rendered inside of a `<Route>` with a `path` prop that uses the `children` prop to render. In those cases, I do not believe an attempt should be made to resolve the path (see #4560), so it is important to distinguish between the two situations. Efforts could be made to behave differently when `context.router.match` is `undefined` vs. `null`, but when it is `undefined`, we really just want a root match `{ url: '/' }`, so I believe that it makes sense to provide that by adding a root `match`.
