### PR TITLE
[react-router@3] ES6 Classes everywhere. HOC on ContextUtils

### DIFF
--- a/modules/ContextUtilsMixins.js
+++ b/modules/ContextUtilsMixins.js
@@ -1,0 +1,121 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+
+// WARNING: You should no longer use these mixin classes
+// because mixins will no longer work in React 16 without createReactClass.
+// This file is kept here just in case someone relies on any of these internal functions
+
+const contextProviderShape = PropTypes.shape({
+  subscribe: PropTypes.func.isRequired,
+  eventIndex: PropTypes.number.isRequired
+})
+
+function makeContextName(name) {
+  return `@@contextSubscriber/${name}`
+}
+
+export function ContextProvider(name) {
+  const contextName = makeContextName(name)
+  const listenersKey = `${contextName}/listeners`
+  const eventIndexKey = `${contextName}/eventIndex`
+  const subscribeKey = `${contextName}/subscribe`
+
+  return {
+    childContextTypes: {
+      [contextName]: contextProviderShape.isRequired
+    },
+
+    getChildContext() {
+      return {
+        [contextName]: {
+          eventIndex: this[eventIndexKey],
+          subscribe: this[subscribeKey]
+        }
+      }
+    },
+
+    componentWillMount() {
+      this[listenersKey] = []
+      this[eventIndexKey] = 0
+    },
+
+    componentWillReceiveProps() {
+      this[eventIndexKey]++
+    },
+
+    componentDidUpdate() {
+      this[listenersKey].forEach(listener =>
+        listener(this[eventIndexKey])
+      )
+    },
+
+    [subscribeKey](listener) {
+      // No need to immediately call listener here.
+      this[listenersKey].push(listener)
+
+      return () => {
+        this[listenersKey] = this[listenersKey].filter(item =>
+          item !== listener
+        )
+      }
+    }
+  }
+}
+
+export function ContextSubscriber(name) {
+  const contextName = makeContextName(name)
+  const lastRenderedEventIndexKey = `${contextName}/lastRenderedEventIndex`
+  const handleContextUpdateKey = `${contextName}/handleContextUpdate`
+  const unsubscribeKey = `${contextName}/unsubscribe`
+
+  return {
+    contextTypes: {
+      [contextName]: contextProviderShape
+    },
+
+    getInitialState() {
+      if (!this.context[contextName]) {
+        return {}
+      }
+
+      return {
+        [lastRenderedEventIndexKey]: this.context[contextName].eventIndex
+      }
+    },
+
+    componentDidMount() {
+      if (!this.context[contextName]) {
+        return
+      }
+
+      this[unsubscribeKey] = this.context[contextName].subscribe(
+        this[handleContextUpdateKey]
+      )
+    },
+
+    componentWillReceiveProps() {
+      if (!this.context[contextName]) {
+        return
+      }
+
+      this.setState({
+        [lastRenderedEventIndexKey]: this.context[contextName].eventIndex
+      })
+    },
+
+    componentWillUnmount() {
+      if (!this[unsubscribeKey]) {
+        return
+      }
+
+      this[unsubscribeKey]()
+      this[unsubscribeKey] = null
+    },
+
+    [handleContextUpdateKey](eventIndex) {
+      if (eventIndex !== this.state[lastRenderedEventIndexKey]) {
+        this.setState({ [lastRenderedEventIndexKey]: eventIndex })
+      }
+    }
+  }
+}

--- a/modules/IndexLink.js
+++ b/modules/IndexLink.js
@@ -1,17 +1,15 @@
-import React from 'react'
-import createReactClass from 'create-react-class'
+import React, { Component } from 'react'
 import Link from './Link'
 
 /**
  * An <IndexLink> is used to link to an <IndexRoute>.
  */
-const IndexLink = createReactClass({
-  displayName: 'IndexLink',
+class IndexLink extends Component {
+  static displayName = 'IndexLink'
 
   render() {
     return <Link {...this.props} onlyActiveOnIndex={true} />
   }
-
-})
+}
 
 export default IndexLink

--- a/modules/IndexRedirect.js
+++ b/modules/IndexRedirect.js
@@ -1,4 +1,4 @@
-import createReactClass from 'create-react-class'
+import { Component } from 'react'
 import { string, object } from 'prop-types'
 import warning from './routerWarning'
 import invariant from 'invariant'
@@ -9,32 +9,28 @@ import { falsy } from './InternalPropTypes'
  * An <IndexRedirect> is used to redirect from an indexRoute.
  */
 /* eslint-disable react/require-render-return */
-const IndexRedirect = createReactClass({
-  displayName: 'IndexRedirect',
+class IndexRedirect extends Component {
+  static displayName = 'IndexRedirect'
 
-  statics: {
-
-    createRouteFromReactElement(element, parentRoute) {
-      /* istanbul ignore else: sanity check */
-      if (parentRoute) {
-        parentRoute.indexRoute = Redirect.createRouteFromReactElement(element)
-      } else {
-        warning(
-          false,
-          'An <IndexRedirect> does not make sense at the root of your route config'
-        )
-      }
+  static createRouteFromReactElement(element, parentRoute) {
+    /* istanbul ignore else: sanity check */
+    if (parentRoute) {
+      parentRoute.indexRoute = Redirect.createRouteFromReactElement(element)
+    } else {
+      warning(
+        false,
+        'An <IndexRedirect> does not make sense at the root of your route config'
+      )
     }
+  }
 
-  },
-
-  propTypes: {
+  static propTypes = {
     to: string.isRequired,
     query: object,
     state: object,
     onEnter: falsy,
     children: falsy
-  },
+  }
 
   /* istanbul ignore next: sanity check */
   render() {
@@ -43,7 +39,6 @@ const IndexRedirect = createReactClass({
       '<IndexRedirect> elements are for router configuration only and should not be rendered'
     )
   }
-
-})
+}
 
 export default IndexRedirect

--- a/modules/IndexRoute.js
+++ b/modules/IndexRoute.js
@@ -1,4 +1,4 @@
-import createReactClass from 'create-react-class'
+import React, { Component } from 'react';
 import { func } from 'prop-types'
 import warning from './routerWarning'
 import invariant from 'invariant'
@@ -10,32 +10,28 @@ import { component, components, falsy } from './InternalPropTypes'
  * a JSX route config.
  */
 /* eslint-disable react/require-render-return */
-const IndexRoute = createReactClass({
-  displayName: 'IndexRoute',
+class IndexRoute extends Component {
+  static displayName = 'IndexRoute'
 
-  statics: {
-
-    createRouteFromReactElement(element, parentRoute) {
-      /* istanbul ignore else: sanity check */
-      if (parentRoute) {
-        parentRoute.indexRoute = createRouteFromReactElement(element)
-      } else {
-        warning(
-          false,
-          'An <IndexRoute> does not make sense at the root of your route config'
-        )
-      }
+  static createRouteFromReactElement = (element, parentRoute) => {
+    /* istanbul ignore else: sanity check */
+    if (parentRoute) {
+      parentRoute.indexRoute = createRouteFromReactElement(element)
+    } else {
+      warning(
+        false,
+        'An <IndexRoute> does not make sense at the root of your route config'
+      )
     }
+  }
 
-  },
-
-  propTypes: {
+  static propTypes = {
     path: falsy,
     component,
     components,
     getComponent: func,
     getComponents: func
-  },
+  }
 
   /* istanbul ignore next: sanity check */
   render() {
@@ -44,7 +40,6 @@ const IndexRoute = createReactClass({
       '<IndexRoute> elements are for router configuration only and should not be rendered'
     )
   }
-
-})
+}
 
 export default IndexRoute

--- a/modules/Redirect.js
+++ b/modules/Redirect.js
@@ -1,4 +1,4 @@
-import createReactClass from 'create-react-class'
+import React, { Component } from 'react'
 import { string, object } from 'prop-types'
 import invariant from 'invariant'
 import { createRouteFromReactElement } from './RouteUtils'
@@ -13,61 +13,57 @@ import { falsy } from './InternalPropTypes'
  * and are traversed in the same manner.
  */
 /* eslint-disable react/require-render-return */
-const Redirect = createReactClass({
-  displayName: 'Redirect',
+class Redirect extends Component {
+  static displayName = 'Redirect'
 
-  statics: {
+  static createRouteFromReactElement = (element) => {
+    const route = createRouteFromReactElement(element)
 
-    createRouteFromReactElement(element) {
-      const route = createRouteFromReactElement(element)
+    if (route.from)
+      route.path = route.from
 
-      if (route.from)
-        route.path = route.from
+    route.onEnter = function (nextState, replace) {
+      const { location, params } = nextState
 
-      route.onEnter = function (nextState, replace) {
-        const { location, params } = nextState
-
-        let pathname
-        if (route.to.charAt(0) === '/') {
-          pathname = formatPattern(route.to, params)
-        } else if (!route.to) {
-          pathname = location.pathname
-        } else {
-          let routeIndex = nextState.routes.indexOf(route)
-          let parentPattern = Redirect.getRoutePattern(nextState.routes, routeIndex - 1)
-          let pattern = parentPattern.replace(/\/*$/, '/') + route.to
-          pathname = formatPattern(pattern, params)
-        }
-
-        replace({
-          pathname,
-          query: route.query || location.query,
-          state: route.state || location.state
-        })
+      let pathname
+      if (route.to.charAt(0) === '/') {
+        pathname = formatPattern(route.to, params)
+      } else if (!route.to) {
+        pathname = location.pathname
+      } else {
+        let routeIndex = nextState.routes.indexOf(route)
+        let parentPattern = Redirect.getRoutePattern(nextState.routes, routeIndex - 1)
+        let pattern = parentPattern.replace(/\/*$/, '/') + route.to
+        pathname = formatPattern(pattern, params)
       }
 
-      return route
-    },
-
-    getRoutePattern(routes, routeIndex) {
-      let parentPattern = ''
-
-      for (let i = routeIndex; i >= 0; i--) {
-        const route = routes[i]
-        const pattern = route.path || ''
-
-        parentPattern = pattern.replace(/\/*$/, '/') + parentPattern
-
-        if (pattern.indexOf('/') === 0)
-          break
-      }
-
-      return '/' + parentPattern
+      replace({
+        pathname,
+        query: route.query || location.query,
+        state: route.state || location.state
+      })
     }
 
-  },
+    return route
+  }
 
-  propTypes: {
+  static getRoutePattern = (routes, routeIndex) => {
+    let parentPattern = ''
+
+    for (let i = routeIndex; i >= 0; i--) {
+      const route = routes[i]
+      const pattern = route.path || ''
+
+      parentPattern = pattern.replace(/\/*$/, '/') + parentPattern
+
+      if (pattern.indexOf('/') === 0)
+        break
+    }
+
+    return '/' + parentPattern
+  }
+
+  static propTypes = {
     path: string,
     from: string, // Alias for path
     to: string.isRequired,
@@ -75,7 +71,7 @@ const Redirect = createReactClass({
     state: object,
     onEnter: falsy,
     children: falsy
-  },
+  }
 
   /* istanbul ignore next: sanity check */
   render() {
@@ -84,7 +80,6 @@ const Redirect = createReactClass({
       '<Redirect> elements are for router configuration only and should not be rendered'
     )
   }
-
-})
+}
 
 export default Redirect

--- a/modules/Route.js
+++ b/modules/Route.js
@@ -1,4 +1,4 @@
-import createReactClass from 'create-react-class'
+import { Component } from 'react'
 import { string, func } from 'prop-types'
 import invariant from 'invariant'
 import { createRouteFromReactElement } from './RouteUtils'
@@ -15,20 +15,18 @@ import { component, components } from './InternalPropTypes'
  * rendered into the DOM, nested in the same order as in the tree.
  */
 /* eslint-disable react/require-render-return */
-const Route = createReactClass({
-  displayName: 'Route',
+class Route extends Component {
+  static displayName = 'Route'
 
-  statics: {
-    createRouteFromReactElement
-  },
+  static createRouteFromReactElement = createRouteFromReactElement
 
-  propTypes: {
+  static propTypes = {
     path: string,
     component,
     components,
     getComponent: func,
     getComponents: func
-  },
+  }
 
   /* istanbul ignore next: sanity check */
   render() {
@@ -37,7 +35,6 @@ const Route = createReactClass({
       '<Route> elements are for router configuration only and should not be rendered'
     )
   }
-
-})
+}
 
 export default Route

--- a/modules/Router.js
+++ b/modules/Router.js
@@ -1,6 +1,5 @@
 import invariant from 'invariant'
-import React from 'react'
-import createReactClass from 'create-react-class'
+import React, { Component } from 'react'
 import { func, object } from 'prop-types'
 
 import createTransitionManager from './createTransitionManager'
@@ -28,27 +27,30 @@ const propTypes = {
  * a router that renders a <RouterContext> with all the props
  * it needs each time the URL changes.
  */
-const Router = createReactClass({
-  displayName: 'Router',
+class Router extends Component {
+  static displayName = 'Router'
 
-  propTypes,
+  static propTypes = propTypes
 
-  getDefaultProps() {
-    return {
-      render(props) {
-        return <RouterContext {...props} />
-      }
-    }
-  },
+  static defaultProps = {
+    render: (props) => <RouterContext {...props} />
+  }
 
-  getInitialState() {
-    return {
+  constructor(props) {
+    super(props)
+
+    this.state = {
       location: null,
       routes: null,
       params: null,
       components: null
     }
-  },
+
+    // No auto bind in ES6
+    this.handleError             = this.handleError.bind(this);
+    this.createRouterObject      = this.createRouterObject.bind(this)
+    this.createTransitionManager = this.createTransitionManager.bind(this)
+  }
 
   handleError(error) {
     if (this.props.onError) {
@@ -57,7 +59,7 @@ const Router = createReactClass({
       // Throw errors by default so we don't silently swallow them!
       throw error // This error probably occurred in getChildRoutes or getComponents.
     }
-  },
+  }
 
   createRouterObject(state) {
     const { matchContext } = this.props
@@ -67,7 +69,7 @@ const Router = createReactClass({
 
     const { history } = this.props
     return createRouterObject(history, this.transitionManager, state)
-  },
+  }
 
   createTransitionManager() {
     const { matchContext } = this.props
@@ -89,7 +91,7 @@ const Router = createReactClass({
       history,
       createRoutes(routes || children)
     )
-  },
+  }
 
   componentWillMount() {
     this.transitionManager = this.createTransitionManager()
@@ -105,7 +107,7 @@ const Router = createReactClass({
         this.setState(state, this.props.onUpdate)
       }
     })
-  },
+  }
 
   /* istanbul ignore next: sanity check */
   componentWillReceiveProps(nextProps) {
@@ -119,12 +121,12 @@ const Router = createReactClass({
         (this.props.routes || this.props.children),
       'You cannot change <Router routes>; it will be ignored'
     )
-  },
+  }
 
   componentWillUnmount() {
     if (this._unlisten)
       this._unlisten()
-  },
+  }
 
   render() {
     const { location, routes, params, components } = this.state
@@ -147,7 +149,6 @@ const Router = createReactClass({
       createElement
     })
   }
-
-})
+}
 
 export default Router

--- a/modules/RouterContext.js
+++ b/modules/RouterContext.js
@@ -1,49 +1,42 @@
 import invariant from 'invariant'
-import React from 'react'
-import createReactClass from 'create-react-class'
+import React, { Component } from 'react'
 import { array, func, object } from 'prop-types'
 
 import getRouteParams from './getRouteParams'
-import { ContextProvider } from './ContextUtils'
+import { ContextProviderEnhancer } from './ContextUtils'
 import { isReactChildren } from './RouteUtils'
 
 /**
  * A <RouterContext> renders the component tree for a given router state
  * and sets the history object and the current location in context.
  */
-const RouterContext = createReactClass({
-  displayName: 'RouterContext',
-
-  mixins: [ ContextProvider('router') ],
-
-  propTypes: {
+class RouterContext extends Component {
+  static propTypes = {
     router: object.isRequired,
     location: object.isRequired,
     routes: array.isRequired,
     params: object.isRequired,
     components: array.isRequired,
     createElement: func.isRequired
-  },
+  }
 
-  getDefaultProps() {
-    return {
-      createElement: React.createElement
-    }
-  },
-
-  childContextTypes: {
+  static childContextTypes = {
     router: object.isRequired
-  },
+  }
+
+  static defaultProps = {
+    createElement: React.createElement
+  }
 
   getChildContext() {
     return {
       router: this.props.router
     }
-  },
+  }
 
   createElement(component, props) {
     return component == null ? null : this.props.createElement(component, props)
-  },
+  }
 
   render() {
     const { location, routes, params, components, router } = this.props
@@ -101,7 +94,9 @@ const RouterContext = createReactClass({
 
     return element
   }
+}
 
-})
+const EnhancedRouterContext = ContextProviderEnhancer(RouterContext, 'router')
+EnhancedRouterContext.displayName = 'RouterContext';
 
-export default RouterContext
+export default EnhancedRouterContext


### PR DESCRIPTION
Considering React 16 will no longer provide `createReactClass` in the default package I thought it could be useful to have `react-router@3` free of that dependency.

This could reduce the library's footprint (if other libraries starts dropping `createReactClass` too) and possibly allow `react-router@3` to make use of the performance improvements offered by React 16+.

What's in this PR:
* We had mixins in [ContextUtils.js](https://github.com/ReactTraining/react-router/blob/1f18e7abb92dd69141f44f4cd846bf82992db9a8/modules/ContextUtils.js). I converted them to Higher Order Components instead. The mixins are still exported for now, to keep compatibility with anyone who depended on it (but they shouldn't, really).
* I changed the functions which used the mixins and wrapped them around the HOCs.
* Rewrote every createReactClass (except for the tests) to use React.Component