### PR TITLE
Make header links work on site & github

### DIFF
--- a/packages/react-router-website/webpack/markdown-loader.js
+++ b/packages/react-router-website/webpack/markdown-loader.js
@@ -46,7 +46,7 @@ const extractHeaders = ($, level, type) => (
     const text = $e.text()
     return {
       text: text,
-      slug: type === 'api'
+      slug: type === 'api' && level === 'h1'
         ? slugify(text)
         : slugify(text).toLowerCase()
     }
@@ -131,7 +131,7 @@ const makeHeaderLinks = ($, moduleSlug, environment, type) => {
   $('h2').each((i, e) => {
     const $e = $(e)
     const rawSlug = slugify($e.text())
-    const slug = type === 'api' ? rawSlug : rawSlug.toLowerCase()
+    const slug = rawSlug.toLowerCase()
     $e.attr('id', `${moduleSlug}-${slug}`)
     const children = $e.html()
     const link = $(`<a href="/${environment}/${type}/${moduleSlug}/${slug}" class="${routerDelegationClassName}"/>`)


### PR DESCRIPTION
This PR makes it so that all subsection headers (a `##` that creates an `<h2>`) use lowercase letters. There is a little bit of discussion about this in #5197, but I'll explain everything below.

The way that GitHub adds `id`s to headers [converts all of the letters to lowercase](https://github.com/jch/html-pipeline/blob/master/lib/html/pipeline/toc_filter.rb#L39). The current way that the React Router website adds `id`s to headers is to convert to lowercase unless the header is from the `api` section, in which case it preserves the case for all letters.

For example, on GitHub, the documentation for the section on a `<Route>`'s render methods has the id [`route-render-methods`](https://github.com/ReactTraining/react-router/blob/v4.1.1/packages/react-router/docs/api/Route.md#route-render-methods). However, on the website, it has the id [`Route-render-methods`](https://reacttraining.com/react-router/core/api/Route/Route-render-methods).

For `href`s generated by the `react-router-website`'s `markdown-loader`, there is no issue with this case discrepancy.  The problem occurs when there is an existing link within one of the markdown files. If these links are in all lowercase, they will work on GitHub but fail on the React Router website, and vice versa.

I've avoided the main headers (`#`/`<h1>`) because I don't think that we need to worry about them (we can just link to the whole markdown file instead of the header). I think that there is a separate issue there (try clicking the `<Router>` link in the first sentence of the [`<MemoryRouter>` documentation](https://reacttraining.com/react-router/core/api/StaticRouter)), but that can be handled in a different PR.