### PR TITLE
Fix typo in quick-start guide

### DIFF
--- a/packages/react-router-native/docs/guides/quick-start.md
+++ b/packages/react-router-native/docs/guides/quick-start.md
@@ -76,7 +76,7 @@ const Topics = ({ match }) => (
   </View>
 )
 
-const nativeRouterExamples = () => (
+const App = () => (
   <NativeRouter>
     <View style={styles.container}>
       <View style={styles.nav}>


### PR DESCRIPTION
The guide doesn't work because the variable `App` is registered at the bottom, but doesn't exist. Solved by renaming `nativeRouterExamples` to `App`.