### PR TITLE
Fix setRouteLeaveHook example

### DIFF
--- a/docs/guides/ConfirmingNavigation.md
+++ b/docs/guides/ConfirmingNavigation.md
@@ -14,7 +14,7 @@ const Home = withRouter(
       // return false to prevent a transition w/o prompting the user,
       // or return a string to allow the user to decide:
       if (!this.state.isSaved)
-        return 'Your work is not saved! Are you sure you want to leave?'
+        return window.confirm('Your work is not saved! Are you sure you want to leave?')
     },
 
     // ...


### PR DESCRIPTION
The setRouteLeaveHook example is incorrect as it is missing the call to `window.confirm`.

This PR fixes it.