### PR TITLE
Remove failing auth.login() call.

### DIFF
--- a/examples/auth-flow/app.js
+++ b/examples/auth-flow/app.js
@@ -20,7 +20,6 @@ const App = React.createClass({
 
   componentWillMount() {
     auth.onChange = this.updateAuth
-    auth.login()
   },
 
   render() {


### PR DESCRIPTION
I am pretty sure this will fail every time and is unnecessary. Right?