### PR TITLE
fix typo

### DIFF
--- a/packages/react-router-config/package.json
+++ b/packages/react-router-config/package.json
@@ -2,7 +2,7 @@
   "name": "react-router-config",
   "version": "1.0.0-beta.1",
   "description": "Static route config matching for React Router",
-  "repository": "ReactTraining/react-router-config",
+  "repository": "ReactTraining/react-router",
   "license": "MIT",
   "authors": [
     "Ryan Florence"


### PR DESCRIPTION
Because [github.com/ReactTraining/react-router-config](https://github.com/ReactTraining/react-router-config) is 404.