### PR TITLE
Support Preact in react-router-redux/ConnectedRouter

### DIFF
--- a/packages/react-router-redux/modules/ConnectedRouter.js
+++ b/packages/react-router-redux/modules/ConnectedRouter.js
@@ -1,3 +1,4 @@
+import invariant from 'invariant'
 import React, { Component, PropTypes } from 'react'
 import { Router, Route } from 'react-router'
 
@@ -14,6 +15,15 @@ class ConnectedRouter extends Component {
     store: PropTypes.object
   }
 
+  componentWillMount() {
+    const { children } = this.props
+
+    invariant(
+      children == null || React.Children.count(children) === 1,
+      'A <ConnectedRouter> may have only one child element'
+    )
+  }
+
   render() {
     const { store:propsStore, history, children, ...props } = this.props
     let store = propsStore || this.context.store
@@ -26,7 +36,7 @@ class ConnectedRouter extends Component {
               payload: location
             })
 
-            return children
+            return React.Children.only(children)
           }}/>
       </Router>
     )

--- a/packages/react-router-redux/modules/__tests__/ConnectedRouter-test.js
+++ b/packages/react-router-redux/modules/__tests__/ConnectedRouter-test.js
@@ -57,4 +57,14 @@ describe('A <ConnectedRouter>', () => {
 
     expect(store.getState()).toHaveProperty('router.location.pathname', '/foo')
   })
+
+  it('renders its children', () => {
+    const tree = renderer.create(
+      <ConnectedRouter store={store} history={history}>
+        <div>Test</div>
+      </ConnectedRouter>
+    ).toJSON()
+
+    expect(tree).toMatchSnapshot()
+  })
 })

--- a/packages/react-router-redux/modules/__tests__/__snapshots__/ConnectedRouter-test.js.snap
+++ b/packages/react-router-redux/modules/__tests__/__snapshots__/ConnectedRouter-test.js.snap
@@ -1,0 +1,7 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`A <ConnectedRouter> renders its children 1`] = `
+<div>
+  Test
+</div>
+`;

--- a/packages/react-router-redux/package.json
+++ b/packages/react-router-redux/package.json
@@ -32,6 +32,7 @@
   },
   "dependencies": {
     "history": "^4.5.1",
+    "invariant": "^2.2.2",
     "react-router": "^4.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
This PR will add support for the ConnectedRouter to render Preact components without the help of `preact-compat` alias. As seen in this repo [developit/react-router-4-test](https://github.com/developit/react-router-4-test), it will work out of the box with the normal Router component.

I'm not sure what other kind of tests you would like to see aside from a snapshot. This shows that it doesn't break the current implementation, but not sure a way to prove in tests, that it does in fact work with Preact.