### PR TITLE
Link to API Docs instead of GitHub in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,9 +13,9 @@ Declarative routing for [React](https://facebook.github.io/react).
 
 This repository is a monorepo that we manage using [Lerna](https://github.com/lerna/lerna). That means that we actually publish [several packages](https://github.com/ReactTraining/react-router/tree/v4/packages) to npm from the same codebase, including: 
 
-- `react-router` - The core of React Router ([API docs](packages/react-router/docs))
-- `react-router-dom` - DOM bindings for React Router ([API docs](packages/react-router-dom/docs))
-- `react-router-native` - [React Native](https://facebook.github.io/react-native/) bindings for React Router ([API docs](packages/react-router-native/docs))
+- `react-router` - The core of React Router ([API docs](https://reacttraining.com/react-router/core/guides/quick-start))
+- `react-router-dom` - DOM bindings for React Router ([API docs](https://reacttraining.com/react-router/web/guides/quick-start))
+- `react-router-native` - [React Native](https://facebook.github.io/react-native/) bindings for React Router ([API docs](https://reacttraining.com/react-router/native/guides/quick-start))
 - `react-router-redux` - [React Router Redux](packages/react-router-redux) Integration with React Router and Redux
 - `react-router-config` - [React Router Config](packages/react-router-config) static route config helpers
 


### PR DESCRIPTION
I think these links should go to the actual documentation site rather than the file directory on GitHub. Searching for "React Router 4 Docs" brought me to this page, when in reality I was looking for the actual doc site.