### PR TITLE
Updating README to explain how to change route.

### DIFF
--- a/packages/react-router-redux/README.md
+++ b/packages/react-router-redux/README.md
@@ -26,7 +26,7 @@ import React from 'react'
 import ReactDOM from 'react-dom'
 
 import { createStore, combineReducers, applyMiddleware } from 'redux'
-import { Provider } from 'react-redux'
+import { Provider, connect } from 'react-redux'
 
 import createHistory from 'history/createBrowserHistory'
 import { Route } from 'react-router'
@@ -51,11 +51,14 @@ const store = createStore(
   applyMiddleware(middleware)
 )
 
-// Now you can dispatch navigation actions from anywhere!
-// store.dispatch(push('/foo'))
-
-ReactDOM.render(
-  <Provider store={store}>
+/* Now you can dispatch navigation actions from anywhere!
+| store.dispatch(push('/foo'))
+| This will cause changes to:
+| > browser's window.location.href
+| > store.routing.location.[pathname + key]
+| but will not necessarily cause page to re-render */
+const Root = () => (
+ <Provider store={store}>
     { /* ConnectedRouter will use the store from Provider automatically */ }
     <ConnectedRouter history={history}>
       <div>
@@ -64,7 +67,19 @@ ReactDOM.render(
         <Route path="/topics" component={Topics}/>
       </div>
     </ConnectedRouter>
-  </Provider>,
-  document.getElementById('root')
+  </Provider>
+)
+
+const mapStateToProps = (state, ownProps) => {
+   const { routing } = state
+   /* location.pathname changes will cause component To Receive Props.
+   | Therefore... will re-render to the new route.
+   */
+   return { ...ownProps, routing }
+}
+const connectedRoot = connect(mapStateToProps)(Root)
+ReactDOM.render(
+   connectedRoot,
+   document.getElementById('root')
 )
 ```


### PR DESCRIPTION
- [x] Simplifies render to just build one element (which more closely mirrors how it will actually be used: rendering a separate file with the Root/App component).
- [x] Reminds (or explains for the first time) that the component will not naturally look for changes to routing unlike in old versions of react-router-redux... it has to be explicitly mapped in.
- [x] Prevents the next person from wondering what's going on when on Refresh of page it works in displaying the correct page,