### PR TITLE
TransitionGroup has moved into another package

### DIFF
--- a/packages/react-router-website/modules/examples/Animation.js
+++ b/packages/react-router-website/modules/examples/Animation.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import ReactCSSTransitionGroup from 'react-transition-group/CSSTransitionGroup'
+import { CSSTransitionGroup } from 'react-transition-group'
 import {
   BrowserRouter as Router,
   Route,
@@ -35,13 +35,13 @@ const AnimationExample = () => (
         </ul>
 
         <div style={styles.content}>
-          <ReactCSSTransitionGroup
+          <CSSTransitionGroup
             transitionName="fade"
             transitionEnterTimeout={300}
             transitionLeaveTimeout={300}
           >
             {/* no different than other usage of
-                ReactCSSTransitionGroup, just make
+                CSSTransitionGroup, just make
                 sure to pass `location` to `Route`
                 so it can match the old location
                 as it animates out
@@ -52,7 +52,7 @@ const AnimationExample = () => (
               path="/:h/:s/:l"
               component={HSL}
             />
-          </ReactCSSTransitionGroup>
+          </CSSTransitionGroup>
         </div>
       </div>
     )}/>

--- a/packages/react-router-website/modules/examples/Animation.js
+++ b/packages/react-router-website/modules/examples/Animation.js
@@ -41,7 +41,7 @@ const AnimationExample = () => (
             transitionLeaveTimeout={300}
           >
             {/* no different than other usage of
-                CSSTransitionGroup, just make
+                ReactCSSTransitionGroup, just make
                 sure to pass `location` to `Route`
                 so it can match the old location
                 as it animates out

--- a/packages/react-router-website/modules/examples/Animation.js
+++ b/packages/react-router-website/modules/examples/Animation.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import ReactCSSTransitionGroup from 'react-addons-css-transition-group'
+import CSSTransitionGroup from 'react-transition-group/CSSTransitionGroup'
 import {
   BrowserRouter as Router,
   Route,
@@ -35,13 +35,13 @@ const AnimationExample = () => (
         </ul>
 
         <div style={styles.content}>
-          <ReactCSSTransitionGroup
+          <CSSTransitionGroup
             transitionName="fade"
             transitionEnterTimeout={300}
             transitionLeaveTimeout={300}
           >
             {/* no different than other usage of
-                ReactCSSTransitionGroup, just make
+                CSSTransitionGroup, just make
                 sure to pass `location` to `Route`
                 so it can match the old location
                 as it animates out
@@ -52,7 +52,7 @@ const AnimationExample = () => (
               path="/:h/:s/:l"
               component={HSL}
             />
-          </ReactCSSTransitionGroup>
+          </CSSTransitionGroup>
         </div>
       </div>
     )}/>

--- a/packages/react-router-website/modules/examples/Animation.js
+++ b/packages/react-router-website/modules/examples/Animation.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import CSSTransitionGroup from 'react-transition-group/CSSTransitionGroup'
+import ReactCSSTransitionGroup from 'react-transition-group/CSSTransitionGroup'
 import {
   BrowserRouter as Router,
   Route,
@@ -35,7 +35,7 @@ const AnimationExample = () => (
         </ul>
 
         <div style={styles.content}>
-          <CSSTransitionGroup
+          <ReactCSSTransitionGroup
             transitionName="fade"
             transitionEnterTimeout={300}
             transitionLeaveTimeout={300}
@@ -52,7 +52,7 @@ const AnimationExample = () => (
               path="/:h/:s/:l"
               component={HSL}
             />
-          </CSSTransitionGroup>
+          </ReactCSSTransitionGroup>
         </div>
       </div>
     )}/>

--- a/packages/react-router-website/package.json
+++ b/packages/react-router-website/package.json
@@ -31,7 +31,6 @@
     "prismjs-loader": "0.0.3",
     "prop-types": "^15.5.4",
     "react": "^15.4.0",
-    "react-addons-css-transition-group": "^15.4.2",
     "react-dom": "^15.4.0",
     "react-motion": "^0.4.4",
     "react-router-dom": "^4.1.1",
@@ -47,6 +46,7 @@
     "cheerio": "^0.22.0",
     "react-icons": "^2.2.3",
     "react-media": "^1.5.1",
+    "react-transition-group": "^1.1.2",
     "resolve-pathname": "^2.0.2",
     "slug": "^0.9.1"
   }


### PR DESCRIPTION
This PR updates the website example to use the new package.
The old one will stop working with React 16.