### PR TITLE
Extending `path` PropType in Route component to accept also RegExp

### DIFF
--- a/packages/react-router/modules/Route.js
+++ b/packages/react-router/modules/Route.js
@@ -8,7 +8,14 @@ import matchPath from './matchPath'
 class Route extends React.Component {
   static propTypes = {
     computedMatch: PropTypes.object, // private, from <Switch>
-    path: PropTypes.string,
+    path: function(props, propName, componentName) {
+      if (!(typeof props[propName] === 'string' || props[propName] instanceof RegExp)) {
+        return new Error(
+          'Invalid prop `' + propName + '` of type `' + typeof props[propName] + '` supplied to' +
+          ' `' + componentName + '`. Expected `string` or `RegExp`.'
+        )
+      }
+    },
     exact: PropTypes.bool,
     strict: PropTypes.bool,
     component: PropTypes.func,


### PR DESCRIPTION
Adding RegExp as one of two accepted types for `path` prop from `Route` component. This is to resemble more what [path-to-regexp](https://github.com/pillarjs/path-to-regexp) accepts, as the [RR docs](https://reacttraining.com/react-router/web/api/Route/path-string) specify.