### PR TITLE
(Don't Merge) Expect ReactRouterDOM as global in react-router-config UMD

### DIFF
--- a/packages/react-router-dom/modules/assignWindow.js
+++ b/packages/react-router-dom/modules/assignWindow.js
@@ -1,2 +1,2 @@
 if (typeof window === 'object' && window.ReactRouterDOM)
-	window.ReactRouter = window.ReactRouterDOM
+  window.ReactRouter = window.ReactRouterDOM

--- a/packages/react-router-dom/modules/assignWindow.js
+++ b/packages/react-router-dom/modules/assignWindow.js
@@ -1,0 +1,2 @@
+if (typeof window === 'object' && window.ReactRouterDOM)
+	window.ReactRouter = window.ReactRouterDOM

--- a/packages/react-router-dom/package.json
+++ b/packages/react-router-dom/package.json
@@ -69,6 +69,7 @@
     "rollup": "^0.48.2",
     "rollup-plugin-babel": "^3.0.2",
     "rollup-plugin-commonjs": "^8.2.0",
+    "rollup-plugin-multi-entry": "^2.0.1",
     "rollup-plugin-node-resolve": "^3.0.0",
     "rollup-plugin-replace": "^1.1.1",
     "rollup-plugin-uglify": "^2.0.1"

--- a/packages/react-router-dom/rollup.config.js
+++ b/packages/react-router-dom/rollup.config.js
@@ -3,9 +3,10 @@ import uglify from 'rollup-plugin-uglify'
 import replace from 'rollup-plugin-replace'
 import commonjs from 'rollup-plugin-commonjs'
 import resolve from 'rollup-plugin-node-resolve'
+import multiEntry from 'rollup-plugin-multi-entry'
 
 const config = {
-  input: 'modules/index.js',
+  input: ['modules/index.js', 'modules/assignWindow.js'],
   name: 'ReactRouterDOM',
   globals: {
     react: 'React'
@@ -14,6 +15,7 @@ const config = {
     'react'
   ],
   plugins: [
+    multiEntry(),
     babel({
       exclude: 'node_modules/**'
     }),

--- a/packages/react-router-dom/tools/build.js
+++ b/packages/react-router-dom/tools/build.js
@@ -11,13 +11,13 @@ const exec = (command, extraEnv) =>
 
 console.log('Building CommonJS modules ...')
 
-exec('babel modules -d . --ignore __tests__', {
+exec('babel modules -d . --ignore __tests__,assignWindow.js', {
   BABEL_ENV: 'cjs'
 })
 
 console.log('\nBuilding ES modules ...')
 
-exec('babel modules -d es --ignore __tests__', {
+exec('babel modules -d es --ignore __tests__,assignWindow.js', {
   BABEL_ENV: 'es'
 })
 


### PR DESCRIPTION
This is a follow up to #5343

I was thinking about the `react-router-config` build. In it, I used `react-router`  as an external (`react-router/Switch` maps to `ReactRouter.Switch`). The issue with this is that the user is more likely to be importing the `react-router-dom` UMD, so `ReactRouterDOM` will be defined and `ReactRouter` won't. That will mean that the user has to include the React Router UMD script in order to ensure that their code works.

This problem also existed in the Webpack build. However, that was never published because `UMD` was only added to the release files in https://github.com/ReactTraining/react-router/commit/6536e931068dda124a44f90300845ceae575d122. I imagine once it actually is released, someone will use it and run into this problem, so we should probably figure out how to address this.

What this PR does is to modify the globals from `ReactRouter/XX` to `ReactRouterDOM/XX`. The reasoning behind this is that when the UMD script runs, there are three checks:

1. check if we are in a commonjs environment and if true, use `exports` as the global
2. check if we are in an AMD environment and if true, use `define`
3. if none of the above, use `this` (`Window` in the browser) as the global.

Correct me if I am mistaken, but the third one should only happen in the browser, which is where users would be running into this issue. If that is true, then we should be able to say that if you are attempting to use this script in the browser, you should be using the React Router DOM script as well.
