### PR TITLE
Make react-router-redux work with time travelling

### DIFF
--- a/packages/react-router-redux/modules/ConnectedRouter.js
+++ b/packages/react-router-redux/modules/ConnectedRouter.js
@@ -15,22 +15,73 @@ class ConnectedRouter extends Component {
   }
 
   handleLocationChange = location => {
-    this.store.dispatch({
-      type: LOCATION_CHANGE,
-      payload: location
-    })
+    /*
+     * Update the store in 2 cases:
+     * 1) Not syncing history to match store (normal flow from history to store).
+     * 2) DevTools resets state to empty location (need to change to an initial
+     * location).
+    */
+    if (!this.isSyncingHistory || !this.store.getState().router.location.pathname) {
+      this.store.dispatch({
+        type: LOCATION_CHANGE,
+        payload: location
+      })
+    }
+    // Stop syncing the history.
+    this.isSyncingHistory = false
+  }
+
+  handleStoreChange = () => {
+    // Extract store's location.
+    const storeLocation = this.store.getState().router.location
+    const {
+      pathname: storePathname,
+      search: storeSearch,
+      hash: storeHash,
+    } = storeLocation
+    // Extract history's location.
+    const {
+      pathname: historyPathname,
+      search: historySearch,
+      hash: historyHash,
+    } = this.props.history.location
+
+    // In normal situation, the store receives location state from the history.
+    // When the store is updated, the location in the store will be in sync with
+    // the location in the history. However, if the location in the store is
+    // updated before the history, they will be different. We might be time
+    // travelling, replacing root reducer, importing state, etc. So, we need to
+    // update the history to sync with the store.
+    if (historyPathname !== storePathname
+      || historySearch !== storeSearch
+      || historyHash !== storeHash) {
+      // start syncing the history
+      this.isSyncingHistory = true
+
+      if (!storePathname) {
+        // Use initial location if the store is reset.
+        // Store will be updated to initial location in handleLocationChange.
+        this.props.history.push(this.initialLocation)
+      } else {
+        this.props.history.push(storeLocation)
+      }
+    }
   }
 
   componentWillMount() {
     const { store:propsStore, history } = this.props
     this.store = propsStore || this.context.store
+    this.isSyncingHistory = false
+    this.initialLocation = history.location
 
     this.unsubscribeFromHistory = history.listen(this.handleLocationChange)
     this.handleLocationChange(history.location)
+    this.unsubscribeFromStore = this.store.subscribe(this.handleStoreChange)
   }
 
   componentWillUnmount() {
     if (this.unsubscribeFromHistory) this.unsubscribeFromHistory()
+    if (this.unsubscribeFromStore) this.unsubscribeFromStore()
   }
 
   render() {

--- a/packages/react-router-redux/modules/__tests__/ConnectedRouter-test.js
+++ b/packages/react-router-redux/modules/__tests__/ConnectedRouter-test.js
@@ -3,6 +3,7 @@ import renderer from 'react-test-renderer'
 import { createStore, combineReducers } from 'redux'
 import { Provider } from 'react-redux'
 import createHistory from 'history/createMemoryHistory'
+import { ActionCreators, instrument } from 'redux-devtools'
 
 import ConnectedRouter from '../ConnectedRouter'
 import { routerReducer } from '../reducer'
@@ -19,7 +20,7 @@ describe('A <ConnectedRouter>', () => {
   })
 
   it('connects to a store via Provider', () => {
-    expect(store.getState()).toHaveProperty('router.location', null)
+    expect(store.getState()).toHaveProperty('router.location', {})
 
     renderer.create(
       <Provider store={store}>
@@ -33,7 +34,7 @@ describe('A <ConnectedRouter>', () => {
   })
 
   it('connects to a store via props', () => {
-    expect(store.getState()).toHaveProperty('router.location', null)
+    expect(store.getState()).toHaveProperty('router.location', {})
 
     renderer.create(
       <ConnectedRouter store={store} history={history}>
@@ -59,24 +60,84 @@ describe('A <ConnectedRouter>', () => {
   })
 
   describe('with children', () => {
-    it('to render', () => {      
+    it('to render', () => {
       const tree = renderer.create(
         <ConnectedRouter store={store} history={history}>
           <div>Test</div>
         </ConnectedRouter>
       ).toJSON()
-      
+
       expect(tree).toMatchSnapshot()
     })
   })
 
   describe('with no children', () => {
-    it('to render', () => {      
+    it('to render', () => {
       const tree = renderer.create(
         <ConnectedRouter store={store} history={history} />
       ).toJSON()
-      
+
       expect(tree).toMatchSnapshot()
+    })
+  })
+
+  describe('Redux DevTools', () => {
+    let devToolsStore
+
+    beforeEach(() => {
+      // Set initial URL before syncing
+      history.push('/foo')
+
+      store = createStore(
+        combineReducers({
+          router: routerReducer
+        }),
+        instrument()
+      )
+      devToolsStore = store.liftedStore
+    })
+
+    it('resets to the initial url', () => {
+      renderer.create(
+        <ConnectedRouter store={store} history={history}>
+          <div>Test</div>
+        </ConnectedRouter>
+      )
+
+      let currentPath
+      const historyUnsubscribe = history.listen(location => {
+        currentPath = location.pathname
+      })
+
+      history.push('/bar')
+      devToolsStore.dispatch(ActionCreators.reset())
+
+      expect(currentPath).toEqual('/foo')
+
+      historyUnsubscribe()
+    })
+
+    it('handles toggle after history change', () => {
+      renderer.create(
+        <ConnectedRouter store={store} history={history}>
+          <div>Test</div>
+        </ConnectedRouter>
+      )
+
+      let currentPath
+      const historyUnsubscribe = history.listen(location => {
+        currentPath = location.pathname
+      })
+
+      history.push('/foo2') // DevTools action #2
+      history.push('/foo3') // DevTools action #3
+
+      // When we toggle an action, the devtools will revert the action
+      // and we therefore expect the history to update to the previous path
+      devToolsStore.dispatch(ActionCreators.toggleAction(3))
+      expect(currentPath).toEqual('/foo2')
+
+      historyUnsubscribe()
     })
   })
 })

--- a/packages/react-router-redux/modules/reducer.js
+++ b/packages/react-router-redux/modules/reducer.js
@@ -5,7 +5,7 @@
 export const LOCATION_CHANGE = '@@router/LOCATION_CHANGE'
 
 const initialState = {
-  location: null
+  location: {}, 
 }
 
 /**

--- a/packages/react-router-redux/package.json
+++ b/packages/react-router-redux/package.json
@@ -55,6 +55,7 @@
     "react-redux": "^5.0.3",
     "react-test-renderer": "^15.3.2",
     "redux": "^3.6.0",
+    "redux-devtools": "^3.3.2",
     "rollup": "^0.41.4",
     "rollup-plugin-babel": "^2.7.1",
     "rollup-plugin-uglify": "^1.0.1"


### PR DESCRIPTION
Hi @timdorr,

This is my first attempt to make it work with time travelling.

- I use a similar approach with [connected-react-router](https://github.com/supasate/connected-react-router/blob/07dfa3cfff3587d5bd3776854b1e5a2aec74d5ca/src/ConnectedRouter.js).
- The test cases are from old [react-router-redux](https://github.com/reactjs/react-router-redux/blob/master/test/_createSyncTest.js#L200-L254).

I make a [repo](https://github.com/supasate/test-react-router-redux) to demonstrate that it starts working now.

However, there are two known problems.
1. [Internal browser stack is modified when time travelling](https://github.com/supasate/connected-react-router/issues/36). It should be later fixed with zalmoxisus/redux-devtools-instrument#15, so, I ignore it for now.

2. `reset` test case is fail. This is crucial and needs to discuss. 

This problem is caused by the `reset` action will reset the store to its initial state which its location state is `null` and cannot be pushed to the history object. 

In [connected-react-router](supasate/connected-react-router), we solved this issue by providing the initial history to be the initial location state in the store like the following:

```js
const store = createStore(
  connectRouter(history)(rootReducer), // new root reducer with router state
  initialState,
  compose(
    ...
  ),
)
``` 

This pattern (higher order reducer) has some advantages.
1. The location in the store will begin with the initial history location instead of `null` (and the devtools's `reset()` will bring the store to match with the first URL request).
2. It doesn't trigger `LOCATION_CHANGE` action at the beginning.
3. Users don't need to manually mount `routerReducer` to the root reducer. It will be done automatically with the key `router`.

I also make a [PR](https://github.com/supasate/connected-react-router/pull/43/files) to `connected-react-router` to check that it works with same test case.

So, if you think this pattern is the right way to go, I will try refactoring the reducer.


