### PR TITLE
Add links to 2.x and 3.x documentation versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
 
 [View the docs here](https://reacttraining.com/react-router)
 
-[3.x docs](https://github.com/ReactTraining/react-router/blob/v3.0.2/docs)
+[3.x docs](https://github.com/ReactTraining/react-router/blob/v3/docs)
 
 [2.x docs](https://github.com/ReactTraining/react-router/blob/v2.8.1/docs)
 

--- a/README.md
+++ b/README.md
@@ -22,6 +22,10 @@
 
 [View the docs here](https://reacttraining.com/react-router)
 
+[3.x docs](https://github.com/ReactTraining/react-router/blob/v3.0.2/docs)
+
+[2.x docs](https://github.com/ReactTraining/react-router/blob/v2.8.1/docs)
+
 ## Packages
 
 This repository is a monorepo that we manage using [Lerna](https://github.com/lerna/lerna). That means that we actually publish [several packages](/packages) to npm from the same codebase, including:


### PR DESCRIPTION
While we're all super excited for the release of react router 4, there are still allot of users who still use 2.x so there should be easy access to these documentation pages until they upgrade.