### PR TITLE
More specific <Redirect from> description

### DIFF
--- a/packages/react-router/docs/api/Redirect.md
+++ b/packages/react-router/docs/api/Redirect.md
@@ -44,7 +44,7 @@ When `true`, redirecting will push a new entry onto the history instead of repla
 
 ## from: string
 
-A pathname to redirect from. This can be used to match a location when rendering a `<Redirect>` inside of a `<Switch>`.
+A pathname to redirect from. This can only be used to match a location when rendering a `<Redirect>` inside of a `<Switch>`. See [`<Switch children>`](./Switch.md#children-node) for more details.
 
 ```js
 <Switch>

--- a/packages/react-router/docs/api/Switch.md
+++ b/packages/react-router/docs/api/Switch.md
@@ -55,6 +55,8 @@ All children of a `<Switch>` should be `<Route>` or `<Redirect>` elements. Only 
 
 `<Route>` elements are matched using their `path` prop and `<Redirect>` elements are matched using their `from` prop. A `<Route>` with no `path` prop or a `<Redirect>` with no `from` prop will always match the current location.
 
+When you include a `<Redirect>` in a `<Switch>`, it can use any of the `<Route>`'s location matching props: `path`, `exact`, and `strict`. `from` is just an alias for the `path` prop.
+
 ```js
 <Switch>
   <Route exact path="/" component={Home}/>


### PR DESCRIPTION
There seems to be some confusion around this.

I think that the link will work (it works within GitHub), but at least for me, none of the single-dot relative paths work when running the documentation site locally.