### PR TITLE
DeepLinking - Return null if this.props.children is undefined

### DIFF
--- a/packages/react-router-native/DeepLinking.js
+++ b/packages/react-router-native/DeepLinking.js
@@ -34,7 +34,7 @@ class DeepLinking extends Component {
   }
 
   render() {
-    return this.props.children
+    return this.props.children || null;
   }
 }
 


### PR DESCRIPTION
Solves a problem similar to #4818 related to `DeepLinking`