### PR TITLE
Fix link to React Router Config

### DIFF
--- a/packages/react-router-dom/docs/guides/server-rendering.md
+++ b/packages/react-router-dom/docs/guides/server-rendering.md
@@ -236,4 +236,4 @@ You might be interested in our [React Router Config][RRC] package to assist with
   [StaticRouter]:../api/StaticRouter.md
   [BrowserRouter]:../api/BrowserRouter.md
   [Redirect]:../api/Redirect.md
-  [RRC]:https://github.com/reacttraining/react-router/packages/react-router-config
+  [RRC]:https://github.com/ReactTraining/react-router/tree/master/packages/react-router-config


### PR DESCRIPTION
This was fixed in static-routes.md in 38a0f5709, but the change wasn't carried over to this page when making the fix.