### PR TITLE
Update code-splitting.md

### DIFF
--- a/packages/react-router-dom/docs/guides/code-splitting.md
+++ b/packages/react-router-dom/docs/guides/code-splitting.md
@@ -15,6 +15,28 @@ import loadSomething from 'bundle?lazy!./Something'
 </Bundle>
 ```
 
+The loadSomething means a function that uses the require.ensure function(what results are converted by bundle-loader)
+
+```js
+module.exports = function(cb) {
+  require.ensure([], function(require) {
+    cb(require(chunkPath));
+  }
+}
+```
+
+If you use typeScript, you can code the loadSomething function like it
+```js
+declare namespace require {
+  function ensure (a: any,b: (require: any) => void,c?: string): void;
+}
+export default function(cb: any) {
+  require.ensure([], function(require) {
+    cb(require(chunkPath).default);
+  }, "chunkName");
+}
+```
+
 If the module is a component, we can render it right there:
 
 ```jsx


### PR DESCRIPTION
add the loadSomething function instruction and how use the code-splitting when user use typeScript
I think it can help users better understand how code-splitting works and help users use it when they use typeScript