### PR TITLE
Redirect on props update (#5003)

### DIFF
--- a/packages/react-router/modules/Redirect.js
+++ b/packages/react-router/modules/Redirect.js
@@ -2,7 +2,7 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import warning from 'warning'
 import invariant from 'invariant'
-import { locationsAreEqual } from 'history'
+import { createLocation, locationsAreEqual } from 'history'
 
 /**
  * The public API for updating the location programmatically
@@ -52,19 +52,14 @@ class Redirect extends React.Component {
   }
 
   componentDidUpdate(prevProps) {
-    let prevTo = prevProps.to
-    let nextTo = this.props.to
+    const prevTo = createLocation(prevProps.to)
+    const nextTo = createLocation(this.props.to)
 
-    prevTo = typeof prevTo === 'string' ? { pathname: prevTo } : prevTo
-    nextTo = typeof nextTo === 'string' ? { pathname: nextTo } : nextTo
-
-    if (locationsAreEqual(prevTo, nextTo))
-      return warning(
-        false,
-        `You tried to redirect to the same route you're currently on: "%s%s"`,
-        nextTo.pathname,
-        nextTo.search || ''
-      )
+    if (locationsAreEqual(prevTo, nextTo)) {
+      warning(false, `You tried to redirect to the same route you're currently on: ` +
+        `"${nextTo.pathname}${nextTo.search}"`)
+      return
+    }
 
     this.perform()
   }

--- a/packages/react-router/modules/Redirect.js
+++ b/packages/react-router/modules/Redirect.js
@@ -1,9 +1,11 @@
 import React from 'react'
 import PropTypes from 'prop-types'
+import warning from 'warning'
 import invariant from 'invariant'
+import { locationsAreEqual } from 'history'
 
 /**
- * The public API for updating the location programatically
+ * The public API for updating the location programmatically
  * with a component.
  */
 class Redirect extends React.Component {
@@ -13,7 +15,7 @@ class Redirect extends React.Component {
     to: PropTypes.oneOfType([
       PropTypes.string,
       PropTypes.object
-    ])
+    ]).isRequired
   }
 
   static defaultProps = {
@@ -47,6 +49,24 @@ class Redirect extends React.Component {
   componentDidMount() {
     if (!this.isStatic())
       this.perform()
+  }
+
+  componentDidUpdate(prevProps) {
+    let prevTo = prevProps.to
+    let nextTo = this.props.to
+
+    prevTo = typeof prevTo === 'string' ? { pathname: prevTo } : prevTo
+    nextTo = typeof nextTo === 'string' ? { pathname: nextTo } : nextTo
+
+    if (locationsAreEqual(prevTo, nextTo))
+      return warning(
+        false,
+        `You tried to redirect to the same route you're currently on: "%s%s"`,
+        nextTo.pathname,
+        nextTo.search || ''
+      )
+
+    this.perform()
   }
 
   perform() {

--- a/packages/react-router/modules/__tests__/Switch-test.js
+++ b/packages/react-router/modules/__tests__/Switch-test.js
@@ -122,6 +122,7 @@ describe('A <Switch>', () => {
   it('warns when redirecting to same route, both strings', () => {
     const node = document.createElement('div')
     let redirected = false
+    let done = false
 
     spyOn(console, 'error')
 
@@ -129,9 +130,13 @@ describe('A <Switch>', () => {
       <MemoryRouter initialEntries={[ '/one' ]}>
         <Switch>
           <Route path="/one" render={() => {
+            if (done)
+              return <h1>done</h1>
+
             if (!redirected) {
               return <Redirect to="/one"/>
             }
+            done = true
 
             return <Redirect to='/one'/>
           }}/>
@@ -139,6 +144,7 @@ describe('A <Switch>', () => {
       </MemoryRouter>
     ), node)
 
+    expect(node.innerHTML).not.toContain('done')
     expect(console.error.calls.count()).toBe(1)
     expect(console.error.calls.argsFor(0)[0]).toMatch(/Warning:.*"\/one"/)
   })
@@ -146,6 +152,7 @@ describe('A <Switch>', () => {
   it('warns when redirecting to same route, mixed types', () => {
     const node = document.createElement('div')
     let redirected = false
+    let done = false
 
     spyOn(console, 'error')
 
@@ -153,19 +160,55 @@ describe('A <Switch>', () => {
       <MemoryRouter initialEntries={[ '/one' ]}>
         <Switch>
           <Route path="/one" render={() => {
+            if (done)
+              return <h1>done</h1>
+
             if (!redirected) {
               redirected = true
               return <Redirect to="/one"/>
             }
+            done = true
 
-            return <Redirect to={{pathname: '/one'}}/>
+            return <Redirect to={{ pathname: '/one' }}/>
           }}/>
         </Switch>
       </MemoryRouter>
     ), node)
 
+    expect(node.innerHTML).not.toContain('done')
     expect(console.error.calls.count()).toBe(1)
     expect(console.error.calls.argsFor(0)[0]).toMatch(/Warning:.*"\/one"/)
+  })
+
+  it('warns when redirecting to same route, mixed types, string with query', () => {
+    const node = document.createElement('div')
+    let redirected = false
+    let done = false
+
+    spyOn(console, 'error')
+
+    ReactDOM.render((
+      <MemoryRouter initialEntries={[ '/one' ]}>
+        <Switch>
+          <Route path="/one" render={() => {
+            if (done)
+              return <h1>done</h1>
+
+            if (!redirected) {
+              redirected = true
+              return <Redirect to="/one?utm=1"/>
+            }
+            done = true
+
+            return <Redirect to={{ pathname: '/one', search: '?utm=1' }}/>
+          }}/>
+        </Switch>
+      </MemoryRouter>
+    ), node)
+
+    expect(node.innerHTML).not.toContain('done')
+    expect(console.error.calls.count()).toBe(1)
+    expect(console.error.calls.argsFor(0)[0]).toMatch(/Warning:.*"\/one\?utm=1"/)
   })
 
   it('does NOT warn when redirecting to same route with different `search`', () => {
@@ -184,12 +227,11 @@ describe('A <Switch>', () => {
 
             if (!redirected) {
               redirected = true
-              return <Redirect to={{pathname: '/one', search: '?utm=1'}}/>
+              return <Redirect to={{ pathname: '/one', search: '?utm=1' }}/>
             }
-
             done = true
 
-            return <Redirect to={{pathname: '/one', search: '?utm=2'}}/>
+            return <Redirect to={{ pathname: '/one', search: '?utm=2' }}/>
           }}/>
         </Switch>
       </MemoryRouter>

--- a/packages/react-router/modules/__tests__/Switch-test.js
+++ b/packages/react-router/modules/__tests__/Switch-test.js
@@ -123,7 +123,7 @@ describe('A <Switch>', () => {
     const node = document.createElement('div')
     let redirected = false
 
-    expect.spyOn(console, 'error')
+    spyOn(console, 'error')
 
     ReactDOM.render((
       <MemoryRouter initialEntries={[ '/one' ]}>
@@ -139,16 +139,15 @@ describe('A <Switch>', () => {
       </MemoryRouter>
     ), node)
 
-    expect(console.error.calls.length).toBe(1)
-    expect(console.error.calls[0].arguments[0]).toMatch(/Warning:.*"\/one"/)
-    expect.restoreSpies()
+    expect(console.error.calls.count()).toBe(1)
+    expect(console.error.calls.argsFor(0)[0]).toMatch(/Warning:.*"\/one"/)
   })
 
   it('warns when redirecting to same route, mixed types', () => {
     const node = document.createElement('div')
     let redirected = false
 
-    expect.spyOn(console, 'error')
+    spyOn(console, 'error')
 
     ReactDOM.render((
       <MemoryRouter initialEntries={[ '/one' ]}>
@@ -165,9 +164,8 @@ describe('A <Switch>', () => {
       </MemoryRouter>
     ), node)
 
-    expect(console.error.calls.length).toBe(1)
-    expect(console.error.calls[0].arguments[0]).toMatch(/Warning:.*"\/one"/)
-    expect.restoreSpies()
+    expect(console.error.calls.count()).toBe(1)
+    expect(console.error.calls.argsFor(0)[0]).toMatch(/Warning:.*"\/one"/)
   })
 
   it('does NOT warn when redirecting to same route with different `search`', () => {
@@ -175,7 +173,7 @@ describe('A <Switch>', () => {
     let redirected = false
     let done = false
 
-    expect.spyOn(console, 'error')
+    spyOn(console, 'error')
 
     ReactDOM.render((
       <MemoryRouter initialEntries={[ '/one' ]}>
@@ -198,8 +196,7 @@ describe('A <Switch>', () => {
     ), node)
 
     expect(node.innerHTML).toContain('done')
-    expect(console.error.calls.length).toBe(0)
-    expect.restoreSpies()
+    expect(console.error.calls.count()).toBe(0)
   })
 
   it('handles comments', () => {

--- a/packages/react-router/modules/__tests__/Switch-test.js
+++ b/packages/react-router/modules/__tests__/Switch-test.js
@@ -102,6 +102,106 @@ describe('A <Switch>', () => {
     expect(node.innerHTML).toContain('bub')
   })
 
+  it('handles subsequent redirects', () => {
+    const node = document.createElement('div')
+
+    ReactDOM.render((
+      <MemoryRouter initialEntries={[ '/one' ]}>
+        <Switch>
+          <Redirect exact from="/one" to="/two"/>
+          <Redirect exact from="/two" to="/three"/>
+
+          <Route path="/three" render={() => <div>three</div>}/>
+        </Switch>
+      </MemoryRouter>
+    ), node)
+
+    expect(node.innerHTML).toContain('three')
+  })
+
+  it('warns when redirecting to same route, both strings', () => {
+    const node = document.createElement('div')
+    let redirected = false
+
+    expect.spyOn(console, 'error')
+
+    ReactDOM.render((
+      <MemoryRouter initialEntries={[ '/one' ]}>
+        <Switch>
+          <Route path="/one" render={() => {
+            if (!redirected) {
+              return <Redirect to="/one"/>
+            }
+
+            return <Redirect to='/one'/>
+          }}/>
+        </Switch>
+      </MemoryRouter>
+    ), node)
+
+    expect(console.error.calls.length).toBe(1)
+    expect(console.error.calls[0].arguments[0]).toMatch(/Warning:.*"\/one"/)
+    expect.restoreSpies()
+  })
+
+  it('warns when redirecting to same route, mixed types', () => {
+    const node = document.createElement('div')
+    let redirected = false
+
+    expect.spyOn(console, 'error')
+
+    ReactDOM.render((
+      <MemoryRouter initialEntries={[ '/one' ]}>
+        <Switch>
+          <Route path="/one" render={() => {
+            if (!redirected) {
+              redirected = true
+              return <Redirect to="/one"/>
+            }
+
+            return <Redirect to={{pathname: '/one'}}/>
+          }}/>
+        </Switch>
+      </MemoryRouter>
+    ), node)
+
+    expect(console.error.calls.length).toBe(1)
+    expect(console.error.calls[0].arguments[0]).toMatch(/Warning:.*"\/one"/)
+    expect.restoreSpies()
+  })
+
+  it('does NOT warn when redirecting to same route with different `search`', () => {
+    const node = document.createElement('div')
+    let redirected = false
+    let done = false
+
+    expect.spyOn(console, 'error')
+
+    ReactDOM.render((
+      <MemoryRouter initialEntries={[ '/one' ]}>
+        <Switch>
+          <Route path="/one" render={() => {
+            if (done)
+              return <h1>done</h1>
+
+            if (!redirected) {
+              redirected = true
+              return <Redirect to={{pathname: '/one', search: '?utm=1'}}/>
+            }
+
+            done = true
+
+            return <Redirect to={{pathname: '/one', search: '?utm=2'}}/>
+          }}/>
+        </Switch>
+      </MemoryRouter>
+    ), node)
+
+    expect(node.innerHTML).toContain('done')
+    expect(console.error.calls.length).toBe(0)
+    expect.restoreSpies()
+  })
+
   it('handles comments', () => {
     const node = document.createElement('div')
 


### PR DESCRIPTION
Fixes https://github.com/ReactTraining/react-router/issues/5003

~~Is it ok I've added `is-equal` dependency? It's used by `expect` already.~~

I needed it because checking if we are redirecting to the same route is not so trivial.  
`to` can be a String or an Object, and the Object variant can have `pathname`, `search` and `state`, each of which could be a valid new route to redirect to.

e.g. I might want to redirect to my own route with a different `search` string or `state` data.

### Other PR Questions:

- I'd really like the warning to be better, telling the user where that last <Redirect> originated or something that will help him realize where the issue is, any ideas?
- How do I test if the usage of `warning`?  
  In this case if we try to redirect to the same route we call `warning` to notify the user.