### PR TITLE
Fix guide docs scrolling

### DIFF
--- a/packages/react-router-website/modules/components/Guide.js
+++ b/packages/react-router-website/modules/components/Guide.js
@@ -9,7 +9,6 @@ const Guide = ({ match, data }) => {
   const { params: { mod, header: headerParam, environment } } = match
   const doc = data.guides.find(doc => mod === doc.title.slug)
   const header = doc && headerParam ? doc.headers.find(h => h.slug === headerParam) : null
-
   return !doc ? (
     <Redirect to={`/${environment}`}/>
   ) : (
@@ -18,6 +17,7 @@ const Guide = ({ match, data }) => {
       fontSize="80%"
     >
       <Block className="api-doc">
+        <ScrollToDoc doc={doc} header={header}/>
         <MarkdownViewer html={doc.markup}/>
       </Block>
       <Route


### PR DESCRIPTION
I found GUIDE docs scroll management is tiny broken.
And append `<ScrollToDoc>`.

|before|after|
|--|--|
|![kapture 2017-03-13 at 23 01 12](https://cloud.githubusercontent.com/assets/13282103/23857522/fa5814d0-0840-11e7-9355-76f6207f5860.gif) | ![kapture 2017-03-13 at 23 02 49](https://cloud.githubusercontent.com/assets/13282103/23857597/2efd85f8-0841-11e7-82ed-e7e8fc0f18c4.gif) |

