### PR TITLE
Added a migration section on PatternUtils

### DIFF
--- a/packages/react-router/docs/guides/migrating.md
+++ b/packages/react-router/docs/guides/migrating.md
@@ -10,6 +10,7 @@ React Router v4 is a complete rewrite, so there is not a simple migration path. 
   * [on* properties](#on-properties)
   * [Switch](#switch)
   * [Redirect](#redirect)
+* [PatternUtils](#patternutils)
 
 ## The Router
 
@@ -168,4 +169,30 @@ In v4, you can achieve the same functionality using `<Redirect>`.
   <Redirect path="*" to="/" />
 </Switch>
 
+```
+
+## PatternUtils
+
+### matchPattern(pattern, pathname)
+In v3, you could use the same matching code used internally to check if a path matched a pattern. In v4 this has been replaced by [matchPath](/packages/react-router/docs/api/matchPath.md) which is powered by the [path-to-regexp](https://github.com/pillarjs/path-to-regexp) library.
+
+### formatPattern(pattern, params)
+In v3, you could use PatternUtils.formatPattern to generate a valid path from a path pattern (perhaps in a constant or in your central routing config) and an object containing the names parameters:
+
+```js
+// v3
+const THING_PATH = '/thing/:id';
+
+<Link to={PatternUtils.formatPattern(THING_PATH, {id: 1})}>A thing</Link>
+```
+
+In v4, you can achieve the same functionality using the [compile](https://github.com/pillarjs/path-to-regexp#compile-reverse-path-to-regexp) function in [path-to-regexp](https://github.com/pillarjs/path-to-regexp).
+
+```js
+// v4
+const THING_PATH = '/thing/:id';
+
+const thingPath = pathToRegexp.compile(THING_PATH);
+
+<Link to={thingPath({id: 1})}>A thing</Link>
 ```


### PR DESCRIPTION
PatternUtils.formatPattern was something I used pretty extensively on several projects, sharing the patterns in routing config and on links (and in action creators) so that if the pattern changed I didn't have to update paths everywhere. It took some time to figure out I could use the compile option on pathToRegexp so I thought it worth documenting here.

While I was at it it seemed worth adding a blurb about the other major util in PatternUtils and linking to matchPath