### PR TITLE
Only dispatch initial LOCATION_CHANGE event once per store in ConnectedRouter

### DIFF
--- a/packages/react-router-redux/modules/ConnectedRouter.js
+++ b/packages/react-router-redux/modules/ConnectedRouter.js
@@ -4,6 +4,8 @@ import { Router } from 'react-router'
 
 import { LOCATION_CHANGE } from './reducer'
 
+const STORES = []
+
 class ConnectedRouter extends Component {
   static propTypes = {
     store: PropTypes.object,
@@ -27,7 +29,11 @@ class ConnectedRouter extends Component {
     this.store = propsStore || this.context.store
 
     this.unsubscribeFromHistory = history.listen(this.handleLocationChange)
-    this.handleLocationChange(history.location)
+    let isNewStore = STORES.every(store => this.store !== store)
+    if (isNewStore) {
+      STORES.push(this.store)
+      this.handleLocationChange(history.location)
+    }
   }
 
   componentWillUnmount() {


### PR DESCRIPTION
If you have multiple ConnectedRouter components on a page and those components share a single store each component dispatches a `LOCATION_CHANGE` event when it mounts. Since event properly initializes the routing info a subsequently mounted ConnectedRouter does not need to dispatch an event.

This pull requests tracks references to stores and only dispatches the initial `LOCATION_CHANGE` if it is new.