### PR TITLE
docs(react-router-redux): create working example, based on others

### DIFF
--- a/packages/react-router-redux/README.md
+++ b/packages/react-router-redux/README.md
@@ -19,52 +19,93 @@ npm install --save react-router-redux@next
 
 ## Usage
 
-Here's a basic idea of how it works:
+Here's how to get a basic example up and running using [Create React App](https://github.com/facebookincubator/create-react-app):
+
+```sh
+npm install -g create-react-app
+create-react-app demo-app
+cd demo-app
+```
+
+```sh
+yarn add react-router-dom react-router-redux@next redux react-redux
+# or, if you're not using yarn
+npm install react-router-dom react-router-redux@next redux react-redux
+```
+
+Now you can copy/paste this example into src/App.js.
 
 ```js
-import React from 'react'
-import ReactDOM from 'react-dom'
-
-import { createStore, combineReducers, applyMiddleware } from 'redux'
-import { Provider } from 'react-redux'
+import React from 'react';
+import { connect, Provider } from 'react-redux';
+import {
+  createStore,
+  combineReducers,
+  applyMiddleware,
+  compose,
+} from 'redux'
+import {
+  Route,
+  Switch,
+  Link,
+} from 'react-router-dom'
+import {
+  ConnectedRouter,
+  routerReducer,
+  routerMiddleware,
+} from 'react-router-redux'
 
 import createHistory from 'history/createBrowserHistory'
-import { Route } from 'react-router'
 
-import { ConnectedRouter, routerReducer, routerMiddleware, push } from 'react-router-redux'
+const About = () => <h2>About</h2>
+const Company = () => <h2>Company</h2>
 
-import reducers from './reducers' // Or wherever you keep your reducers
+const App = () => (
+  <div>
+     <ul>
+       <li><Link to="/about">About Us</Link></li>
+       <li><Link to="/company">Company</Link></li>
+     </ul>
+     <Switch>
+       <Route path="/about" component={About}/>
+       <Route path="/company" component={Company}/>
+     </Switch>
+  </div>
+);
 
-// Create a history of your choosing (we're using a browser history in this case)
-const history = createHistory()
+// opt into the Redux dev tools Chrome extension
+const devtools = window.devToolsExtension || (() => noop => noop);
 
-// Build the middleware for intercepting and dispatching navigation actions
-const middleware = routerMiddleware(history)
+const history = createHistory();
 
-// Add the reducer to your store on the `router` key
-// Also apply our middleware for navigating
+const middleware = [
+  routerMiddleware(history),
+];
+
+const enhancers = [
+  devtools(),
+  applyMiddleware(...middleware),
+];
+
+const ConnectedApp = connect()(App);
+
+const appReducer = (state = {}, action) => state;
+
 const store = createStore(
   combineReducers({
-    ...reducers,
+    app: appReducer,
     router: routerReducer
   }),
-  applyMiddleware(middleware)
+  compose(...enhancers),
 )
 
-// Now you can dispatch navigation actions from anywhere!
-// store.dispatch(push('/foo'))
-
-ReactDOM.render(
+const ReactReduxRouterExample = () => (
   <Provider store={store}>
-    { /* ConnectedRouter will use the store from Provider automatically */ }
     <ConnectedRouter history={history}>
-      <div>
-        <Route exact path="/" component={Home}/>
-        <Route path="/about" component={About}/>
-        <Route path="/topics" component={Topics}/>
-      </div>
+      <Route component={ConnectedApp} />
     </ConnectedRouter>
-  </Provider>,
-  document.getElementById('root')
-)
+  </Provider>
+);
+
+export default ReactReduxRouterExample;
 ```


### PR DESCRIPTION
This example works, is fairly simple and uses the same template outlining examples on the website. Is this ok or should I add anything else? Is it possibly preferable to use `withRouter` instead of wrapping the `<ConnectedApp/>` component in a `<Route/>`?