### PR TITLE
Remove babel-loader devDeps

### DIFF
--- a/packages/react-router-config/package.json
+++ b/packages/react-router-config/package.json
@@ -31,7 +31,6 @@
   "devDependencies": {
     "babel-cli": "^6.18.0",
     "babel-eslint": "^6.0.4",
-    "babel-loader": "^6.2.10",
     "babel-plugin-dev-expression": "^0.2.1",
     "babel-plugin-external-helpers": "^6.22.0",
     "babel-plugin-transform-react-remove-prop-types": "^0.2.11",

--- a/packages/react-router-dom/package.json
+++ b/packages/react-router-dom/package.json
@@ -49,7 +49,6 @@
   "devDependencies": {
     "babel-cli": "^6.18.0",
     "babel-eslint": "^6.0.4",
-    "babel-loader": "^6.2.10",
     "babel-plugin-dev-expression": "^0.2.1",
     "babel-plugin-external-helpers": "^6.22.0",
     "babel-plugin-transform-react-remove-prop-types": "^0.2.11",

--- a/packages/react-router/package.json
+++ b/packages/react-router/package.json
@@ -47,7 +47,6 @@
   "devDependencies": {
     "babel-cli": "^6.18.0",
     "babel-eslint": "^6.0.4",
-    "babel-loader": "^6.2.10",
     "babel-plugin-dev-expression": "^0.2.1",
     "babel-plugin-external-helpers": "^6.22.0",
     "babel-plugin-transform-react-remove-prop-types": "^0.2.11",


### PR DESCRIPTION
Missed removing these when switching to Rollup.