### PR TITLE
ConnectedRouter can render without children.

### DIFF
--- a/packages/react-router-redux/modules/ConnectedRouter.js
+++ b/packages/react-router-redux/modules/ConnectedRouter.js
@@ -36,7 +36,7 @@ class ConnectedRouter extends Component {
               payload: location
             })
 
-            return React.Children.only(children)
+            return children ? React.Children.only(children) : null
           }}/>
       </Router>
     )

--- a/packages/react-router-redux/modules/__tests__/ConnectedRouter-test.js
+++ b/packages/react-router-redux/modules/__tests__/ConnectedRouter-test.js
@@ -58,13 +58,25 @@ describe('A <ConnectedRouter>', () => {
     expect(store.getState()).toHaveProperty('router.location.pathname', '/foo')
   })
 
-  it('renders its children', () => {
-    const tree = renderer.create(
-      <ConnectedRouter store={store} history={history}>
-        <div>Test</div>
-      </ConnectedRouter>
-    ).toJSON()
+  describe('with children', () => {
+    it('to render', () => {      
+      const tree = renderer.create(
+        <ConnectedRouter store={store} history={history}>
+          <div>Test</div>
+        </ConnectedRouter>
+      ).toJSON()
+      
+      expect(tree).toMatchSnapshot()
+    })
+  })
 
-    expect(tree).toMatchSnapshot()
+  describe('with no children', () => {
+    it('to render', () => {      
+      const tree = renderer.create(
+        <ConnectedRouter store={store} history={history} />
+      ).toJSON()
+      
+      expect(tree).toMatchSnapshot()
+    })
   })
 })

--- a/packages/react-router-redux/modules/__tests__/__snapshots__/ConnectedRouter-test.js.snap
+++ b/packages/react-router-redux/modules/__tests__/__snapshots__/ConnectedRouter-test.js.snap
@@ -1,7 +1,9 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`A <ConnectedRouter> renders its children 1`] = `
+exports[`A <ConnectedRouter> with children to render 1`] = `
 <div>
   Test
 </div>
 `;
+
+exports[`A <ConnectedRouter> with no children to render 1`] = `null`;


### PR DESCRIPTION
This allows us to use `ConnectedRouter` without any children:

```
<Provider store={store}>
  <ConnectedRouter history={history} routes={routes} />
</Provider>
```