### PR TITLE
Renamed route context variable to react_router_route

### DIFF
--- a/packages/react-router/modules/Route.js
+++ b/packages/react-router/modules/Route.js
@@ -8,7 +8,7 @@ import matchPath from './matchPath'
 class Route extends React.Component {
   static contextTypes = {
     history: PropTypes.object.isRequired,
-    route: PropTypes.object.isRequired
+    react_router_route: PropTypes.object.isRequired
   }
 
   static propTypes = {
@@ -26,13 +26,13 @@ class Route extends React.Component {
   }
 
   static childContextTypes = {
-    route: PropTypes.object.isRequired
+    react_router_route: PropTypes.object.isRequired
   }
 
   getChildContext() {
     return {
-      route: {
-        location: this.props.location || this.context.route.location,
+      react_router_route: {
+        location: this.props.location || this.context.react_router_route.location,
         match: this.state.match
       }
     }
@@ -42,13 +42,13 @@ class Route extends React.Component {
     match: this.computeMatch(this.props, this.context)
   }
 
-  computeMatch({ computedMatch, location, path, strict, exact }, { route }) {
+  computeMatch({ computedMatch, location, path, strict, exact }, { react_router_route }) {
     if (computedMatch)
       return computedMatch // <Switch> already computed the match for us
 
-    const pathname = (location || route.location).pathname
+    const pathname = (location || react_router_route.location).pathname
 
-    return path ? matchPath(pathname, { path, strict, exact }) : route.match
+    return path ? matchPath(pathname, { path, strict, exact }) : react_router_route.match
   }
 
   componentWillReceiveProps(nextProps, nextContext) {
@@ -70,8 +70,8 @@ class Route extends React.Component {
   render() {
     const { match } = this.state
     const { children, component, render } = this.props
-    const { history, route } = this.context
-    const location = this.props.location || route.location
+    const { history, react_router_route } = this.context
+    const location = this.props.location || react_router_route.location
     const props = { match, location, history }
 
     return (

--- a/packages/react-router/modules/Router.js
+++ b/packages/react-router/modules/Router.js
@@ -13,13 +13,13 @@ class Router extends React.Component {
 
   static childContextTypes = {
     history: PropTypes.object.isRequired,
-    route: PropTypes.object.isRequired
+    react_router_route: PropTypes.object.isRequired
   }
 
   getChildContext() {
     return {
       history: this.props.history,
-      route: {
+      react_router_route: {
         location: this.props.history.location,
         match: this.state.match
       }

--- a/packages/react-router/modules/Switch.js
+++ b/packages/react-router/modules/Switch.js
@@ -7,7 +7,7 @@ import matchPath from './matchPath'
  */
 class Switch extends React.Component {
   static contextTypes = {
-    route: PropTypes.object.isRequired
+    react_router_route: PropTypes.object.isRequired
   }
 
   static propTypes = {
@@ -28,9 +28,9 @@ class Switch extends React.Component {
   }
 
   render() {
-    const { route } = this.context
+    const { react_router_route } = this.context
     const { children } = this.props
-    const location = this.props.location || route.location
+    const location = this.props.location || react_router_route.location
 
     let match, child
     React.Children.forEach(children, element => {
@@ -39,7 +39,7 @@ class Switch extends React.Component {
 
       if (match == null) {
         child = element
-        match = path ? matchPath(location.pathname, { path, exact, strict }) : route.match
+        match = path ? matchPath(location.pathname, { path, exact, strict }) : react_router_route.match
       }
     })
 

--- a/packages/react-router/modules/__tests__/Route-test.js
+++ b/packages/react-router/modules/__tests__/Route-test.js
@@ -37,7 +37,7 @@ describe('A <Route>', () => {
     expect(node.innerHTML).toNotContain(TEXT)
   })
 
-  it('can use a `location` prop instead of `context.route.location`', () => {
+  it('can use a `location` prop instead of `context.react_router_route.location`', () => {
     const TEXT = 'tamarind chutney'
     const node = document.createElement('div')
 
@@ -299,7 +299,7 @@ describe('A <Route location>', () => {
 
       expect(node.innerHTML).toContain(TEXT)
     })
-    
+
     it('continues to use parent\'s prop location after navigation', () => {
       const TEXT = 'cheddar pretzel'
       const node = document.createElement('div')

--- a/packages/react-router/modules/__tests__/Router-test.js
+++ b/packages/react-router/modules/__tests__/Router-test.js
@@ -58,7 +58,7 @@ describe('A <Router>', () => {
 
     ContextChecker.contextTypes = {
       history: React.PropTypes.object,
-      route: React.PropTypes.object
+      react_router_route: React.PropTypes.object
     }
 
     afterEach(() => {
@@ -77,7 +77,7 @@ describe('A <Router>', () => {
       expect(rootContext.history).toBe(history)
     })
 
-    it('sets context.route at the root', () => {
+    it('sets context.react_router_route at the root', () => {
       const history = createHistory({
         initialEntries: ['/']
       })
@@ -89,14 +89,14 @@ describe('A <Router>', () => {
         node
       )
 
-      expect(rootContext.route.match.path).toEqual('/')
-      expect(rootContext.route.match.url).toEqual('/')
-      expect(rootContext.route.match.params).toEqual({})
-      expect(rootContext.route.match.isExact).toEqual(true)
-      expect(rootContext.route.location).toEqual(history.location)
+      expect(rootContext.react_router_route.match.path).toEqual('/')
+      expect(rootContext.react_router_route.match.url).toEqual('/')
+      expect(rootContext.react_router_route.match.params).toEqual({})
+      expect(rootContext.react_router_route.match.isExact).toEqual(true)
+      expect(rootContext.react_router_route.location).toEqual(history.location)
     })
 
-    it('updates context.route upon navigation', () => {
+    it('updates context.react_router_route upon navigation', () => {
       const history = createHistory({
         initialEntries: [ '/' ]
       })
@@ -108,12 +108,12 @@ describe('A <Router>', () => {
         node
       )
 
-      expect(rootContext.route.match.isExact).toBe(true)
+      expect(rootContext.react_router_route.match.isExact).toBe(true)
 
       const newLocation = { pathname: '/new' }
       history.push(newLocation)
 
-      expect(rootContext.route.match.isExact).toBe(false)
+      expect(rootContext.react_router_route.match.isExact).toBe(false)
     })
   })
 })


### PR DESCRIPTION
Fix for overriding context variable `route` with `react-relay` context variable with same name.