### PR TITLE
Added Redirect with parameters

### DIFF
--- a/packages/react-router/docs/api/Redirect.md
+++ b/packages/react-router/docs/api/Redirect.md
@@ -16,7 +16,8 @@ import { Route, Redirect } from 'react-router'
 
 ## to: string
 
-The URL to redirect to.
+The URL to redirect to. Any valid URL path that [`path-to-regexp`](https://www.npmjs.com/package/path-to-regexp) understands.
+All URL parameters that are used in `to` must be covered by `from`.
 
 ```js
 <Redirect to="/somewhere/else"/>
@@ -24,7 +25,7 @@ The URL to redirect to.
 
 ## to: object
 
-A location to redirect to.
+A location to redirect to. `pathname` can be any valid URL path that [`path-to-regexp`](https://www.npmjs.com/package/path-to-regexp) understands.
 
 ```js
 <Redirect to={{
@@ -44,11 +45,22 @@ When `true`, redirecting will push a new entry onto the history instead of repla
 
 ## from: string
 
-A pathname to redirect from. This can only be used to match a location when rendering a `<Redirect>` inside of a `<Switch>`. See [`<Switch children>`](./Switch.md#children-node) for more details.
+A pathname to redirect from. Any valid URL path that [`path-to-regexp`](https://www.npmjs.com/package/path-to-regexp) understands.
+All matched URL parameters are provided to the pattern in `to`. Must contain all parameters that are used in `to`. Additional parameters not used by `to` are ignored. 
+
+This can only be used to match a location when rendering a `<Redirect>` inside of a `<Switch>`. See [`<Switch children>`](./Switch.md#children-node) for more details.
 
 ```js
 <Switch>
   <Redirect from='/old-path' to='/new-path'/>
   <Route path='/new-path' component={Place}/>
+</Switch>
+```
+
+```js
+// Redirect with matched parameters
+<Switch>
+  <Redirect from='/users/:id' to='/users/profile/:id'/>
+  <Route path='/users/profile/:id' component={Profile}/>
 </Switch>
 ```

--- a/packages/react-router/modules/Redirect.js
+++ b/packages/react-router/modules/Redirect.js
@@ -1,5 +1,6 @@
 import React from 'react'
 import PropTypes from 'prop-types'
+import generatePath from './generatePath'
 
 /**
  * The public API for updating the location programatically
@@ -7,6 +8,7 @@ import PropTypes from 'prop-types'
  */
 class Redirect extends React.Component {
   static propTypes = {
+    computedMatch: PropTypes.object, // private, from <Switch>
     push: PropTypes.bool,
     from: PropTypes.string,
     to: PropTypes.oneOfType([
@@ -43,9 +45,24 @@ class Redirect extends React.Component {
       this.perform()
   }
 
+  computeTo({ computedMatch, to }) {
+    if (computedMatch) {
+      if (typeof to === "string") {
+        return generatePath(to, computedMatch.params)
+      } else {
+        return {
+          ...to,
+          pathname: generatePath(to.pathname, computedMatch.params)
+        }
+      }
+    }
+    return to
+  }
+
   perform() {
     const { history } = this.context.router
-    const { push, to } = this.props
+    const { push } = this.props
+    const to = this.computeTo(this.props)
 
     if (push) {
       history.push(to)

--- a/packages/react-router/modules/__tests__/generatePath-test.js
+++ b/packages/react-router/modules/__tests__/generatePath-test.js
@@ -1,0 +1,57 @@
+import expect from 'expect'
+import generatePath from '../generatePath'
+
+describe('generatePath', () => {
+  describe('with pattern="/"', () => {
+    it('returns correct url with no params', () => {
+      const pattern = '/'
+      const generated = generatePath(pattern)
+      expect(generated).toBe('/')
+    })
+
+    it('returns correct url with params', () => {
+      const pattern = '/'
+      const params = { foo: "tobi", bar: 123 }
+      const generated = generatePath(pattern, params)
+      expect(generated).toBe('/')
+    })
+  })
+
+  describe('with pattern="/:foo/somewhere/:bar"', () => {
+    it('throws with no params', () => {
+      const pattern = '/:foo/somewhere/:bar'
+      expect(() => {
+        generatePath(pattern)
+      }).toThrow()
+    })
+
+    it('throws with some params', () => {
+      const pattern = '/:foo/somewhere/:bar'
+      const params = { foo: "tobi", quux: 999 }
+      expect(() => {
+        generatePath(pattern, params)
+      }).toThrow()
+    })
+
+    it('returns correct url with params', () => {
+      const pattern = '/:foo/somewhere/:bar'
+      const params = { foo: "tobi", bar: 123 }
+      const generated = generatePath(pattern, params)
+      expect(generated).toBe('/tobi/somewhere/123')
+    })
+
+    it('returns correct url with additional params', () => {
+      const pattern = '/:foo/somewhere/:bar'
+      const params = { foo: "tobi", bar: 123, quux: 999 }
+      const generated = generatePath(pattern, params)
+      expect(generated).toBe('/tobi/somewhere/123')
+    })
+  })
+
+  describe('with no path', () => {
+    it('matches the root URL', () => {
+      const generated = generatePath()
+      expect(generated).toBe('/')
+    })
+  })
+})

--- a/packages/react-router/modules/generatePath.js
+++ b/packages/react-router/modules/generatePath.js
@@ -1,0 +1,35 @@
+import pathToRegexp from 'path-to-regexp'
+
+const patternCache = {}
+const cacheLimit = 10000
+let cacheCount = 0
+
+const compileGenerator = (pattern) => {
+  const cacheKey = pattern
+  const cache = patternCache[cacheKey] || (patternCache[cacheKey] = {})
+
+  if (cache[pattern])
+    return cache[pattern]
+
+  const compiledGenerator = pathToRegexp.compile(pattern)
+
+  if (cacheCount < cacheLimit) {
+    cache[pattern] = compiledGenerator
+    cacheCount++
+  }
+
+  return compiledGenerator
+}
+
+/**
+ * Public API for generating a URL pathname from a pattern and parameters.
+ */
+const generatePath = (pattern = '/', params = {}) => {
+  if (pattern === '/') {
+    return pattern
+  }
+  const generator = compileGenerator(pattern)
+  return generator(params)
+}
+
+export default generatePath


### PR DESCRIPTION
This pull request adds back a feature from v3 where the `to` URL pathnames of `<Redirect>` could contain parameters.

Currently, parameters in `from` are already matched by `<Switch>` and then passed into `<Redirect>` as `computedMatch` prop just like `<Route>` children. However, `<Redirect>` does not do anything with that information yet.

I implemented a new `generatePath(pattern, params)` function that creates a new pathname using [path-to-regexp's `compile` function](https://github.com/pillarjs/path-to-regexp#compile-reverse-path-to-regexp). This guarantees that patterns are processed in the same way as they are parsed in `matchPath`. This function is used to put the params from `computedMatch` into the respective slots of the `to` prop, which may from now include named parameters as well.

All `compile` functions are cached by `pattern` using the same mechanism as `matchPath`.

Most importantly, the matching logic remains completely untouched and as-is. All of this is meant to be minimally invasive.

Tests, docs and batteries included. It might make sense to make `generatePath` available as a public API helper method and document it like `matchPath`.

**Examples** (without `<Switch>` for brevity)

```jsx
// /users/123 → /users/profile/123
<Redirect from="/users/:id" to="/users/profile/:id" />

// /users/123 → /users/profile/123?additional=args
// Location objects work as well, `to.pathname` gets populated with parameters
<Redirect from="/users/:id" to={{ pathname: "/users/profile/:id", search: "?additional=args" }} />

// /users/editors/123 → /users/profile/123
// parameters in `from` that are not included in `to` are ignored
<Redirect from="/users/:group/:id" to="/users/profile/:id" />

// /users/editors/123 → /users/home
// `to` can be completely "static"
<Redirect from="/users/:group/:id" to="/users/home" />

// /foo/bar → does not match, no redirect (duh)
<Redirect from="/users/:group/:id" to="/users/home" />

// /users/123 → ERROR
// Parameter :foo is missing in `from`, path-to-regexp throws an error
<Redirect from="/users/:id" to="/users/:id/:foo" />

// /users/profiles → /profiles
// Needless to say, all redirects without parameters work just like usual.
<Redirect from="/users/profiles" to="/profiles" />
```