### PR TITLE
aria-current in NavLink #4707

### DIFF
--- a/packages/react-router-dom/modules/NavLink.js
+++ b/packages/react-router-dom/modules/NavLink.js
@@ -14,6 +14,7 @@ const NavLink = ({
   activeStyle,
   style,
   isActive: getIsActive,
+  ariaCurrent,
   ...rest
 }) => (
   <Route
@@ -28,6 +29,7 @@ const NavLink = ({
           to={to}
           className={isActive ? [ activeClassName, className ].join(' ') : className}
           style={isActive ? { ...style, ...activeStyle } : style}
+          aria-current={isActive && ariaCurrent}
           {...rest}
         />
       )
@@ -43,11 +45,13 @@ NavLink.propTypes = {
   className: PropTypes.string,
   activeStyle: PropTypes.object,
   style: PropTypes.object,
-  isActive: PropTypes.func
+  isActive: PropTypes.func,
+  ariaCurrent: PropTypes.oneOf(['page', 'step', 'location', 'true'])
 }
 
 NavLink.defaultProps = {
-  activeClassName: 'active'
+  activeClassName: 'active',
+  ariaCurrent: 'true'
 }
 
 export default NavLink


### PR DESCRIPTION
Line 32 has to be `aria-current` instead of `ariaCurrent`, otherwise React will strip it out.