### PR TITLE
NavLink className update

### DIFF
--- a/packages/react-router-dom/modules/NavLink.js
+++ b/packages/react-router-dom/modules/NavLink.js
@@ -29,7 +29,7 @@ const NavLink = ({
       return (
         <Link
           to={to}
-          className={isActive ? [ activeClassName, className ].filter(i => i).join(' ') : className}
+          className={isActive ? [ className, activeClassName ].filter(i => i).join(' ') : className}
           style={isActive ? { ...style, ...activeStyle } : style}
           {...rest}
         />


### PR DESCRIPTION
* append `activeClassName` at end of class attribute ( only for aesthetic purpose  )
* css tip: active-class should be declared after default-class ( css specificity )