### PR TITLE
Fix webpack-related anonymous function issue

### DIFF
--- a/modules/createRouterHistory.js
+++ b/modules/createRouterHistory.js
@@ -4,7 +4,7 @@ const canUseDOM = !!(
   typeof window !== 'undefined' && window.document && window.document.createElement
 )
 
-export default function (createHistory) {
+export default function createRouterHistory(createHistory) {
   let history
   if (canUseDOM)
     history = useRouterHistory(createHistory)()


### PR DESCRIPTION
Fixes an issue identified in #4855. Occurs when webpack tries to parse an anonymous function without expression brackets wrapping the function.
Looks like simply giving the function a name fixes this issue (hopefully). It at least worked when I tested it locally.