### PR TITLE
Bring back <Route> render prop warnings

### DIFF
--- a/packages/react-router/modules/Route.js
+++ b/packages/react-router/modules/Route.js
@@ -58,6 +58,8 @@ class Route extends React.Component {
   }
 
   componentWillMount() {
+    const { component, render, children } = this.props
+
     warning(
       !(component && render),
       'You should not use <Route component> and <Route render> in the same route; <Route render> will be ignored'   

--- a/packages/react-router/modules/Route.js
+++ b/packages/react-router/modules/Route.js
@@ -57,6 +57,23 @@ class Route extends React.Component {
     return path ? matchPath(pathname, { path, strict, exact }) : route.match
   }
 
+  componentWillMount() {
+    warning(
+      !(component && render),
+      'You should not use <Route component> and <Route render> in the same route; <Route render> will be ignored'   
+    )
+
+    warning(
+      !(component && children),
+      'You should not use <Route component> and <Route children> in the same route; <Route children> will be ignored'   
+    )
+
+    warning(
+      !(render && children),
+      'You should not use <Route render> and <Route children> in the same route; <Route children> will be ignored'    
+    )
+  }
+
   componentWillReceiveProps(nextProps, nextContext) {
     warning(
       !(nextProps.location && !this.props.location),


### PR DESCRIPTION
I'm not sure if these were intentionally or accidentally removed in 45649fd. I have seen a few people having issues that would be easier to debug with these warnings.