### PR TITLE
Update quick-start.md

### DIFF
--- a/packages/react-router-dom/docs/guides/quick-start.md
+++ b/packages/react-router-dom/docs/guides/quick-start.md
@@ -33,24 +33,6 @@ import {
   Link
 } from 'react-router-dom'
 
-const BasicExample = () => (
-  <Router>
-    <div>
-      <ul>
-        <li><Link to="/">Home</Link></li>
-        <li><Link to="/about">About</Link></li>
-        <li><Link to="/topics">Topics</Link></li>
-      </ul>
-
-      <hr/>
-
-      <Route exact path="/" component={Home}/>
-      <Route path="/about" component={About}/>
-      <Route path="/topics" component={Topics}/>
-    </div>
-  </Router>
-)
-
 const Home = () => (
   <div>
     <h2>Home</h2>
@@ -60,6 +42,12 @@ const Home = () => (
 const About = () => (
   <div>
     <h2>About</h2>
+  </div>
+)
+
+const Topic = ({ match }) => (
+  <div>
+    <h3>{match.params.topicId}</h3>
   </div>
 )
 
@@ -91,12 +79,23 @@ const Topics = ({ match }) => (
   </div>
 )
 
-const Topic = ({ match }) => (
-  <div>
-    <h3>{match.params.topicId}</h3>
-  </div>
-)
+const BasicExample = () => (
+  <Router>
+    <div>
+      <ul>
+        <li><Link to="/">Home</Link></li>
+        <li><Link to="/about">About</Link></li>
+        <li><Link to="/topics">Topics</Link></li>
+      </ul>
 
+      <hr/>
+
+      <Route exact path="/" component={Home}/>
+      <Route path="/about" component={About}/>
+      <Route path="/topics" component={Topics}/>
+    </div>
+  </Router>
+)
 export default BasicExample
 ```
 


### PR DESCRIPTION
The quick-start uses `react-create-app`, but following the instructions & dropping in the Basic Example results in linting warnings (e.g. `warning  'Home' was used before it was defined  no-use-before-define`)