### PR TITLE
NavLink should render child components wrapped by withRouter #5141

### DIFF
--- a/packages/react-router-dom/modules/__tests__/NavLink-test.js
+++ b/packages/react-router-dom/modules/__tests__/NavLink-test.js
@@ -3,6 +3,7 @@ import React from 'react'
 import ReactDOM from 'react-dom'
 import MemoryRouter from 'react-router/MemoryRouter'
 import NavLink from '../NavLink'
+import withRouter from '../withRouter'
 
 describe('NavLink', () => {
   const node = document.createElement('div')
@@ -20,6 +21,24 @@ describe('NavLink', () => {
       ), node)
       const a = node.getElementsByTagName('a')[0]
       expect(a.className).toEqual('active')
+    })
+
+    it('renders child components that use withRouter', () => {
+      class WrappedComponent extends React.Component {
+        render() {
+          return null
+        }
+      }
+      const Component = withRouter(WrappedComponent)
+
+      let ref
+      ReactDOM.render((
+        <MemoryRouter initialEntries={['/pizza']}>
+          <NavLink to='/pizza'><Component wrappedComponentRef={r => ref = r} /></NavLink>
+        </MemoryRouter>
+      ), node)
+
+      expect(ref).toBeA(WrappedComponent)
     })
 
     it('applies its passed activeClassName', () => {
@@ -61,6 +80,24 @@ describe('NavLink', () => {
       ), node)
       const a = node.getElementsByTagName('a')[0]
       expect(a.className).toNotContain('active')
+    })
+
+    it('renders child components that use withRouter', () => {
+      class WrappedComponent extends React.Component {
+        render() {
+          return null
+        }
+      }
+      const Component = withRouter(WrappedComponent)
+
+      let ref
+      ReactDOM.render((
+        <MemoryRouter initialEntries={['/pizza']}>
+          <NavLink exact to="/salad"><Component wrappedComponentRef={r => ref = r} /></NavLink>
+        </MemoryRouter>
+      ), node)
+
+      expect(ref).toBeA(WrappedComponent)
     })
 
     it('does not apply its passed activeClassName', () => {
@@ -272,7 +309,7 @@ describe('NavLink', () => {
       const a = node.getElementsByTagName('a')[0]
       expect(a.className).toNotContain('active').toContain('selected')
     })
-    
+
     it('is not overwritten by the current location', () => {
       ReactDOM.render((
         <MemoryRouter initialEntries={['/pasta']}>

--- a/packages/react-router/modules/withRouter.js
+++ b/packages/react-router/modules/withRouter.js
@@ -10,7 +10,7 @@ const withRouter = (Component) => {
   const C = (props) => {
     const { wrappedComponentRef, ...remainingProps } = props
     return (
-      <Route render={routeComponentProps => (
+      <Route children={routeComponentProps => (
         <Component {...remainingProps} {...routeComponentProps} ref={wrappedComponentRef}/>
       )}/>
     )


### PR DESCRIPTION
- Created failing test for `NavLink` - as per #5141 and https://codepen.io/penx/pen/jmeEXz
- Fixed issue #5141 - `NavLink` should render child components that are wrapped by `withRouter`