### PR TITLE
react-router-native/Link improvements

### DIFF
--- a/packages/react-router-native/Link.js
+++ b/packages/react-router-native/Link.js
@@ -31,13 +31,15 @@ class Link extends Component {
     if (this.props.onPress)
       this.props.onPress(event)
 
-    const { history } = this.context.router
-    const { to, replace } = this.props
+    if (!event.defaultPrevented) {
+      const { history } = this.context.router
+      const { to, replace } = this.props
 
-    if (replace) {
-      history.replace(to)
-    } else {
-      history.push(to)
+      if (replace) {
+        history.replace(to)
+      } else {
+        history.push(to)
+      }
     }
   }
 

--- a/packages/react-router-native/Link.js
+++ b/packages/react-router-native/Link.js
@@ -13,6 +13,7 @@ class Link extends Component {
   }
 
   static propTypes = {
+    onPress: PropTypes.func,
     component: PropTypes.func,
     replace: PropTypes.bool,
     to: PropTypes.oneOfType([
@@ -26,7 +27,10 @@ class Link extends Component {
     replace: false
   }
 
-  handlePress = () => {
+  handlePress = (event) => {
+    if (this.props.onPress)
+      this.props.onPress(event)
+
     const { history } = this.context.router
     const { to, replace } = this.props
 

--- a/packages/react-router-native/__tests__/Link-test.js
+++ b/packages/react-router-native/__tests__/Link-test.js
@@ -1,0 +1,85 @@
+import React from 'react'
+import ReactTestUtils from 'react-addons-test-utils'
+import Link from '../Link'
+
+const createContext = () => ({
+  router: {
+    history: {
+      push: jest.fn(),
+      replace: jest.fn()
+    }
+  }
+})
+
+class EventStub {
+  preventDefault() {
+    this.defaultPrevented = true
+  }
+}
+
+describe('<Link />', () => {
+  it('navigates using push when pressed', () => {
+    const renderer = ReactTestUtils.createRenderer()
+    const context = createContext()
+    renderer.render((
+      <Link to='/push'/>
+    ), context)
+
+    const output = renderer.getRenderOutput()
+    const event = new EventStub()
+    output.props.onPress(event)
+
+    const { push } = context.router.history
+    expect(push.mock.calls.length).toBe(1)
+    expect(push.mock.calls[0][0]).toBe('/push')
+  })
+
+  it('navigates using replace when replace is true', () => {
+    const renderer = ReactTestUtils.createRenderer()
+    const context = createContext()
+    renderer.render((
+      <Link to='/replace' replace={true}/>
+    ), context)
+
+    const output = renderer.getRenderOutput()
+    const event = new EventStub()
+    output.props.onPress(event)
+
+    const { replace } = context.router.history
+    expect(replace.mock.calls.length).toBe(1)
+    expect(replace.mock.calls[0][0]).toBe('/replace')
+  })
+
+  it('calls onPress when pressed', () =>{
+    const renderer = ReactTestUtils.createRenderer()
+    const onPress = jest.fn()
+    const context = createContext()
+    renderer.render((
+      <Link onPress={onPress} to='/'/>
+    ), context)
+
+    const output = renderer.getRenderOutput()
+    const event = new EventStub()
+    output.props.onPress(event)
+
+    expect(onPress.mock.calls.length).toBe(1)
+    expect(onPress.mock.calls[0][0]).toBe(event)
+  })
+
+  it('does not navigate when the press event is cancelled', () =>{
+    const renderer = ReactTestUtils.createRenderer()
+    const onPress = (event) =>  event.preventDefault()
+    const context = createContext()
+    renderer.render((
+      <Link onPress={onPress} to='/'/>
+    ), context)
+
+    const output = renderer.getRenderOutput()
+    const event = new EventStub()
+    output.props.onPress(event)
+
+    const { push, replace } = context.router.history
+    expect(push.mock.calls.length).toBe(0)
+    expect(replace.mock.calls.length).toBe(0)
+  })
+})

--- a/packages/react-router-native/__tests__/Link-test.js
+++ b/packages/react-router-native/__tests__/Link-test.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import ReactTestUtils from 'react-addons-test-utils'
+import ShallowRenderer from 'react-test-renderer/shallow'
 import Link from '../Link'
 
 const createContext = () => ({
@@ -19,7 +19,7 @@ class EventStub {
 
 describe('<Link />', () => {
   it('navigates using push when pressed', () => {
-    const renderer = ReactTestUtils.createRenderer()
+    const renderer = new ShallowRenderer()
     const context = createContext()
     renderer.render((
       <Link to='/push'/>
@@ -35,7 +35,7 @@ describe('<Link />', () => {
   })
 
   it('navigates using replace when replace is true', () => {
-    const renderer = ReactTestUtils.createRenderer()
+    const renderer = new ShallowRenderer()
     const context = createContext()
     renderer.render((
       <Link to='/replace' replace={true}/>
@@ -51,7 +51,7 @@ describe('<Link />', () => {
   })
 
   it('calls onPress when pressed', () =>{
-    const renderer = ReactTestUtils.createRenderer()
+    const renderer = new ShallowRenderer()
     const onPress = jest.fn()
     const context = createContext()
     renderer.render((
@@ -67,7 +67,7 @@ describe('<Link />', () => {
   })
 
   it('does not navigate when the press event is cancelled', () =>{
-    const renderer = ReactTestUtils.createRenderer()
+    const renderer = new ShallowRenderer()
     const onPress = (event) =>  event.preventDefault()
     const context = createContext()
     renderer.render((

--- a/packages/react-router-native/package.json
+++ b/packages/react-router-native/package.json
@@ -3,7 +3,8 @@
   "version": "4.1.1",
   "main": "main.js",
   "scripts": {
-    "start": "node node_modules/react-native/local-cli/cli.js start"
+    "start": "node node_modules/react-native/local-cli/cli.js start",
+    "test": "jest"
   },
   "files": [
     "DeepLinking.js",
@@ -27,6 +28,8 @@
     "babel-preset-react-native": "1.9.1",
     "jest": "18.1.0",
     "react": "15.4.1",
+    "react-addons-test-utils": "^15.4.2",
+    "react-dom": "^15.4.2",
     "react-native": "0.42.0",
     "react-test-renderer": "~15.4.0-rc.4"
   },

--- a/packages/react-router-native/package.json
+++ b/packages/react-router-native/package.json
@@ -28,10 +28,8 @@
     "babel-preset-react-native": "1.9.1",
     "jest": "18.1.0",
     "react": "15.4.1",
-    "react-addons-test-utils": "^15.4.2",
-    "react-dom": "^15.4.2",
     "react-native": "0.42.0",
-    "react-test-renderer": "~15.4.0-rc.4"
+    "react-test-renderer": "15.5.4"
   },
   "jest": {
     "preset": "react-native"


### PR DESCRIPTION
This change adds the following behavior to the react-router-native/Link component:

 - `onPress` handler can now be passed to Link
 - `onPress` event can now be cancelled using `preventDefault()`

---

An example illustrating the new behavior

```jsx
import React, { Component } from 'react'
import { Link } from 'react-router-native'

class Example extends Component {
  onPress(event) { // this function is now called
    event.preventDefault() // this stops react-router from navigating
  }

  render() {
    return <Link to='/' onPress={this.onPress.bind(this)} />
  }
}
```

Fixes #4811

---

Notes: The react-native init included tests are failing. There is not an eslint config in react-router-native, so I tried to match the style of the other packages.