### PR TITLE
<Route> can contain multi-paths

### DIFF
--- a/packages/react-router/docs/api/Route.md
+++ b/packages/react-router/docs/api/Route.md
@@ -130,9 +130,9 @@ This could also be useful for animations:
 
 **Warning:** Both `<Route component>` and `<Route render>` take precendence over `<Route children>` so don't use more than one in the same `<Route>`.
 
-## path: string
+## path: string | array
 
-Any valid URL path that [`path-to-regexp`](https://www.npmjs.com/package/path-to-regexp) understands.
+Any valid URL path(s) that [`path-to-regexp`](https://www.npmjs.com/package/path-to-regexp) understands.
 
 ```js
 <Route path="/users/:id" component={User}/>

--- a/packages/react-router/modules/__tests__/Route-test.js
+++ b/packages/react-router/modules/__tests__/Route-test.js
@@ -116,6 +116,30 @@ describe('A unicode <Route>', () => {
   })
 })
 
+describe('A <Route> can contain several paths', () => {
+  it('matches the first path', () => {
+    const node = document.createElement('div')
+    ReactDOM.render((
+      <MemoryRouter initialEntries={[ '/sushi/tuna' ]}>
+        <Route path={[ '/sushi/:neta', '/sake' ]} render={({ match }) => <div>{match.params.neta}</div>} />
+      </MemoryRouter>
+    ), node)
+
+    expect(node.innerHTML).toContain('tuna')
+  })
+
+  it('matches the second path', () => {
+    const node = document.createElement('div')
+    ReactDOM.render((
+      <MemoryRouter initialEntries={[ '/sake' ]}>
+        <Route path={[ '/sushi/:neta', '/sake' ]} render={({ match }) => <div>{match.url}</div>} />
+      </MemoryRouter>
+    ), node)
+
+    expect(node.innerHTML).toContain('/sake')
+  })
+})
+
 describe('<Route render>', () => {
   const history = createMemoryHistory()
   const node = document.createElement('div')


### PR DESCRIPTION
the [path-to-regexp](https://www.npmjs.com/package/path-to-regexp#usage) API document has describe `path` argument as  "an array of strings, or a regular expression" :v: