### PR TITLE
Fix server side async hooks

### DIFF
--- a/modules/TransitionUtils.js
+++ b/modules/TransitionUtils.js
@@ -8,119 +8,127 @@ class PendingHooks {
   clear = () => this.hooks = []
 }
 
-const enterHooks = new PendingHooks()
-const changeHooks = new PendingHooks()
+export default function getTransitionUtils() {
+  const enterHooks = new PendingHooks()
+  const changeHooks = new PendingHooks()
 
-function createTransitionHook(hook, route, asyncArity, pendingHooks) {
-  const isSync = hook.length < asyncArity
+  function createTransitionHook(hook, route, asyncArity, pendingHooks) {
+    const isSync = hook.length < asyncArity
 
-  const transitionHook = (...args) => {
-    hook.apply(route, args)
+    const transitionHook = (...args) => {
+      hook.apply(route, args)
 
-    if (isSync) {
-      let callback = args[args.length - 1]
-      // Assume hook executes synchronously and
-      // automatically call the callback.
+      if (isSync) {
+        let callback = args[args.length - 1]
+        // Assume hook executes synchronously and
+        // automatically call the callback.
+        callback()
+      }
+    }
+
+    pendingHooks.add(transitionHook)
+
+    return transitionHook
+  }
+
+  function getEnterHooks(routes) {
+    return routes.reduce(function (hooks, route) {
+      if (route.onEnter)
+        hooks.push(createTransitionHook(route.onEnter, route, 3, enterHooks))
+      return hooks
+    }, [])
+  }
+
+  function getChangeHooks(routes) {
+    return routes.reduce(function (hooks, route) {
+      if (route.onChange)
+        hooks.push(createTransitionHook(route.onChange, route, 4, changeHooks))
+      return hooks
+    }, [])
+  }
+
+  function runTransitionHooks(length, iter, callback) {
+    if (!length) {
       callback()
+      return
     }
+
+    let redirectInfo
+    function replace(location) {
+      redirectInfo = location
+    }
+
+    loopAsync(length, function (index, next, done) {
+      iter(index, replace, function (error) {
+        if (error || redirectInfo) {
+          done(error, redirectInfo) // No need to continue.
+        } else {
+          next()
+        }
+      })
+    }, callback)
   }
 
-  pendingHooks.add(transitionHook)
-
-  return transitionHook
-}
-
-function getEnterHooks(routes) {
-  return routes.reduce(function (hooks, route) {
-    if (route.onEnter)
-      hooks.push(createTransitionHook(route.onEnter, route, 3, enterHooks))
-    return hooks
-  }, [])
-}
-
-function getChangeHooks(routes) {
-  return routes.reduce(function (hooks, route) {
-    if (route.onChange)
-      hooks.push(createTransitionHook(route.onChange, route, 4, changeHooks))
-    return hooks
-  }, [])
-}
-
-function runTransitionHooks(length, iter, callback) {
-  if (!length) {
-    callback()
-    return
+  /**
+   * Runs all onEnter hooks in the given array of routes in order
+   * with onEnter(nextState, replace, callback) and calls
+   * callback(error, redirectInfo) when finished. The first hook
+   * to use replace short-circuits the loop.
+   *
+   * If a hook needs to run asynchronously, it may use the callback
+   * function. However, doing so will cause the transition to pause,
+   * which could lead to a non-responsive UI if the hook is slow.
+   */
+  function runEnterHooks(routes, nextState, callback) {
+    enterHooks.clear()
+    const hooks = getEnterHooks(routes)
+    return runTransitionHooks(hooks.length, (index, replace, next) => {
+      const wrappedNext = (...args) => {
+        if (enterHooks.has(hooks[index])) {
+          next(...args)
+          enterHooks.remove(hooks[index])
+        }
+      }
+      hooks[index](nextState, replace, wrappedNext)
+    }, callback)
   }
 
-  let redirectInfo
-  function replace(location) {
-    redirectInfo = location
+  /**
+   * Runs all onChange hooks in the given array of routes in order
+   * with onChange(prevState, nextState, replace, callback) and calls
+   * callback(error, redirectInfo) when finished. The first hook
+   * to use replace short-circuits the loop.
+   *
+   * If a hook needs to run asynchronously, it may use the callback
+   * function. However, doing so will cause the transition to pause,
+   * which could lead to a non-responsive UI if the hook is slow.
+   */
+  function runChangeHooks(routes, state, nextState, callback) {
+    changeHooks.clear()
+    const hooks = getChangeHooks(routes)
+    return runTransitionHooks(hooks.length, (index, replace, next) => {
+      const wrappedNext = (...args) => {
+        if (changeHooks.has(hooks[index])) {
+          next(...args)
+          changeHooks.remove(hooks[index])
+        }
+      }
+      hooks[index](state, nextState, replace, wrappedNext)
+    }, callback)
   }
 
-  loopAsync(length, function (index, next, done) {
-    iter(index, replace, function (error) {
-      if (error || redirectInfo) {
-        done(error, redirectInfo) // No need to continue.
-      } else {
-        next()
-      }
-    })
-  }, callback)
-}
+  /**
+   * Runs all onLeave hooks in the given array of routes in order.
+   */
+  function runLeaveHooks(routes, prevState) {
+    for (let i = 0, len = routes.length; i < len; ++i)
+      if (routes[i].onLeave)
+        routes[i].onLeave.call(routes[i], prevState)
+  }
 
-/**
- * Runs all onEnter hooks in the given array of routes in order
- * with onEnter(nextState, replace, callback) and calls
- * callback(error, redirectInfo) when finished. The first hook
- * to use replace short-circuits the loop.
- *
- * If a hook needs to run asynchronously, it may use the callback
- * function. However, doing so will cause the transition to pause,
- * which could lead to a non-responsive UI if the hook is slow.
- */
-export function runEnterHooks(routes, nextState, callback) {
-  enterHooks.clear()
-  const hooks = getEnterHooks(routes)
-  return runTransitionHooks(hooks.length, (index, replace, next) => {
-    const wrappedNext = (...args) => {
-      if (enterHooks.has(hooks[index])) {
-        next(...args)
-        enterHooks.remove(hooks[index])
-      }
-    }
-    hooks[index](nextState, replace, wrappedNext)
-  }, callback)
-}
-
-/**
- * Runs all onChange hooks in the given array of routes in order
- * with onChange(prevState, nextState, replace, callback) and calls
- * callback(error, redirectInfo) when finished. The first hook
- * to use replace short-circuits the loop.
- *
- * If a hook needs to run asynchronously, it may use the callback
- * function. However, doing so will cause the transition to pause,
- * which could lead to a non-responsive UI if the hook is slow.
- */
-export function runChangeHooks(routes, state, nextState, callback) {
-  changeHooks.clear()
-  const hooks = getChangeHooks(routes)
-  return runTransitionHooks(hooks.length, (index, replace, next) => {
-    const wrappedNext = (...args) => {
-      if (changeHooks.has(hooks[index])) {
-        next(...args)
-        changeHooks.remove(hooks[index])
-      }
-    }
-    hooks[index](state, nextState, replace, wrappedNext)
-  }, callback)
-}
-
-/**
- * Runs all onLeave hooks in the given array of routes in order.
- */
-export function runLeaveHooks(routes, prevState) {
-  for (let i = 0, len = routes.length; i < len; ++i)
-    if (routes[i].onLeave)
-      routes[i].onLeave.call(routes[i], prevState)
+  return {
+    runEnterHooks,
+    runChangeHooks,
+    runLeaveHooks
+  }
 }

--- a/modules/__tests__/AsyncHooksServer-test.js
+++ b/modules/__tests__/AsyncHooksServer-test.js
@@ -1,0 +1,51 @@
+import expect from 'expect'
+import React from 'react'
+
+import { match, Route } from '../index'
+
+function App(props) {
+  return (
+    <div>
+      {props.children}
+    </div>
+  )
+}
+
+function Test() {
+  return (
+    <div>
+      Test App
+    </div>
+  )
+}
+
+const onEnter = function (nextState, replace, cb) {
+  setTimeout(() => {
+    cb()
+  }, Math.ceil(Math.random() * 800))
+}
+
+const AppRoute = (<Route path="/" component={App} onEnter={onEnter}>
+  <Route path="test" component={Test} />
+</Route>)
+
+
+describe('Test async route hooks on server', () => {
+  it('handles multiple request simultaneously', (done) => {
+    let callCount = 0
+
+    for (let i = 0; i < 100; i++) {
+      match({
+        routes: AppRoute,
+        location: '/'
+      }, () => {
+        callCount += 1
+      })
+    }
+
+    setTimeout (() => {
+      expect(callCount).toEqual(100)
+      done()
+    }, 1900)
+  })
+})

--- a/modules/createTransitionManager.js
+++ b/modules/createTransitionManager.js
@@ -1,6 +1,6 @@
 import warning from './routerWarning'
 import computeChangedRoutes from './computeChangedRoutes'
-import { runEnterHooks, runChangeHooks, runLeaveHooks } from './TransitionUtils'
+import getTransitionUtils from './TransitionUtils'
 import _isActive from './isActive'
 import getComponents from './getComponents'
 import matchRoutes from './matchRoutes'
@@ -15,6 +15,8 @@ function hasAnyProperties(object) {
 
 export default function createTransitionManager(history, routes) {
   let state = {}
+
+  const { runEnterHooks, runChangeHooks, runLeaveHooks } = getTransitionUtils()
 
   // Signature should be (location, indexOnly), but needs to support (path,
   // query, indexOnly)


### PR DESCRIPTION
**Issue:** When having async hooks (onEnter, getComponent) on routes, server side parallel request fails a lot of time.

**Reason:** Because pending hooks of onEnter and onChange are defined globally (https://github.com/ReactTraining/react-router/blob/v3/modules/TransitionUtils.js#L11), it can cause hooks collision between parallel request. And enterHooks.clear() can cause clearing other request hooks. 

**Fix:** Provide a scope for pending hooks instance and utility methods, so for each request hooks are maintained separately.  

Added test case which fails on the current version and passes with the patch on this PR. Let me know if any change required on PR. 