### PR TITLE
[react-router-config] add `exact` handling for renderRoutes

### DIFF
--- a/packages/react-router-config/modules/renderRoutes.js
+++ b/packages/react-router-config/modules/renderRoutes.js
@@ -5,9 +5,15 @@ import Route from 'react-router/Route'
 const renderRoutes = (routes) => routes ? (
   <Switch>
     {routes.map((route, i) => (
-      <Route key={i} path={route.path} exact={route.exact} render={(props) => (
-        <route.component {...props} route={route}/>
-      )}/>
+      <Route
+        exact={route.exact}
+        key={i}
+        path={route.path}
+        strict={route.strict}
+        render={(props) => (
+          <route.component {...props} route={route}/>
+        )}
+      />
     ))}
   </Switch>
 ) : null

--- a/packages/react-router-config/modules/renderRoutes.js
+++ b/packages/react-router-config/modules/renderRoutes.js
@@ -5,7 +5,7 @@ import Route from 'react-router/Route'
 const renderRoutes = (routes) => routes ? (
   <Switch>
     {routes.map((route, i) => (
-      <Route key={i} path={route.path} render={(props) => (
+      <Route key={i} path={route.path} exact={route.exact} render={(props) => (
         <route.component {...props} route={route}/>
       )}/>
     ))}


### PR DESCRIPTION
The `renderRoutes` doesn't current have any concept of `exact`. Adding it here.

No `CHANGELOG` because still in beta, and no tests because there don't exist any for `renderRoutes` yet.

... and, on another note since v4 just came out:

Thanks for all the work. I can appreciate how challenging (and, frankly, thankless) maintaining an OSS project can be. So just thought it worth expressing my gratitude.