### PR TITLE
Fix incorrect Route warnings

### DIFF
--- a/packages/react-router/modules/Route.js
+++ b/packages/react-router/modules/Route.js
@@ -63,11 +63,11 @@ class Route extends React.Component {
     })
 
     warning(
-      !(nextProps.location && !this.props.location),
+      nextProps.location && !this.props.location,
       'You cannot change from an uncontrolled to controlled Route. You passed in a `location` prop on a re-render when initially there was none.'
     )
     warning(
-      !(!nextProps.location && this.props.location),
+      !nextProps.location && this.props.location,
       'You cannot change from a controlled to an uncontrolled Route. You passed in a `location` prop initially but on a re-render there was none.'
     )
   }


### PR DESCRIPTION
The previous checks were incorrect and would spam the console with incorrect warnings.

The previous check looked like `!(!nextProps.location && this.props.location)` which in the case of the location not existing would always return true.

`!(!nextProps.location && this.props.location)` => `!(!undefined && undefined)` => `!(false)` => `true`