### PR TITLE
[docs] Fix typo in code-splitting example

### DIFF
--- a/packages/react-router-dom/docs/guides/code-splitting.md
+++ b/packages/react-router-dom/docs/guides/code-splitting.md
@@ -19,7 +19,7 @@ If the module is a component, we can render it right there:
 
 ```jsx
 <Bundle load={loadSomething}>
-  {(Comp) => Comp
+  {(Comp) => (Comp
     ? <Comp/>
     : <Loading/>
   )}


### PR DESCRIPTION
Add missing opening parenthesis