### PR TITLE
Fixes duplicate loadAbout import within code splitting docs.

### DIFF
--- a/packages/react-router-dom/docs/guides/code-splitting.md
+++ b/packages/react-router-dom/docs/guides/code-splitting.md
@@ -91,7 +91,7 @@ The `Bundle` component is great for loading as you approach a new screen, but it
 
 ```js
 import loadAbout from 'bundle?lazy!./loadAbout'
-import loadDashboard from 'bundle?lazy!./loadAbout'
+import loadDashboard from 'bundle?lazy!./loadDashboard'
 
 // components load their module for initial visit
 const About = () => (


### PR DESCRIPTION
Code-splitting documentation for `react-router-dom` has an import for the loadDashboard module, but references the same loadAbout module that precedes it.

Changes the import filename to reflect the import name.