### PR TITLE
Add example for StaticRouter (sync from DefinitelyTyped)

### DIFF
--- a/packages/react-router-website/modules/docs/Web.js
+++ b/packages/react-router-website/modules/docs/Web.js
@@ -89,6 +89,11 @@ export default {
       slug: 'modal-gallery',
       load: require('bundle?lazy!babel!../examples/ModalGallery'),
       loadSource: require('bundle?lazy!!prismjs?lang=jsx!../examples/ModalGallery.js')
+    },
+    { label: 'StaticRouter Context',
+      slug: 'static-router',
+      load: require('bundle?lazy!babel!../examples/StaticRouter'),
+      loadSource: require('bundle?lazy!!prismjs?lang=jsx!../examples/StaticRouter.js')
     }
   ]
 }

--- a/packages/react-router-website/modules/examples/StaticRouter.js
+++ b/packages/react-router-website/modules/examples/StaticRouter.js
@@ -1,9 +1,34 @@
 import * as React from 'react'
 import { StaticRouter, Route } from 'react-router-dom'
 
+// This example renders a route within a StaticRouter and populates its staticContext,
+// which it then prints out.
+// In the real world you would use the StaticRouter for server-side rendering:
+//
+// import * as express from 'express'
+// import { renderToString } from 'react-dom/server'
+//
+// const app = express()
+//
+// app.get('*', (req, res) => {
+//     const staticContext = {}
+//
+//     const html = renderToString(
+//         <StaticRouter location={req.url} context={staticContext}>
+//             <App /> (includes the RouteStatus component below e.g. for 404 errors)
+//         </StaticRouter>
+//     )
+//
+//     res.status(staticContext.statusCode || 200).send(html)
+// })
+//
+// app.listen(process.env.PORT || 3000)
+
 const RouteStatus = (props) => (
     <Route
         render={({ staticContext }) => {
+            // we have to check if staticContext exists
+            // because it will be undefined if rendered through a BrowserRouter
             if (staticContext) {
                 staticContext.statusCode = props.statusCode
             }
@@ -24,6 +49,10 @@ const PrintContext = (props) => (
 )
 
 class StaticRouterExample extends React.Component {
+
+    // This is the context object that we pass to the StaticRouter.
+    // It can be modified by routes to provide additional information
+    // for the server-side render
     staticContext = {};
 
     render() {

--- a/packages/react-router-website/modules/examples/StaticRouter.js
+++ b/packages/react-router-website/modules/examples/StaticRouter.js
@@ -1,0 +1,43 @@
+import * as React from 'react'
+import { StaticRouter, Route } from 'react-router-dom'
+
+const RouteStatus = (props) => (
+    <Route
+        render={({ staticContext }) => {
+            if (staticContext) {
+                staticContext.statusCode = props.statusCode
+            }
+
+            return (
+                <div>
+                    {props.children}
+                </div>
+            )
+        }}
+    />
+)
+
+const PrintContext = (props) => (
+    <p>
+        Static context: {JSON.stringify(props.staticContext)}
+    </p>
+)
+
+class StaticRouterExample extends React.Component {
+    staticContext = {};
+
+    render() {
+        return (
+            <StaticRouter location="/foo" context={this.staticContext}>
+                <div>
+                    <RouteStatus statusCode={404}>
+                        <p>Route with statusCode 404</p>
+                        <PrintContext staticContext={this.staticContext} />
+                    </RouteStatus>
+                </div>
+            </StaticRouter>
+        )
+    }
+}
+
+export default StaticRouterExample


### PR DESCRIPTION
This is the JS port of the example added to the TypeScript definitions for StaticRouter and staticContext in https://github.com/DefinitelyTyped/DefinitelyTyped/pull/16812 as requested by @tkrotoff 