### PR TITLE
add externals config for prop-types?

### DIFF
--- a/packages/react-router-dom/webpack.config.js
+++ b/packages/react-router-dom/webpack.config.js
@@ -12,6 +12,12 @@ module.exports = {
       commonjs2: 'react',
       commonjs: 'react',
       amd: 'react'
+    },
+    'prop-types': {
+      root: 'PropTypes',
+      commonjs2: 'prop-types',
+      commonjs: 'prop-types',
+      amd: 'prop-types'
     }
   },
 

--- a/packages/react-router/webpack.config.js
+++ b/packages/react-router/webpack.config.js
@@ -12,6 +12,12 @@ module.exports = {
       commonjs2: 'react',
       commonjs: 'react',
       amd: 'react'
+    },
+    'prop-types': {
+      root: 'PropTypes',
+      commonjs2: 'prop-types',
+      commonjs: 'prop-types',
+      amd: 'prop-types'
     }
   },
 


### PR DESCRIPTION
I think that you shouldn't package `prop-types` in the UMD modules.