### PR TITLE
react-router-config: adds test that covers decoding of params

### DIFF
--- a/packages/react-router-config/modules/__tests__/matchRoutes-test.js
+++ b/packages/react-router-config/modules/__tests__/matchRoutes-test.js
@@ -40,6 +40,19 @@ it('stops matching after finding the first match, just like <Switch>', () => {
   expect(branch[0].route).toEqual(routes[0])
 })
 
+it('decodes params', () => {
+  const dynamicParam = 'τένις'
+
+  const routes = [
+    { path: '/el/:dynamic',
+      exact: true
+    }
+  ]
+
+  const branch = matchRoutes(routes, `/el/${encodeURI(dynamicParam)}`)
+  expect(branch.length).toEqual(1)
+  expect(branch[0].match.params.dynamic).toEqual(dynamicParam)
+})
 
 describe('pathless routes', () => {
 


### PR DESCRIPTION
Hi,

My team found a problem with foreign characters and decoding of params with react-router-config. I added a failing test. I'm not sure if this should be handled by `matchRoutes` with using `decodeURI` on the `pathname` param or if this should be done before we use `matchRoutes`?

Anyway, using something like `decodeURI` is needed to be able to have a equal render between server side routing and browser routing. I need your opinion on where this should be solved.