### PR TITLE
Update docs sample code to avoid side effects in render()

### DIFF
--- a/packages/react-router-dom/docs/guides/server-rendering.md
+++ b/packages/react-router-dom/docs/guides/server-rendering.md
@@ -44,15 +44,23 @@ if (context.url) {
 The router only ever adds `context.url`. But you may want some redirects to be 301 and others 302. Or maybe you'd like to send a 404 response if some specific branch of UI is rendered, or a 401 if they aren't authorized. The context prop is yours, so you can mutate it. Here's a way to distinguish between 301 and 302 redirects:
 
 ```js
-const RedirectWithStatus = ({ from, to, status }) => (
-  <Route render={({ staticContext }) => {
-    // there is no `staticContext` on the client, so
-    // we need to guard against that here
-    if (staticContext)
-      staticContext.status = status
+class RedirectWithStatus extends React.Component {
+  static contextTypes = {
+    router: React.PropTypes.shape({
+      staticContext: React.PropTypes.object
+    }).isRequired
+  }
+  componentWillMount () {
+    const { router: { staticContext } } = this.context
+    if (staticContext) {
+      staticContext.status = this.props.code
+    }
+  }
+  render () {
+    const { from, to } = this.props
     return <Redirect from={from} to={to}/>
-  }}/>
-)
+  }
+}
 
 // somewhere in your app
 const App = () => (
@@ -92,13 +100,22 @@ if (context.url) {
 We can do the same thing as above. Create a component that adds some context and render it anywhere in the app to get a different status code.
 
 ```js
-const Status = ({ code, children }) => (
-  <Route render={({ staticContext }) => {
-    if (staticContext)
-      staticContext.status = code
-    return children
-  }}/>
-)
+class Status extends React.Component {
+  static contextTypes = {
+    router: React.PropTypes.shape({
+      staticContext: React.PropTypes.object
+    }).isRequired
+  }
+  componentWillMount () {
+    const { router: { staticContext } } = this.context
+    if (staticContext) {
+      staticContext.status = this.props.code
+    }
+  }
+  render () {
+    return this.props.children
+  }
+}
 ```
 
 Now you can render a `Status` anywhere in the app that you want to add the code to `staticContext`.


### PR DESCRIPTION
Side-effects in `render()` are bad, right?

I noticed that the server-side rendering docs suggest setting the `staticContext` prop the following way:

```
const Status = ({ code, children }) => (
  <Route render={({ staticContext }) => {
    if (staticContext)
      staticContext.status = code
    return children
  }}/>
)
```
(Via https://reacttraining.com/react-router/web/guides/server-rendering/404-401-or-any-other-status)

@gaearon has this to say about side-effects in render:
> In React render() method should not have side effects. Dispatching from render() is wrong.
source: https://twitter.com/dan_abramov/status/693068087613116416

React docs say:
> Keeping render() pure makes components easier to think about.
source: https://facebook.github.io/react/docs/react-component.html#render

I think we can take this opportunity to educate developers (who are likely new to react when learning about this project) to do things the Right Way™.

This is what I suggest instead:

```
class Status extends React.Component {
  static contextTypes = {
    router: React.PropTypes.shape({
      staticContext: React.PropTypes.object
    }).isRequired
  }
  componentWillMount () {
    const { router: { staticContext } } = this.context
    if (staticContext) {
      staticContext.status = this.props.code
    }
  }
  render () {
    return this.props.children
  }
}
```

Sure, it's a little more verbose, but I think the trade-off is worth it.

What do you guys think?