### PR TITLE
Group context under context.router

### DIFF
--- a/packages/react-router-dom/modules/Link.js
+++ b/packages/react-router-dom/modules/Link.js
@@ -8,10 +8,12 @@ const isModifiedEvent = (event) =>
  */
 class Link extends React.Component {
   static contextTypes = {
-    history: PropTypes.shape({
-      push: PropTypes.func.isRequired,
-      replace: PropTypes.func.isRequired,
-      createHref: PropTypes.func.isRequired
+    router: PropTypes.shape({
+      history: PropTypes.shape({
+        push: PropTypes.func.isRequired,
+        replace: PropTypes.func.isRequired,
+        createHref: PropTypes.func.isRequired
+      }).isRequired
     }).isRequired
   }
 
@@ -41,7 +43,7 @@ class Link extends React.Component {
     ) {
       event.preventDefault()
 
-      const { history } = this.context
+      const { history } = this.context.router
       const { replace, to } = this.props
 
       if (replace) {
@@ -55,7 +57,7 @@ class Link extends React.Component {
   render() {
     const { replace, to, ...props } = this.props // eslint-disable-line no-unused-vars
 
-    const href = this.context.history.createHref(
+    const href = this.context.router.history.createHref(
       typeof to === 'string' ? { pathname: to } : to
     )
 

--- a/packages/react-router-dom/modules/__tests__/BrowserRouter-test.js
+++ b/packages/react-router-dom/modules/__tests__/BrowserRouter-test.js
@@ -4,15 +4,15 @@ import ReactDOM from 'react-dom'
 import BrowserRouter from '../BrowserRouter'
 
 describe('A <BrowserRouter>', () => {
-  it('puts history on context', () => {
+  it('puts history on context.router', () => {
     let history
     const ContextChecker = (props, context) => {
-      history = context.history
+      history = context.router.history
       return null
     }
 
     ContextChecker.contextTypes = {
-      history: PropTypes.object.isRequired
+      router: PropTypes.object.isRequired
     }
 
     const node = document.createElement('div')

--- a/packages/react-router-dom/modules/__tests__/HashRouter-test.js
+++ b/packages/react-router-dom/modules/__tests__/HashRouter-test.js
@@ -4,15 +4,15 @@ import ReactDOM from 'react-dom'
 import HashRouter from '../HashRouter'
 
 describe('A <HashRouter>', () => {
-  it('puts history on context', () => {
+  it('puts history on context.router', () => {
     let history
     const ContextChecker = (props, context) => {
-      history = context.history
+      history = context.router.history
       return null
     }
 
     ContextChecker.contextTypes = {
-      history: PropTypes.object.isRequired
+      router: PropTypes.object.isRequired
     }
 
     const node = document.createElement('div')

--- a/packages/react-router-native/AndroidBackButton.js
+++ b/packages/react-router-native/AndroidBackButton.js
@@ -3,7 +3,12 @@ import { BackAndroid } from 'react-native'
 
 class AndroidBackButton extends Component {
   static contextTypes = {
-    router: PropTypes.object
+    router: PropTypes.shape({
+      history: PropTypes.shape({
+        goBack: PropTypes.func.isRequired,
+        index: PropTypes.number.isRequired
+      }).isRequired
+    }).isRequired
   }
 
   componentDidMount() {
@@ -15,11 +20,11 @@ class AndroidBackButton extends Component {
   }
 
   handleBack = () => {
-    const { router } = this.context
-    if (router.index === 0) {
+    const { history } = this.context.router
+    if (history.index === 0) {
       return false // home screen
     } else {
-      router.goBack()
+      history.goBack()
       return true
     }
   }

--- a/packages/react-router-native/DeepLinking.js
+++ b/packages/react-router-native/DeepLinking.js
@@ -5,7 +5,11 @@ const regex = /.*?:\/\//g
 
 class DeepLinking extends Component {
   static contextTypes = {
-    router: PropTypes.object
+    router: PropTypes.shape({
+      history: PropTypes.shape({
+        push: PropTypes.func.isRequired
+      }).isRequired
+    }).isRequired
   }
 
   async componentDidMount() {

--- a/packages/react-router-native/Link.js
+++ b/packages/react-router-native/Link.js
@@ -3,7 +3,12 @@ import { TouchableHighlight } from 'react-native'
 
 class Link extends Component {
   static contextTypes = {
-    history: React.PropTypes.object
+    router: PropTypes.shape({
+      history: PropTypes.shape({
+        push: PropTypes.func.isRequired,
+        replace: PropTypes.func.isRequired
+      }).isRequired
+    }).isRequired
   }
 
   static propTypes = {
@@ -21,7 +26,7 @@ class Link extends Component {
   }
 
   handlePress = () => {
-    const { history } = this.context
+    const { history } = this.context.router
     const { to, replace } = this.props
 
     if (replace) {

--- a/packages/react-router/modules/Prompt.js
+++ b/packages/react-router/modules/Prompt.js
@@ -6,8 +6,10 @@ import React, { PropTypes } from 'react'
  */
 class Prompt extends React.Component {
   static contextTypes = {
-    history: PropTypes.shape({
-      block: PropTypes.func.isRequired
+    router: PropTypes.shape({
+      history: PropTypes.shape({
+        block: PropTypes.func.isRequired
+      }).isRequired
     }).isRequired
   }
 
@@ -27,7 +29,7 @@ class Prompt extends React.Component {
     if (this.unblock)
       this.unblock()
 
-    this.unblock = this.context.history.block(message)
+    this.unblock = this.context.router.history.block(message)
   }
 
   disable() {

--- a/packages/react-router/modules/Redirect.js
+++ b/packages/react-router/modules/Redirect.js
@@ -6,13 +6,13 @@ import React, { PropTypes } from 'react'
  */
 class Redirect extends React.Component {
   static contextTypes = {
-    history: PropTypes.shape({
-      push: PropTypes.func.isRequired,
-      replace: PropTypes.func.isRequired
-    }).isRequired,
     router: PropTypes.shape({
+      history: PropTypes.shape({
+        push: PropTypes.func.isRequired,
+        replace: PropTypes.func.isRequired
+      }).isRequired,
       staticContext: PropTypes.object
-    })
+    }).isRequired
   }
 
   static propTypes = {
@@ -43,7 +43,7 @@ class Redirect extends React.Component {
   }
 
   perform() {
-    const { history } = this.context
+    const { history } = this.context.router
     const { push, to } = this.props
 
     if (push) {

--- a/packages/react-router/modules/Route.js
+++ b/packages/react-router/modules/Route.js
@@ -7,8 +7,10 @@ import matchPath from './matchPath'
  */
 class Route extends React.Component {
   static contextTypes = {
-    history: PropTypes.object.isRequired,
-    route: PropTypes.object.isRequired
+    router: PropTypes.shape({
+      history: PropTypes.object.isRequired,
+      route: PropTypes.object.isRequired
+    })
   }
 
   static propTypes = {
@@ -26,20 +28,24 @@ class Route extends React.Component {
   }
 
   static childContextTypes = {
-    route: PropTypes.object.isRequired
+    router: PropTypes.object.isRequired
   }
 
   getChildContext() {
+    const { router } = this.context
     return {
-      route: {
-        location: this.props.location || this.context.route.location,
-        match: this.state.match
+      router: {
+        ...this.context.router,
+        route: {
+          location: this.props.location || this.context.router.route.location,
+          match: this.state.match
+        }
       }
     }
   }
 
   state = {
-    match: this.computeMatch(this.props, this.context)
+    match: this.computeMatch(this.props, this.context.router)
   }
 
   computeMatch({ computedMatch, location, path, strict, exact }, { route }) {
@@ -63,14 +69,14 @@ class Route extends React.Component {
     )
 
     this.setState({
-      match: this.computeMatch(nextProps, nextContext)
+      match: this.computeMatch(nextProps, nextContext.router)
     })
   }
 
   render() {
     const { match } = this.state
     const { children, component, render } = this.props
-    const { history, route } = this.context
+    const { history, route } = this.context.router
     const location = this.props.location || route.location
     const props = { match, location, history }
 

--- a/packages/react-router/modules/Router.js
+++ b/packages/react-router/modules/Router.js
@@ -11,6 +11,10 @@ class Router extends React.Component {
     children: PropTypes.node
   }
 
+  static contextTypes = {
+    router: PropTypes.object
+  }
+
   static childContextTypes = {
     router: PropTypes.object.isRequired
   }
@@ -18,12 +22,12 @@ class Router extends React.Component {
   getChildContext() {
     return {
       router: {
+        ...this.context.router,
         history: this.props.history,
         route: {
           location: this.props.history.location,
           match: this.state.match
-        },
-        staticContext: this.props.history.staticContext
+        }
       }
     }
   }

--- a/packages/react-router/modules/Router.js
+++ b/packages/react-router/modules/Router.js
@@ -12,16 +12,18 @@ class Router extends React.Component {
   }
 
   static childContextTypes = {
-    history: PropTypes.object.isRequired,
-    route: PropTypes.object.isRequired
+    router: PropTypes.object.isRequired
   }
 
   getChildContext() {
     return {
-      history: this.props.history,
-      route: {
-        location: this.props.history.location,
-        match: this.state.match
+      router: {
+        history: this.props.history,
+        route: {
+          location: this.props.history.location,
+          match: this.state.match
+        },
+        staticContext: this.props.history.staticContext
       }
     }
   }

--- a/packages/react-router/modules/StaticRouter.js
+++ b/packages/react-router/modules/StaticRouter.js
@@ -75,6 +75,18 @@ class StaticRouter extends React.Component {
     location: '/'
   }
 
+  static childContextTypes = {
+    router: PropTypes.object.isRequired
+  }
+
+  getChildContext() {
+    return {
+      router: {
+        staticContext: this.props.context
+      }
+    }
+  }
+
   createHref = (path) =>
     addLeadingSlash(this.props.basename + createURL(path))
 
@@ -111,8 +123,7 @@ class StaticRouter extends React.Component {
       goBack: staticHandler('goBack'),
       goForward: staticHandler('goForward'),
       listen: this.handleListen,
-      block: this.handleBlock,
-      staticContext: context
+      block: this.handleBlock
     }
 
     return <Router {...props} history={history}/>

--- a/packages/react-router/modules/StaticRouter.js
+++ b/packages/react-router/modules/StaticRouter.js
@@ -75,18 +75,6 @@ class StaticRouter extends React.Component {
     location: '/'
   }
 
-  static childContextTypes = {
-    router: PropTypes.object.isRequired
-  }
-
-  getChildContext() {
-    return {
-      router: {
-        staticContext: this.props.context
-      }
-    }
-  }
-
   createHref = (path) =>
     addLeadingSlash(this.props.basename + createURL(path))
 
@@ -123,7 +111,8 @@ class StaticRouter extends React.Component {
       goBack: staticHandler('goBack'),
       goForward: staticHandler('goForward'),
       listen: this.handleListen,
-      block: this.handleBlock
+      block: this.handleBlock,
+      staticContext: context
     }
 
     return <Router {...props} history={history}/>

--- a/packages/react-router/modules/Switch.js
+++ b/packages/react-router/modules/Switch.js
@@ -7,7 +7,9 @@ import matchPath from './matchPath'
  */
 class Switch extends React.Component {
   static contextTypes = {
-    route: PropTypes.object.isRequired
+    router: PropTypes.shape({
+      route: PropTypes.object.isRequired
+    }).isRequired
   }
 
   static propTypes = {
@@ -28,7 +30,7 @@ class Switch extends React.Component {
   }
 
   render() {
-    const { route } = this.context
+    const { route } = this.context.router
     const { children } = this.props
     const location = this.props.location || route.location
 

--- a/packages/react-router/modules/__tests__/MemoryRouter-test.js
+++ b/packages/react-router/modules/__tests__/MemoryRouter-test.js
@@ -4,15 +4,15 @@ import ReactDOM from 'react-dom'
 import MemoryRouter from '../MemoryRouter'
 
 describe('A <MemoryRouter>', () => {
-  it('puts history on context', () => {
+  it('puts history on context.router', () => {
     let history
     const ContextChecker = (props, context) => {
-      history = context.history
+      history = context.router.history
       return null
     }
 
     ContextChecker.contextTypes = {
-      history: PropTypes.object.isRequired
+      router: PropTypes.object.isRequired
     }
 
     const node = document.createElement('div')

--- a/packages/react-router/modules/__tests__/Route-test.js
+++ b/packages/react-router/modules/__tests__/Route-test.js
@@ -37,7 +37,7 @@ describe('A <Route>', () => {
     expect(node.innerHTML).toNotContain(TEXT)
   })
 
-  it('can use a `location` prop instead of `context.route.location`', () => {
+  it('can use a `location` prop instead of `context.router.route.location`', () => {
     const TEXT = 'tamarind chutney'
     const node = document.createElement('div')
 

--- a/packages/react-router/modules/__tests__/Router-test.js
+++ b/packages/react-router/modules/__tests__/Router-test.js
@@ -57,8 +57,10 @@ describe('A <Router>', () => {
     }
 
     ContextChecker.contextTypes = {
-      history: React.PropTypes.object,
-      route: React.PropTypes.object
+      router: React.PropTypes.shape({
+        history: React.PropTypes.object,
+        route: React.PropTypes.object
+      })
     }
 
     afterEach(() => {
@@ -74,10 +76,10 @@ describe('A <Router>', () => {
         node
       )
 
-      expect(rootContext.history).toBe(history)
+      expect(rootContext.router.history).toBe(history)
     })
 
-    it('sets context.route at the root', () => {
+    it('sets context.router.route at the root', () => {
       const history = createHistory({
         initialEntries: ['/']
       })
@@ -89,14 +91,14 @@ describe('A <Router>', () => {
         node
       )
 
-      expect(rootContext.route.match.path).toEqual('/')
-      expect(rootContext.route.match.url).toEqual('/')
-      expect(rootContext.route.match.params).toEqual({})
-      expect(rootContext.route.match.isExact).toEqual(true)
-      expect(rootContext.route.location).toEqual(history.location)
+      expect(rootContext.router.route.match.path).toEqual('/')
+      expect(rootContext.router.route.match.url).toEqual('/')
+      expect(rootContext.router.route.match.params).toEqual({})
+      expect(rootContext.router.route.match.isExact).toEqual(true)
+      expect(rootContext.router.route.location).toEqual(history.location)
     })
 
-    it('updates context.route upon navigation', () => {
+    it('updates context.router.route upon navigation', () => {
       const history = createHistory({
         initialEntries: [ '/' ]
       })
@@ -108,12 +110,12 @@ describe('A <Router>', () => {
         node
       )
 
-      expect(rootContext.route.match.isExact).toBe(true)
+      expect(rootContext.router.route.match.isExact).toBe(true)
 
       const newLocation = { pathname: '/new' }
       history.push(newLocation)
 
-      expect(rootContext.route.match.isExact).toBe(false)
+      expect(rootContext.router.route.match.isExact).toBe(false)
     })
   })
 })

--- a/packages/react-router/modules/__tests__/Router-test.js
+++ b/packages/react-router/modules/__tests__/Router-test.js
@@ -117,5 +117,20 @@ describe('A <Router>', () => {
 
       expect(rootContext.router.route.match.isExact).toBe(false)
     })
+
+    it('does not contain context.router.staticContext by default', () => {
+      const history = createHistory({
+        initialEntries: [ '/' ]
+      })
+
+      ReactDOM.render(
+        <Router history={history}>
+          <ContextChecker />
+        </Router>,
+        node
+      )
+
+      expect(rootContext.router.staticContext).toBe(undefined)
+    })
   })
 })

--- a/packages/react-router/modules/__tests__/StaticRouter-test.js
+++ b/packages/react-router/modules/__tests__/StaticRouter-test.js
@@ -31,15 +31,38 @@ describe('A <StaticRouter>', () => {
     expect(router.staticContext).toBe(context)
   })
 
-  it('provides context.history', () => {
-    let history
+  it('context.router.staticContext persists inside of a <Route>', () => {
+    let router
     const ContextChecker = (props, context) => {
-      history = context.history
+      router = context.router
       return null
     }
 
     ContextChecker.contextTypes = {
-      history: PropTypes.object.isRequired
+      router: PropTypes.object.isRequired
+    }
+
+    const context = {  }
+
+    ReactDOMServer.renderToStaticMarkup(
+      <StaticRouter context={context}>
+        <Route component={ContextChecker}/>
+      </StaticRouter>
+    )
+
+    expect(router).toBeAn('object')
+    expect(router.staticContext).toBe(context)
+  })
+
+  it('provides context.router.history', () => {
+    let history
+    const ContextChecker = (props, context) => {
+      history = context.router.history
+      return null
+    }
+
+    ContextChecker.contextTypes = {
+      router: PropTypes.object.isRequired
     }
 
     const context = {}


### PR DESCRIPTION
Per #4650. This is mostly self-explanatory. I didn't look through the docs, but I am sure there are a few small changes that will need to be made with them.

@ryanflorence I updated the context references that I saw in `react-router-native`. There aren't any tests there to verify nothing is breaking, but everything looks right to me.

@mjackson I changed how `staticContext` gets placed on `context.router` to make `<Router>`'s implementation slightly simpler. I can revert it, but then `<Router>` would need to check its parent context.