### PR TITLE
Adds a simple nested routes example with match.path usage

### DIFF
--- a/packages/react-router-website/modules/docs/Web.js
+++ b/packages/react-router-website/modules/docs/Web.js
@@ -88,6 +88,11 @@ export default {
       slug: 'modal-gallery',
       load: require('bundle?lazy!babel!../examples/ModalGallery'),
       loadSource: require('bundle?lazy!!prismjs?lang=jsx!../examples/ModalGallery.js')
+    },
+    { label: 'Nested Routes',
+      slug: 'nested-routes',
+      load: require('bundle?lazy!babel!../examples/NestedRoutes'),
+      loadSource: require('bundle?lazy!!prismjs?lang=jsx!../examples/NestedRoutes.js')
     }
   ]
 }

--- a/packages/react-router-website/modules/examples/NestedRoutes.js
+++ b/packages/react-router-website/modules/examples/NestedRoutes.js
@@ -1,0 +1,72 @@
+import React from 'react'
+import {
+  BrowserRouter as Router,
+  Route,
+  Link,
+  Switch
+} from 'react-router-dom'
+
+const ALBUMS = [
+  { id: 'album-1', title: 'Sports', photos: [ 'photo-1', 'photo-2' ] },
+  { id: 'album-2', title: 'Family', photos: [ 'photo-3', 'photo-4' ] },
+  { id: 'album-3', title: 'Friends', photos: [ 'photo-5' ] }
+];
+
+const PHOTOS = [
+  { id: 'photo-1', caption: 'Running around fast' },
+  { id: 'photo-2', caption: 'At the gym' },
+  { id: 'photo-3', caption: 'My dogs' },
+  { id: 'photo-4', caption: 'Me and my wife' },
+  { id: 'photo-5', caption: 'Just hanging around' }
+]
+
+const NestedRoutes = () => (
+  <Router>
+    <div>
+      <h1>Photo Albums</h1>
+      <ul>
+        {ALBUMS.map(album => (
+          <li key={album.id}>
+            <Link to={`/albums/${album.id}`}>{album.title}</Link>
+          </li>
+        ))}
+      </ul>
+
+      <Route path="/albums/:albumId" component={PhotoAlbum} />
+    </div>
+  </Router>
+)
+
+const PhotoAlbum = ({ match }) => {
+  const album = ALBUMS.find(album => album.id === match.params.albumId)
+  return (
+    <div>
+      <h2>Album: {album.title}</h2>
+      <ul>
+        {album.photos.map(photoId => {
+          const photo = PHOTOS.find(photo => photoId === photo.id)
+          return (
+            <li key={photoId}>
+              <Link to={`${match.url}/photos/${photo.id}`}>{photo.caption}</Link>
+            </li>
+          )
+        })}
+      </ul>
+
+      <Route path={`${match.path}/photos/:photoId`} component={Photo} />
+    </div>
+  )
+}
+
+const Photo = ({ match }) => {
+  const photo = PHOTOS.find(photo => photo.id === match.params.photoId)
+  const album = ALBUMS.find(album => album.id === match.params.albumId)
+  return (
+    <div>
+      <h3>Photo: {photo.caption}</h3>
+      <p>This photo is in: <strong>{album.title}</strong></p>
+    </div>
+  )
+}
+
+export default NestedRoutes


### PR DESCRIPTION
This pull request adds an example that shows how to use `match.path` with nested routes and `match.url` when linking to those.