### PR TITLE
fix typo in loadDashboard #5179

### DIFF
--- a/packages/react-router-dom/docs/guides/code-splitting.md
+++ b/packages/react-router-dom/docs/guides/code-splitting.md
@@ -110,7 +110,7 @@ class App extends React.Component {
   componentDidMount() {
     // preloads the rest
     loadAbout(() => {})
-    loadDashbaord(() => {})
+    loadDashboard(() => {})
   }
 
   render() {


### PR DESCRIPTION
Fixes "loadDashboard" typo in code snippet for `react-router/web/guides/code-splitting` #5179