### PR TITLE
Add default activeClassName to NavLink

### DIFF
--- a/packages/react-router-dom/modules/NavLink.js
+++ b/packages/react-router-dom/modules/NavLink.js
@@ -46,4 +46,8 @@ NavLink.propTypes = {
   isActive: PropTypes.func
 }
 
+NavLink.defaultProps = {
+  activeClassName: 'active'
+}
+
 export default NavLink


### PR DESCRIPTION
Since most of users provide the same class, it would be great to have it as a default one so we don't need to define it every time or make a wrapper component for this.

The other users, who need another class will pass another activeClassName, same as they have to do in current version.