### PR TITLE
Improve withRouter

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+## HEAD
+
+- Add `wrappedComponent` to the component returned by `withRouter`
+
 ## [v4.0.0-beta.8]
 > Mar 8, 2017
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,7 @@
 ## HEAD
 
 - Add `wrappedComponent` to the component returned by `withRouter`
+- Add `wrappedComponentRef` prop to the component returned by `withRouter`
 
 ## [v4.0.0-beta.8]
 > Mar 8, 2017

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@
 
 - Add `wrappedComponent` to the component returned by `withRouter`
 - Add `wrappedComponentRef` prop to the component returned by `withRouter`
+- Add non-react static methods and properties of the wrapped component to the component returned by `withRouter`
 
 ## [v4.0.0-beta.8]
 > Mar 8, 2017

--- a/packages/react-router/docs/api/withRouter.md
+++ b/packages/react-router/docs/api/withRouter.md
@@ -41,3 +41,17 @@ connect(...)(withRouter(MyComponent))
 ```
 
 See [this guide](https://github.com/ReactTraining/react-router/blob/master/packages/react-router/docs/guides/blocked-updates.md) for more information.
+
+## Component.WrappedComponent
+
+The wrapped component is exposed as the static property `WrappedComponent` on the returned component, which can be used
+for testing the component in isolation, among other things.
+
+```js
+// MyComponent.js
+export default withRouter(MyComponent)
+
+// MyComponent.test.js
+import MyComponent from './MyComponent'
+render(<MyComponent.WrappedComponent location={{...}} ... />)
+```

--- a/packages/react-router/docs/api/withRouter.md
+++ b/packages/react-router/docs/api/withRouter.md
@@ -55,3 +55,21 @@ export default withRouter(MyComponent)
 import MyComponent from './MyComponent'
 render(<MyComponent.WrappedComponent location={{...}} ... />)
 ```
+
+## wrappedComponentRef: func
+
+A function that will be passed as the `ref` prop to the wrapped component.
+
+```js
+class Container extends React.Component {
+  componentDidMount() {
+    this.component.doSomething()  
+  }
+  
+  render() {
+    return (
+      <MyComponent wrappedComponentRef={c => this.component = c}/>
+    )
+  }
+}
+```

--- a/packages/react-router/docs/api/withRouter.md
+++ b/packages/react-router/docs/api/withRouter.md
@@ -42,6 +42,11 @@ connect(...)(withRouter(MyComponent))
 
 See [this guide](https://github.com/ReactTraining/react-router/blob/master/packages/react-router/docs/guides/blocked-updates.md) for more information.
 
+#### Static Methods and Properties
+
+All non-react specific static methods and properties of the wrapped component are automatically copied to the 
+"connected" component.
+
 ## Component.WrappedComponent
 
 The wrapped component is exposed as the static property `WrappedComponent` on the returned component, which can be used

--- a/packages/react-router/modules/__tests__/withRouter-test.js
+++ b/packages/react-router/modules/__tests__/withRouter-test.js
@@ -90,4 +90,23 @@ describe('withRouter', () => {
 
     expect(ref).toBeA(WrappedComponent)
   })
+
+  it('hoists non-react statics from the wrapped component', () => {
+    class Component extends React.Component {
+      static foo() {
+        return 'bar'
+      }
+
+      render() {
+        return null
+      }
+    }
+    Component.hello = 'world'
+
+    const decorated = withRouter(Component)
+
+    expect(decorated.hello).toBe('world')
+    expect(decorated.foo).toBeA('function')
+    expect(decorated.foo()).toBe('bar')
+  })
 })

--- a/packages/react-router/modules/__tests__/withRouter-test.js
+++ b/packages/react-router/modules/__tests__/withRouter-test.js
@@ -64,4 +64,10 @@ describe('withRouter', () => {
       ), node)
     })
   })
+
+  it('exposes the wrapped component as WrappedComponent', () => {
+    const Component = () => <div/>
+    const decorated = withRouter(Component)
+    expect(decorated.WrappedComponent).toBe(Component)
+  })
 })

--- a/packages/react-router/modules/__tests__/withRouter-test.js
+++ b/packages/react-router/modules/__tests__/withRouter-test.js
@@ -70,4 +70,24 @@ describe('withRouter', () => {
     const decorated = withRouter(Component)
     expect(decorated.WrappedComponent).toBe(Component)
   })
+
+  it('exposes the instance of the wrapped component via wrappedComponentRef', () => {
+    class WrappedComponent extends React.Component {
+      render() {
+        return null
+      }
+    }
+    const Component = withRouter(WrappedComponent)
+
+    let ref
+    ReactDOM.render((
+      <MemoryRouter initialEntries={[ '/bubblegum' ]}>
+        <Route path="/bubblegum" render={() => (
+          <Component wrappedComponentRef={r => ref = r}/>
+        )}/>
+      </MemoryRouter>
+    ), node)
+
+    expect(ref).toBeA(WrappedComponent)
+  })
 })

--- a/packages/react-router/modules/withRouter.js
+++ b/packages/react-router/modules/withRouter.js
@@ -1,18 +1,24 @@
-import React from 'react'
+import React, { PropTypes } from 'react'
 import Route from './Route'
 
 /**
  * A public higher-order component to access the imperative API
  */
 const withRouter = (Component) => {
-  const C = (props) => (
-    <Route render={routeComponentProps => (
-      <Component {...props} {...routeComponentProps}/>
-    )}/>
-  )
+  const C = (props) => {
+    const { wrappedComponentRef, ...remainingProps } = props
+    return (
+      <Route render={routeComponentProps => (
+        <Component {...remainingProps} {...routeComponentProps} ref={wrappedComponentRef}/>
+      )}/>
+    )
+  }
 
   C.displayName = `withRouter(${Component.displayName || Component.name})`
   C.WrappedComponent = Component
+  C.propTypes = {
+    wrappedComponentRef: PropTypes.func
+  }
 
   return C
 }

--- a/packages/react-router/modules/withRouter.js
+++ b/packages/react-router/modules/withRouter.js
@@ -12,6 +12,7 @@ const withRouter = (Component) => {
   )
 
   C.displayName = `withRouter(${Component.displayName || Component.name})`
+  C.WrappedComponent = Component
 
   return C
 }

--- a/packages/react-router/modules/withRouter.js
+++ b/packages/react-router/modules/withRouter.js
@@ -1,4 +1,5 @@
 import React, { PropTypes } from 'react'
+import hoistStatics from 'hoist-non-react-statics'
 import Route from './Route'
 
 /**
@@ -20,7 +21,7 @@ const withRouter = (Component) => {
     wrappedComponentRef: PropTypes.func
   }
 
-  return C
+  return hoistStatics(C, Component)
 }
 
 export default withRouter

--- a/packages/react-router/package.json
+++ b/packages/react-router/package.json
@@ -37,6 +37,7 @@
   },
   "dependencies": {
     "history": "^4.6.0",
+    "hoist-non-react-statics": "^1.2.0",
     "invariant": "^2.2.2",
     "loose-envify": "^1.3.1",
     "path-to-regexp": "^1.5.3",


### PR DESCRIPTION
This brings the current `withRouter` more in line with what we had in v3.

1. WrappedComponent: Lets people access the original component as a static property. Useful for unit testing the component without the router (might help with #4795). It's also what react-redux does.
2. wrappedComponentRef prop: Passed as `ref` to the original component. v3 and react-redux use a different API based on `options: { withRef: true }` and `getWrappedInstance()`, but this way seems more comfortable to me to use with ref functions, and we don't need to change the signature to something like `options => Component => Component` or `(Component, options) => Component`. It's also suggested in the  [react docs](https://facebook.github.io/react/docs/higher-order-components.html#refs-arent-passed-through).
3. Hoist statics of the original component