### PR TITLE
switch to new api

### DIFF
--- a/packages/react-router-native/experimental/StackRoute.js
+++ b/packages/react-router-native/experimental/StackRoute.js
@@ -394,12 +394,12 @@ class StackRootContainer extends Component {
   handlePanBack = () => {
     if (this.state.parentLocation) {
       this.panCancelLocation = this.props.location
-      this.context.router.replace(this.state.parentLocation)
+      this.context.router.history.replace(this.state.parentLocation)
     }
   }
 
   handlePanCancel = () => {
-    this.context.router.replace(this.panCancelLocation)
+    this.context.router.history.replace(this.panCancelLocation)
   }
 
   render() {


### PR DESCRIPTION
This PR changes old route.replace to route.history.replace. Fixes pan control errors.