### PR TITLE
Specify proper basename format in docs

### DIFF
--- a/packages/react-router-dom/docs/api/BrowserRouter.md
+++ b/packages/react-router-dom/docs/api/BrowserRouter.md
@@ -17,7 +17,7 @@ import { BrowserRouter } from 'react-router-dom'
 
 ## basename: string
 
-The base URL for all locations. If your app is served from a sub-directory on your server, you'll want to set this to the sub-directory.
+The base URL for all locations. If your app is served from a sub-directory on your server, you'll want to set this to the sub-directory. A properly formatted basename should have a leading slash, but no trailing slash.
 
 ```js
 <BrowserRouter basename="/calendar"/>

--- a/packages/react-router-dom/docs/api/HashRouter.md
+++ b/packages/react-router-dom/docs/api/HashRouter.md
@@ -14,7 +14,7 @@ import { HashRouter } from 'react-router-dom'
 
 ## basename: string
 
-The base URL for all locations.
+The base URL for all locations. A properly formatted basename should have a leading slash, but no trailing slash.
 
 ```js
 <HashRouter basename="/calendar"/>

--- a/packages/react-router/docs/api/StaticRouter.md
+++ b/packages/react-router/docs/api/StaticRouter.md
@@ -38,7 +38,7 @@ createServer((req, res) => {
 
 ## basename: string
 
-The base URL for all locations.
+The base URL for all locations. A properly formatted basename should have a leading slash, but no trailing slash.
 
 ```js
 <StaticRouter basename="/calendar">


### PR DESCRIPTION
History will do some work to fix malformed basenames, but it is still helpful to state that there is a correct format.