### PR TITLE
Clarify setRouteLeaveHook() and child routes

### DIFF
--- a/upgrade-guides/v2.4.0.md
+++ b/upgrade-guides/v2.4.0.md
@@ -12,6 +12,8 @@ import { withRouter } from 'react-router'
 
 const Page = React.createClass({
   componentDidMount() {
+    // Note that navigating to child routes won't register as leaving this route. In other words,
+    // navigating to any routes described in this.props.route.childRoutes[] won't trigger the callback.
     this.props.router.setRouteLeaveHook(this.props.route, () => {
       if (this.state.unsaved)
         return 'You have unsaved information, are you sure you want to leave this page?'


### PR DESCRIPTION
I couldn't figure out why the `setRouteLeaveHook()` callback wasn't being called when I navigated to a child route, and in doing some searching, I'm not the only person who had this problem.