### PR TITLE
Fix ConnectedRouter not passing router.staticContext

### DIFF
--- a/packages/react-router-redux/README.md
+++ b/packages/react-router-redux/README.md
@@ -58,7 +58,8 @@ const store = createStore(
 ReactDOM.render(
   <Provider store={store}>
     { /* ConnectedRouter will use the store from Provider automatically */ }
-    <ConnectedRouter history={history}>
+    { /* isServer tells ConnectedRouter to create a staticContext for Route/Redirect */ }
+    <ConnectedRouter history={history} isServer={true}>
       <div>
         <Route exact path="/" component={Home}/>
         <Route path="/about" component={About}/>

--- a/packages/react-router-redux/modules/ConnectedRouter.js
+++ b/packages/react-router-redux/modules/ConnectedRouter.js
@@ -8,11 +8,26 @@ class ConnectedRouter extends Component {
   static propTypes = {
     store: PropTypes.object,
     history: PropTypes.object,
-    children: PropTypes.node
+    children: PropTypes.node,
+    isServer: PropTypes.bool
   }
 
   static contextTypes = {
     store: PropTypes.object
+  }
+
+  static childContextTypes = {
+    router: PropTypes.shape({
+      staticContext: PropTypes.object
+    })
+  }
+
+  getChildContext() {
+    return this.props.isServer ? {
+      router: {
+        staticContext: {}
+      }
+    } : undefined
   }
 
   handleLocationChange = location => {

--- a/packages/react-router-redux/modules/__tests__/ConnectedRouter-test.js
+++ b/packages/react-router-redux/modules/__tests__/ConnectedRouter-test.js
@@ -1,4 +1,5 @@
 import React from 'react'
+import PropTypes from 'prop-types'
 import renderer from 'react-test-renderer'
 import { createStore, combineReducers } from 'redux'
 import { Provider } from 'react-redux'
@@ -58,7 +59,42 @@ describe('A <ConnectedRouter>', () => {
     expect(store.getState()).toHaveProperty('router.location.pathname', '/foo')
   })
 
+  describe('with isServer set to true', () => {
+    const ChildWithContext = (_, { router }) => <div>{'staticContext: ' + JSON.stringify(router.staticContext)}</div>
+    ChildWithContext.contextTypes = {
+      router: PropTypes.object.isRequired
+    }
+
+    it('creates a child context', () => {
+      const tree = renderer.create(
+        <ConnectedRouter store={store} history={history}  isServer={true}>
+          <ChildWithContext />
+        </ConnectedRouter>
+      ).toJSON()
+      
+      expect(tree).toMatchSnapshot()
+    })
+  })  
+
+  describe('with isServer set to false', () => {
+    const ChildWithContext = (_, { router }) => <div>{'staticContext: ' + JSON.stringify(router.staticContext)}</div>
+    ChildWithContext.contextTypes = {
+      router: PropTypes.object.isRequired
+    }
+
+    it('does not create a child context', () => {
+      const tree = renderer.create(
+        <ConnectedRouter store={store} history={history}  isServer={false}>
+          <ChildWithContext />
+        </ConnectedRouter>
+      ).toJSON()
+      
+      expect(tree).toMatchSnapshot()
+    })
+  })
+
   describe('with children', () => {
+
     it('to render', () => {      
       const tree = renderer.create(
         <ConnectedRouter store={store} history={history}>

--- a/packages/react-router-redux/modules/__tests__/__snapshots__/ConnectedRouter-test.js.snap
+++ b/packages/react-router-redux/modules/__tests__/__snapshots__/ConnectedRouter-test.js.snap
@@ -6,4 +6,16 @@ exports[`A <ConnectedRouter> with children to render 1`] = `
 </div>
 `;
 
+exports[`A <ConnectedRouter> with isServer set to false does not create a child context 1`] = `
+<div>
+  staticContext: undefined
+</div>
+`;
+
+exports[`A <ConnectedRouter> with isServer set to true creates a child context 1`] = `
+<div>
+  staticContext: {}
+</div>
+`;
+
 exports[`A <ConnectedRouter> with no children to render 1`] = `null`;


### PR DESCRIPTION
When using the latest `react-router-redux` (5.0.0-alpha.6) on the server a `staticContext` is not created ([as in `StaticRouter`](https://github.com/ReactTraining/react-router/blob/master/packages/react-router/modules/StaticRouter.js#L84)). However, this is [needed by the `Redirect` component](https://github.com/ReactTraining/react-router/blob/master/packages/react-router/modules/Redirect.js#L37) to determine whether it should perform the redirect when rendering on the server:

```js
  isStatic() {
    return this.context.router && this.context.router.staticContext
  }

  componentWillMount() {
    if (this.isStatic())
      this.perform()
  }
```

This means any use of a `Redirect` component on the server is ignored.

This PR adds an extra prop to the `ConnectedRouter` called `isServer` (best name I could think of that wouldn't confuse anyone using it) that instructs it to create the `staticContext`. Any `Redirect` components will then perform the redirect on the server.

There is another problem that anything put into the context ([as suggested by the docs](https://reacttraining.com/react-router/web/guides/server-rendering/adding-app-specific-context-information)) is inaccessible when using `react-router-redux` anyway as it isn't placed into the store. But I guess you could just use history state instead?