### PR TITLE
Fix <Switch> documentation

### DIFF
--- a/packages/react-router/docs/api/Switch.md
+++ b/packages/react-router/docs/api/Switch.md
@@ -48,13 +48,12 @@ This is also useful for animated transitions since the matched `<Route>` is rend
       a bit more cumbersome to work out */}
 </Fade>
 ```
-## Switch props
 
-### location: object
+## location: object
 
 A [`location`](location.md) object to be used for matching children elements instead of the current history location (usually the current browser URL).
 
-### children: node
+## children: node
 
 All children of a `<Switch>` should be `<Route>` or `<Redirect>` elements. Only the first child to match the current location will be rendered.
 


### PR DESCRIPTION
This was broken in https://github.com/ReactTraining/react-router/pull/5136

Basically, only `<h1>` (`#`) and `<h2>` (`##`) headings get converted into links for the documentation website, so we need to make the prop headings `<h2>` s.
