### PR TITLE
Link - catch errors thrown by onClick function

### DIFF
--- a/packages/react-router-dom/modules/Link.js
+++ b/packages/react-router-dom/modules/Link.js
@@ -33,8 +33,13 @@ class Link extends React.Component {
   }
 
   handleClick = (event) => {
-    if (this.props.onClick)
-      this.props.onClick(event)
+    if (this.props.onClick) {
+      try {
+        this.props.onClick(event);
+      } catch (error) {
+        console.error(error);
+      }
+    }
 
     if (
       !event.defaultPrevented && // onClick prevented default


### PR DESCRIPTION
**Problem:**
If the function onClick throws an error it doesn't apply the method preventDefault to the click event. When this happens the click event keeps the normal <a/> behaviour jumping to the next route with a page refresh. Therefore it's hard to detect what is causing the problem, because the error was logged in the context of a different page.

**Solution:**
Catch the error thrown by the execution of the function onClick() so it can log the error and keep the normal behaviour of the Link component without reloading the page. 