### PR TITLE
Added note on use of withRouter in Scroll Restoration doc

### DIFF
--- a/packages/react-router-dom/docs/guides/scroll-restoration.md
+++ b/packages/react-router-dom/docs/guides/scroll-restoration.md
@@ -8,7 +8,7 @@ Because browsers are starting to handle the "default case" and apps have varying
 
 ## Scroll to top
 
-Most of the time all you need is to "scroll to the top" because you have a long content page, that when navigated to, stays scrolled down. This is straightforward to handle with a `<ScrollToTop>` component that will scroll the window up on every navigation:
+Most of the time all you need is to "scroll to the top" because you have a long content page, that when navigated to, stays scrolled down. This is straightforward to handle with a `<ScrollToTop>` component that will scroll the window up on every navigation, make sure to wrap it in `withRouter` to give it access to the router's props:
 
 ```jsx
 class ScrollToTop extends Component {


### PR DESCRIPTION
Added a note in the docs to make it clearer that the `<ScrollToTop />` component needs to be wrapped in `withRouter`.

#5031