### PR TITLE
Fix pathless route's match when parent is null

### DIFF
--- a/packages/react-router/docs/api/match.md
+++ b/packages/react-router/docs/api/match.md
@@ -41,4 +41,4 @@ A similar, but more subtle situation occurs when you use a pathless `<Route>` in
 )}/>
 ```
 
-Pathless `<Route>`s always match, so they need to have a `match` object. To deal with this, a pseudo-match object is created. In order to make it clear that it is not a real match, the match's `url` property is set to `/_FAKE_MATCH_DO_NOT_ATTEMPT_TO_RESOLVE_USING_THIS_OR_YOU_WILL_BE_DISAPPOINTED`. If that string is part of a URL that you generate, you know that it is because you are attempting to 
+Pathless `<Route>`s inherit their `match` object from their parent. If their parent `match` is `null`, then their match will also be `null`. This means that a) any child routes/links will have to be absolute because there is no parent to resolve with and b) a pathless route whose parent `match` can be `null` will need to use the `children` prop to render.

--- a/packages/react-router/docs/api/match.md
+++ b/packages/react-router/docs/api/match.md
@@ -17,3 +17,28 @@ You'll have access `match` objects in various places:
 
 If a Route does not have a `path`, and therefore always matches, you'll get the closest parent match. Same goes for `withRouter`.
 
+## null matches
+
+A `<Route>` that uses the `children` prop will call its `children` function even when the route's `path` does not match the current location. When this is the case, the `match` will be `null`. Being able to render a `<Route>`'s contents when it does match can be useful, but certain challenges arise from this situation.
+
+The default way to "resolve" URLs is to join the `match.url` string to the "relative" path.
+
+```js
+`${match.url}/relative-path`
+```
+
+If you attempt to do this when the match is `null`, you will end up with a `TypeError`. This means that it is considered unsafe to attempt to join "relative" paths inside of a `<Route>` when using the `children` prop.
+
+A similar, but more subtle situation occurs when you use a pathless `<Route>` inside of a `<Route>` that generates a `null` match object.
+
+```js
+// location.pathname = '/matches'
+<Route path='/does-not-match' children={({ match }) => (
+  // match === null
+  <Route render={({ match:pathlessMatch }) => (
+    // pathlessMatch === ???
+  )}/>
+)}/>
+```
+
+Pathless `<Route>`s always match, so they need to have a `match` object. To deal with this, a pseudo-match object is created. In order to make it clear that it is not a real match, the match's `url` property is set to `/_FAKE_MATCH_DO_NOT_ATTEMPT_TO_RESOLVE_USING_THIS_OR_YOU_WILL_BE_DISAPPOINTED`. If that string is part of a URL that you generate, you know that it is because you are attempting to 

--- a/packages/react-router/modules/Route.js
+++ b/packages/react-router/modules/Route.js
@@ -66,7 +66,7 @@ class Route extends React.Component {
     const { route } = router
     const pathname = (location || route.location).pathname
 
-    return path ? matchPath(pathname, { path, strict, exact, sensitive }) : route.match
+    return matchPath(pathname, { path, strict, exact, sensitive }, route.match)
   }
 
   componentWillMount() {

--- a/packages/react-router/modules/Switch.js
+++ b/packages/react-router/modules/Switch.js
@@ -52,7 +52,7 @@ class Switch extends React.Component {
 
       if (match == null) {
         child = element
-        match = path ? matchPath(location.pathname, { path, exact, strict, sensitive }) : route.match
+        match = matchPath(location.pathname, { path, exact, strict, sensitive }, route.match)
       }
     })
 

--- a/packages/react-router/modules/__tests__/Route-test.js
+++ b/packages/react-router/modules/__tests__/Route-test.js
@@ -421,7 +421,7 @@ describe('A pathless <Route>', () => {
     const { match } = rootContext.router.route
 
     expect(match.path).toBe(undefined)
-    expect(match.url).toBe('/somepath')
+    expect(match.url).toBe('/_FAKE_MATCH_DO_NOT_ATTEMPT_TO_RESOLVE_USING_THIS_OR_YOU_WILL_BE_DISAPPOINTED')
     expect(match.isExact).toBe(true)
     expect(match.params).toEqual({})
   })

--- a/packages/react-router/modules/__tests__/Route-test.js
+++ b/packages/react-router/modules/__tests__/Route-test.js
@@ -394,7 +394,7 @@ describe('A pathless <Route>', () => {
     rootContext = undefined
   })
 
-  it("inherits its parent match", () => {
+  it('inherits its parent match', () => {
     const node = document.createElement('div')
     ReactDOM.render((
       <MemoryRouter initialEntries={[ '/somepath' ]}>
@@ -409,7 +409,7 @@ describe('A pathless <Route>', () => {
     expect(match.params).toEqual({})
   })
 
-  it('computes match with default values when parent match is null', () => {
+  it('does not render when parent match is null', () => {
     const node = document.createElement('div')
     ReactDOM.render((
       <MemoryRouter initialEntries={[ '/somepath' ]}>
@@ -418,11 +418,6 @@ describe('A pathless <Route>', () => {
         )}/>
       </MemoryRouter>
     ), node)
-    const { match } = rootContext.router.route
-
-    expect(match.path).toBe(undefined)
-    expect(match.url).toBe('/_FAKE_MATCH_DO_NOT_ATTEMPT_TO_RESOLVE_USING_THIS_OR_YOU_WILL_BE_DISAPPOINTED')
-    expect(match.isExact).toBe(true)
-    expect(match.params).toEqual({})
+    expect(rootContext).toBe(undefined)
   })
 })

--- a/packages/react-router/modules/__tests__/Route-test.js
+++ b/packages/react-router/modules/__tests__/Route-test.js
@@ -378,3 +378,51 @@ describe('A <Route location>', () => {
     })
   })
 })
+
+describe('A pathless <Route>', () => {
+  let rootContext
+  const ContextChecker = (props, context) => {
+    rootContext = context
+    return null
+  }
+
+  ContextChecker.contextTypes = {
+    router: React.PropTypes.object
+  }
+
+  afterEach(() => {
+    rootContext = undefined
+  })
+
+  it("inherits its parent match", () => {
+    const node = document.createElement('div')
+    ReactDOM.render((
+      <MemoryRouter initialEntries={[ '/somepath' ]}>
+        <Route component={ContextChecker} />
+      </MemoryRouter>
+    ), node)
+
+    const { match } = rootContext.router.route
+    expect(match.path).toBe('/')
+    expect(match.url).toBe('/')
+    expect(match.isExact).toBe(false)
+    expect(match.params).toEqual({})
+  })
+
+  it('computes match with default values when parent match is null', () => {
+    const node = document.createElement('div')
+    ReactDOM.render((
+      <MemoryRouter initialEntries={[ '/somepath' ]}>
+        <Route path='/no-match' children={({ match }) => (
+          <Route component={ContextChecker} />
+        )}/>
+      </MemoryRouter>
+    ), node)
+    const { match } = rootContext.router.route
+
+    expect(match.path).toBe(undefined)
+    expect(match.url).toBe('/somepath')
+    expect(match.isExact).toBe(true)
+    expect(match.params).toEqual({})
+  })
+})

--- a/packages/react-router/modules/__tests__/matchPath-test.js
+++ b/packages/react-router/modules/__tests__/matchPath-test.js
@@ -69,7 +69,7 @@ describe('matchPath', () => {
     it('returns match with default values when parent match is null', () => {
       const pathname = '/some/path'
       const match = matchPath(pathname, {}, null)
-      expect(match.url).toBe(pathname)
+      expect(match.url).toBe('/_FAKE_MATCH_DO_NOT_ATTEMPT_TO_RESOLVE_USING_THIS_OR_YOU_WILL_BE_DISAPPOINTED')
       expect(match.path).toBe(undefined)
       expect(match.params).toEqual({})
       expect(match.isExact).toBe(true)

--- a/packages/react-router/modules/__tests__/matchPath-test.js
+++ b/packages/react-router/modules/__tests__/matchPath-test.js
@@ -55,14 +55,24 @@ describe('matchPath', () => {
   })
 
   describe('with no path', () => {
-    it('matches the root URL', () => {
-      const match = matchPath('/test-location/7', {})
-      expect(match).toMatchObject({
-        url: '/',
-        path: '/',
-        params: {},
-        isExact: false
-      })
+    it('returns parent match', () => {
+      const parentMatch = {
+        url: '/test-location/7',
+        path: '/test-location/:number',
+        params: { number: 7 },
+        isExact: true
+      }
+      const match = matchPath('/test-location/7', {}, parentMatch)
+      expect(match).toBe(parentMatch)
+    })
+
+    it('returns match with default values when parent match is null', () => {
+      const pathname = '/some/path'
+      const match = matchPath(pathname, {}, null)
+      expect(match.url).toBe(pathname)
+      expect(match.path).toBe(undefined)
+      expect(match.params).toEqual({})
+      expect(match.isExact).toBe(true)
     })
   })
 

--- a/packages/react-router/modules/__tests__/matchPath-test.js
+++ b/packages/react-router/modules/__tests__/matchPath-test.js
@@ -66,13 +66,10 @@ describe('matchPath', () => {
       expect(match).toBe(parentMatch)
     })
 
-    it('returns match with default values when parent match is null', () => {
+    it('returns null when parent match is null', () => {
       const pathname = '/some/path'
       const match = matchPath(pathname, {}, null)
-      expect(match.url).toBe('/_FAKE_MATCH_DO_NOT_ATTEMPT_TO_RESOLVE_USING_THIS_OR_YOU_WILL_BE_DISAPPOINTED')
-      expect(match.path).toBe(undefined)
-      expect(match.params).toEqual({})
-      expect(match.isExact).toBe(true)
+      expect(match).toBe(null)
     })
   })
 

--- a/packages/react-router/modules/__tests__/withRouter-test.js
+++ b/packages/react-router/modules/__tests__/withRouter-test.js
@@ -46,6 +46,32 @@ describe('withRouter', () => {
     ), node)
   })
 
+  it('works when parent match is null', () => {
+    let injectedProps
+    let parentMatch
+
+    const PropChecker = (props) => {
+      injectedProps = props
+      return null
+    }
+
+    const WrappedPropChecker = withRouter(PropChecker)
+
+    const node = document.createElement('div')
+        ReactDOM.render((
+      <MemoryRouter initialEntries={[ '/somepath' ]}>
+        <Route path='/no-match' children={({ match }) => {
+          parentMatch = match
+          return <Route component={WrappedPropChecker} />
+        }}/>
+      </MemoryRouter>
+    ), node)
+
+    const { match } = injectedProps
+    expect(parentMatch).toBe(null)
+    expect(match).not.toBe(null)
+  })
+
   describe('inside a <StaticRouter>', () => {
     it('provides the staticContext prop', () => {
       const PropsChecker = withRouter(props => {

--- a/packages/react-router/modules/__tests__/withRouter-test.js
+++ b/packages/react-router/modules/__tests__/withRouter-test.js
@@ -62,14 +62,13 @@ describe('withRouter', () => {
       <MemoryRouter initialEntries={[ '/somepath' ]}>
         <Route path='/no-match' children={({ match }) => {
           parentMatch = match
-          return <Route component={WrappedPropChecker} />
+          return <WrappedPropChecker />
         }}/>
       </MemoryRouter>
     ), node)
 
-    const { match } = injectedProps
     expect(parentMatch).toBe(null)
-    expect(match).not.toBe(null)
+    expect(injectedProps.match).toBe(null)
   })
 
   describe('inside a <StaticRouter>', () => {

--- a/packages/react-router/modules/matchPath.js
+++ b/packages/react-router/modules/matchPath.js
@@ -33,13 +33,7 @@ const matchPath = (pathname, options = {}, parent) => {
   const { path, exact = false, strict = false, sensitive = false } = options
 
   if (path == null)
-    return parent != null
-      ? parent
-      : {
-          url: '/_FAKE_MATCH_DO_NOT_ATTEMPT_TO_RESOLVE_USING_THIS_OR_YOU_WILL_BE_DISAPPOINTED',
-          isExact: true,
-          params: {}
-        }
+    return parent
 
   const { re, keys } = compilePath(path, { end: exact, strict, sensitive })
   const match = re.exec(pathname)

--- a/packages/react-router/modules/matchPath.js
+++ b/packages/react-router/modules/matchPath.js
@@ -26,11 +26,15 @@ const compilePath = (pattern, options) => {
 /**
  * Public API for matching a URL pathname to a path pattern.
  */
-const matchPath = (pathname, options = {}) => {
+const matchPath = (pathname, options = {}, parent) => {
   if (typeof options === 'string')
     options = { path: options }
 
-  const { path = '/', exact = false, strict = false, sensitive = false } = options
+  const { path, exact = false, strict = false, sensitive = false } = options
+
+  if (path == null)
+    return parent != null ? parent : { url: pathname, isExact: true, params: {} }
+
   const { re, keys } = compilePath(path, { end: exact, strict, sensitive })
   const match = re.exec(pathname)
 

--- a/packages/react-router/modules/matchPath.js
+++ b/packages/react-router/modules/matchPath.js
@@ -33,7 +33,13 @@ const matchPath = (pathname, options = {}, parent) => {
   const { path, exact = false, strict = false, sensitive = false } = options
 
   if (path == null)
-    return parent != null ? parent : { url: pathname, isExact: true, params: {} }
+    return parent != null
+      ? parent
+      : {
+          url: '/_FAKE_MATCH_DO_NOT_ATTEMPT_TO_RESOLVE_USING_THIS_OR_YOU_WILL_BE_DISAPPOINTED',
+          isExact: true,
+          params: {}
+        }
 
   const { re, keys } = compilePath(path, { end: exact, strict, sensitive })
   const match = re.exec(pathname)

--- a/packages/react-router/modules/withRouter.js
+++ b/packages/react-router/modules/withRouter.js
@@ -10,7 +10,7 @@ const withRouter = (Component) => {
   const C = (props) => {
     const { wrappedComponentRef, ...remainingProps } = props
     return (
-      <Route render={routeComponentProps => (
+      <Route children={routeComponentProps => (
         <Component {...remainingProps} {...routeComponentProps} ref={wrappedComponentRef}/>
       )}/>
     )


### PR DESCRIPTION
This moves the logic for getting the match object for a pathless `<Route>` `matchPath`. When automatic path resolving is added, `matchPath` will need access to the parent `match`, so we will need to pass that argument to `matchPath` eventually anyways.

When a parent `match` is `null`, a match object with default values is returned by `matchPath`. This match object should not be relied upon for resolving paths, but it will allow a `<Route>` that uses the `component` or `render` prop to render.

Fixes #4695