### PR TITLE
Provide location object to <FakeBrowser>

### DIFF
--- a/packages/react-router-website/modules/components/WebExample.js
+++ b/packages/react-router-website/modules/components/WebExample.js
@@ -1,6 +1,7 @@
 import React, { PropTypes } from 'react'
 import Media from 'react-media'
 import { Block } from 'jsxstyle'
+import { Route } from 'react-router-dom'
 import Bundle from './Bundle'
 import FakeBrowser from './FakeBrowser'
 import SourceViewer from './SourceViewer'
@@ -18,17 +19,19 @@ const WebExample = ({ example }) => (
                 background="rgb(45, 45, 45)"
                 padding="40px"
               >
-                <FakeBrowser
-                  key={location.key /*force new instance*/}
-                  position={largeScreen ? 'fixed' : 'static'}
-                  width={largeScreen ? '400px' : 'auto'}
-                  height={largeScreen ? 'auto' : '70vh'}
-                  left="290px"
-                  top="40px"
-                  bottom="40px"
-                >
-                  <Example/>
-                </FakeBrowser>
+                <Route render={({ location }) => (
+                  <FakeBrowser
+                    key={location.key /*force new instance*/}
+                    position={largeScreen ? 'fixed' : 'static'}
+                    width={largeScreen ? '400px' : 'auto'}
+                    height={largeScreen ? 'auto' : '70vh'}
+                    left="290px"
+                    top="40px"
+                    bottom="40px"
+                  >
+                    <Example/>
+                  </FakeBrowser>
+                )}/>
                 <SourceViewer
                   code={src}
                   fontSize="11px"


### PR DESCRIPTION
Currently, the `location` object that `<FakeBrowser>` uses as its key is `window.location`, which does not have a `key` property.

This PR just renders a `<Route>` around the `<FakeBrowser>` so that it can access the current `location` object. This will reset the active example when the link to it in the sidebar is clicked.

Alternatively, the `example.slug` could be used as a key. If that is the case, then clicking the sidebar link of the active example will have no effect.

I am not certain which of those is preferable.