### PR TITLE
Mutate context.route

### DIFF
--- a/packages/react-router/modules/.babelrc
+++ b/packages/react-router/modules/.babelrc
@@ -4,6 +4,9 @@
     "stage-1",
     "react"
   ],
+  "plugins": [
+    "transform-object-assign"
+  ],
   "env": {
     "production": {
       "plugins": [

--- a/packages/react-router/modules/Route.js
+++ b/packages/react-router/modules/Route.js
@@ -31,10 +31,7 @@ class Route extends React.Component {
 
   getChildContext() {
     return {
-      route: {
-        location: this.props.location || this.context.route.location,
-        match: this.state.match
-      }
+      route: this.route
     }
   }
 
@@ -51,6 +48,13 @@ class Route extends React.Component {
     return matchPath(pathname, { path, strict, exact })
   }
 
+  componentWillMount() {
+    this.route = {
+      match: this.state.match,
+      location: this.props.location || this.context.route.location
+    }
+  }
+
   componentWillReceiveProps(nextProps, nextContext) {
     warning(
       !(nextProps.location && !this.props.location),
@@ -62,9 +66,14 @@ class Route extends React.Component {
       '<Route> elements should not change from controlled to uncontrolled (or vice versa). You provided a "location" prop initially but omitted it on a subsequent render.'
     )
 
-    this.setState({
-      match: this.computeMatch(nextProps, nextContext)
+    const match = this.computeMatch(nextProps, nextContext)
+
+    Object.assign(this.route, {
+      match,
+      location: nextProps.location || nextContext.route.location
     })
+
+    this.setState({ match })
   }
 
   render() {

--- a/packages/react-router/modules/Router.js
+++ b/packages/react-router/modules/Router.js
@@ -19,10 +19,7 @@ class Router extends React.Component {
   getChildContext() {
     return {
       history: this.props.history,
-      route: {
-        location: this.props.history.location,
-        match: this.state.match
-      }
+      route: this.route
     }
   }
 
@@ -47,13 +44,21 @@ class Router extends React.Component {
       'A <Router> may have only one child element'
     )
 
+    this.route = {
+      match: this.state.match,
+      location: this.props.history.location
+    }
+
     // Do this here so we can setState when a <Redirect> changes the
     // location in componentWillMount. This happens e.g. when doing
     // server rendering using a <StaticRouter>.
     this.unlisten = history.listen(() => {
-      this.setState({
-        match: this.computeMatch(history.location.pathname)
+      const match = this.computeMatch(history.location.pathname)
+      Object.assign(this.route, {
+        location: history.location,
+        match
       })
+      this.setState({ match })
     })
   }
 

--- a/packages/react-router/modules/__tests__/Router-test.js
+++ b/packages/react-router/modules/__tests__/Router-test.js
@@ -115,5 +115,61 @@ describe('A <Router>', () => {
 
       expect(rootContext.route.match.isExact).toBe(false)
     })
+
+    it('mutates route object when updating', () => {
+      let location, goForward
+
+      class UpdateBlocker extends React.Component {
+        static contextTypes = {
+          history: React.PropTypes.object
+        }
+
+        shouldComponentUpdate() {
+          return false
+        }
+
+        render() {
+          return <Listener />
+        }
+
+        componentDidMount() {
+          goForward = this.context.history.goForward
+        }
+      }
+
+      class Listener extends React.Component {
+        static contextTypes = {
+          history: React.PropTypes.shape({
+            listen: React.PropTypes.func.isRequired
+          }).isRequired,
+          route: React.PropTypes.object.isRequired
+        }
+
+        componentWillMount() {
+          this.unlisten = this.context.history.listen(() => {
+            this.forceUpdate()
+          })
+        }
+
+        render() {
+          location = this.context.route.location
+          return null
+        }
+      }
+
+      const history = createHistory({
+        initialEntries: [ '/bubblegum', '/shoelaces' ]
+      })
+
+      ReactDOM.render((
+        <Router history={history}>
+          <UpdateBlocker />
+        </Router>
+      ), node)
+
+      expect(location.pathname).toBe('/bubblegum')
+      goForward()
+      expect(location.pathname).toBe('/shoelaces')
+    })
   })
 })

--- a/packages/react-router/package.json
+++ b/packages/react-router/package.json
@@ -48,6 +48,7 @@
     "babel-eslint": "^6.0.4",
     "babel-loader": "^6.2.10",
     "babel-plugin-dev-expression": "^0.2.1",
+    "babel-plugin-transform-object-assign": "^6.22.0",
     "babel-plugin-transform-react-remove-prop-types": "^0.2.11",
     "babel-preset-es2015": "^6.14.0",
     "babel-preset-react": "^6.5.0",


### PR DESCRIPTION
When subscriptions were removed, so was mutating an object that was used for the `context`. The problem is that if a component _is_ stuck behind `shouldComponentUpdate` and it uses a subscription to respond to navigation changes, then when it updates, it will still have the old `context`. This is fine for `context.history` because it is always the same object, but it is an issue for `context.route` because it will have the previous `match` and `location` objects.

The solution that this PR takes is to have the `<Router>` and `<Route>` keep internal `route` components that they mutate upon re-render. (This is actually one place where having `<Router>` render a `<Route>` at its base instead of adding its own `context.route` would make implementation slightly easier).