### PR TITLE
Change BackAndroid to BackHandler

### DIFF
--- a/packages/react-router-native/AndroidBackButton.js
+++ b/packages/react-router-native/AndroidBackButton.js
@@ -1,6 +1,6 @@
 import React, { Component } from 'react'
 import PropTypes from 'prop-types'
-import { BackAndroid } from 'react-native'
+import { BackHandler } from 'react-native'
 
 class AndroidBackButton extends Component {
   static contextTypes = {
@@ -13,11 +13,11 @@ class AndroidBackButton extends Component {
   }
 
   componentDidMount() {
-    BackAndroid.addEventListener('hardwareBackPress', this.handleBack)
+    BackHandler.addEventListener('hardwareBackPress', this.handleBack)
   }
 
   componentWillUnmount() {
-    BackAndroid.removeEventListener('hardwareBackPress', this.handleBack)
+    BackHandler.removeEventListener('hardwareBackPress', this.handleBack)
   }
 
   handleBack = () => {

--- a/packages/react-router-native/package.json
+++ b/packages/react-router-native/package.json
@@ -16,7 +16,7 @@
   ],
   "peerDependencies": {
     "react": "^15",
-    "react-native": ">=0.40"
+    "react-native": ">=0.44"
   },
   "dependencies": {
     "prop-types": "^15.5.4",


### PR DESCRIPTION
As of React Native 0.44 the BackAndroid API is deprecated in favor of BackHandler.