### PR TITLE
fix(config/renderRoutes): add missing props

### DIFF
--- a/packages/react-router-config/modules/renderRoutes.js
+++ b/packages/react-router-config/modules/renderRoutes.js
@@ -4,11 +4,19 @@ import Route from 'react-router/Route'
 
 const renderRoutes = (routes) => routes ? (
   <Switch>
-    {routes.map((route, i) => (
-      <Route key={i} path={route.path} render={(props) => (
-        <route.component {...props} route={route}/>
-      )}/>
-    ))}
+    {
+      routes.map((route, i) => (
+        <Route
+          key={i}
+          path={route.path}
+          exact={route.exact}
+          strict={route.strict}
+          render={(props) => (
+            <route.component {...props} route={route} />
+          )}
+        />
+      ))
+    }
   </Switch>
 ) : null
 


### PR DESCRIPTION
## What

follow the README guide here [renderRoutes(routes)](https://github.com/ReactTraining/react-router/tree/master/packages/react-router-config#renderroutesroutes) , the props not working

```
...
exact: true,
...
```

## So

add `exact` and `strict` follow the docs: [Route](https://reacttraining.com/react-router/web/api/Route) here.

## But

I think the demo in here: https://reacttraining.com/react-router/web/example/route-config

is better than this package.
