### PR TITLE
Do not include trailing `/` in url if it's not included in path

### DIFF
--- a/packages/react-router/modules/matchPath.js
+++ b/packages/react-router/modules/matchPath.js
@@ -23,6 +23,16 @@ const compilePath = (pattern, options) => {
   return compiledPattern
 }
 
+const normalizeURL = (path, url) => {
+  if (path === '/' && url === '') {
+    return '/';
+  }
+  if (path[path.length - 1] !== '/' && url[url.length - 1] === '/') {
+    return url.substr(0, url.length - 1);
+  }
+  return url;
+}
+
 /**
  * Public API for matching a URL pathname to a path pattern.
  */
@@ -45,7 +55,7 @@ const matchPath = (pathname, options = {}) => {
 
   return {
     path, // the path pattern used to match
-    url: path === '/' && url === '' ? '/' : url, // the matched portion of the URL
+    url: normalizeURL(path, url), // the matched portion of the URL
     isExact, // whether or not we matched exactly
     params: keys.reduce((memo, key, index) => {
       memo[key.name] = values[index]


### PR DESCRIPTION
This fixes an issue where you have something like:

```js
const App = () => {
  return (
    <div>
      <a href="/foo/">Go to foo</a>
      <Route path="/foo" component={Foo} />
    </div>
  );
};
const Foo = ({match: {url, path}}) => {
  return (
    <div>
      <a href={url + '/bar'}>Go to bar</a>
      <Route path={path + '/bar'} component={Bar} />
    </div>
  );
};
const Bar = () => <div>Hello World</div>;
```

If you load this app and click on the link to "foo" it seems to work fine, except that because it's not strict, it has allowed you to add a trailing `/` to the path.  The "Go to bar" link then has a double `//` in it, causing the app to break when you attempt to click that link.

The easiest fix is to never include a trailing `/` in the `url` if there wasn't one in the path.