### PR TITLE
Fix strict dependencies

### DIFF
--- a/packages/react-router-dom/package.json
+++ b/packages/react-router-dom/package.json
@@ -42,7 +42,7 @@
   },
   "dependencies": {
     "history": "^4.5.1",
-    "react-router": "^4.0.0-beta.7"
+    "react-router": "4.0.0-beta.7"
   },
   "devDependencies": {
     "babel-cli": "^6.18.0",

--- a/packages/react-router-native/package.json
+++ b/packages/react-router-native/package.json
@@ -19,7 +19,7 @@
     "react-native": ">=0.40"
   },
   "dependencies": {
-    "react-router": "^4.0.0-beta.7"
+    "react-router": "4.0.0-beta.7"
   },
   "devDependencies": {
     "babel-jest": "18.0.0",


### PR DESCRIPTION
Fixes #4656
Dependencies between react-router's packages should be strict to avoid versions mismatching.