### PR TITLE
Add modal gallery to list of examples

### DIFF
--- a/packages/react-router-website/modules/docs/Web.js
+++ b/packages/react-router-website/modules/docs/Web.js
@@ -70,6 +70,11 @@ export default {
       slug: 'route-config',
       load: require('bundle?lazy!babel!../examples/RouteConfig'),
       loadSource: require('bundle?lazy!!prismjs?lang=jsx!../examples/RouteConfig.js')
+    },
+    { label: 'Modal Gallery',
+      slug: 'modal-gallery',
+      load: require('bundle?lazy!babel!../examples/ModalGallery'),
+      loadSource: require('bundle?lazy!!prismjs?lang=jsx!../examples/ModalGallery.js')
     }
   ]
 }


### PR DESCRIPTION
This was not transferred to the data in `Web.js` during the website overhaul.