### PR TITLE
Handle non-element Switch children

### DIFF
--- a/packages/react-router/modules/Switch.js
+++ b/packages/react-router/modules/Switch.js
@@ -36,6 +36,8 @@ class Switch extends React.Component {
 
     let match, child
     React.Children.forEach(children, element => {
+      if (!React.isValidElement(element)) return
+
       const { path: pathProp, exact, strict, from } = element.props
       const path = pathProp || from
 

--- a/packages/react-router/modules/__tests__/Switch-test.js
+++ b/packages/react-router/modules/__tests__/Switch-test.js
@@ -119,6 +119,22 @@ describe('A <Switch>', () => {
     expect(node.innerHTML).toNotContain('bub')
     expect(node.innerHTML).toContain('cup')
   })
+
+  it('renders with non-element children', () => {
+    const node = document.createElement('div')
+
+    ReactDOM.render((
+      <MemoryRouter initialEntries={[ '/one' ]}>
+        <Switch>
+          <Route path="/one" render={() => (<h1>one</h1>)}/>
+          {false}
+          {undefined}
+        </Switch>
+      </MemoryRouter>
+    ), node)
+
+    expect(node.innerHTML).toMatch(/one/)
+  })
 })
 
 
@@ -148,7 +164,7 @@ describe('A <Switch location>', () => {
         return <Route {...props} />
       }
 
-      const switchLocation = { pathname: '/two' } 
+      const switchLocation = { pathname: '/two' }
       ReactDOM.render((
         <MemoryRouter initialEntries={[ '/one' ]}>
           <Switch location={switchLocation}>


### PR DESCRIPTION
Fixes #4725

Makes `&&` booleans easier inside of Switch.