### PR TITLE
Passthrough `style` prop inside `<Switch />` component

### DIFF
--- a/packages/react-router/modules/Switch.js
+++ b/packages/react-router/modules/Switch.js
@@ -31,7 +31,7 @@ class Switch extends React.Component {
 
   render() {
     const { route } = this.context.router
-    const { children } = this.props
+    const { children, style } = this.props
     const location = this.props.location || route.location
 
     let match, child
@@ -47,7 +47,7 @@ class Switch extends React.Component {
       }
     })
 
-    return match ? React.cloneElement(child, { location, computedMatch: match }) : null
+    return match ? React.cloneElement(child, { location, computedMatch: match, style }) : null
   }
 }
 


### PR DESCRIPTION
In several cases (such as when using `react-motion` container components around routes) you need to be able to pass the incoming `style` prop down to the route children of a <Switch />. This PR ensures that the `style` prop that's assigned to `<Switch />` gets sent down to its components.

An example of this might be:

```
import {TransitionMotion} from 'react-motion';

<TransitionMotion>
    <Switch>
        <Route ... />
        <Route ... />
    </Switch>
</TransitionMotion>
```

Where the `TransitionMotion` component passes down a new `style` prop that should be propagated down to the next immediate DOM node child. Because `Switch` doesn't pass that prop through, the animation is broken.

A few questions about this PR:

- I'm currently only passing down the `style` prop to solve my specific needs, but should `Switch` pass down all props instead?
- I'm not sure why the CI tests are failing. I'm not seeing where the error is.