### PR TITLE
Return null if this.props.children is undefined

### DIFF
--- a/packages/react-router-native/AndroidBackButton.js
+++ b/packages/react-router-native/AndroidBackButton.js
@@ -30,7 +30,7 @@ class AndroidBackButton extends Component {
   }
 
   render() {
-    return this.props.children
+    return this.props.children || null;
   }
 }
 


### PR DESCRIPTION
Without this change I get:

```js
AndroidBackButton.render(): A valid React element (or null) must be returned.
```

When used as shown in docs:

```js
          <NativeRouter>
            <View style={{flex: 1}}>
              <AndroidBackButton />
            </View>
          </NativeRouter>
```