### PR TITLE
Make the Docs link stand out a little bit more

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@
 
 ## Docs
 
-[View the docs here](https://reacttraining.com/react-router)
+**[View the docs here](https://reacttraining.com/react-router)**
 
 [Migrating from 2.x/3.x?](/packages/react-router/docs/guides/migrating.md)
 


### PR DESCRIPTION
My eye was drawn to the individual packages, then I had to come back to this page before realising this link was the primary documentation link.