### PR TITLE
Link - Prevent default href behaviour even if onClick has an error (avoid weird SPA errors)

### DIFF
--- a/packages/react-router-dom/modules/Link.js
+++ b/packages/react-router-dom/modules/Link.js
@@ -34,24 +34,26 @@ class Link extends React.Component {
   }
 
   handleClick = (event) => {
-    if (this.props.onClick)
-      this.props.onClick(event)
+    try {
+      if (this.props.onClick)
+        this.props.onClick(event)
+    } finally {
+      if (
+        !event.defaultPrevented && // onClick prevented default
+        event.button === 0 && // ignore right clicks
+        !this.props.target && // let browser handle "target=_blank" etc.
+        !isModifiedEvent(event) // ignore clicks with modifier keys
+      ) {
+        event.preventDefault()
 
-    if (
-      !event.defaultPrevented && // onClick prevented default
-      event.button === 0 && // ignore right clicks
-      !this.props.target && // let browser handle "target=_blank" etc.
-      !isModifiedEvent(event) // ignore clicks with modifier keys
-    ) {
-      event.preventDefault()
+        const { history } = this.context.router
+        const { replace, to } = this.props
 
-      const { history } = this.context.router
-      const { replace, to } = this.props
-
-      if (replace) {
-        history.replace(to)
-      } else {
-        history.push(to)
+        if (replace) {
+          history.replace(to)
+        } else {
+          history.push(to)
+        }
       }
     }
   }


### PR DESCRIPTION
#5246 - Old pull request (look at my last comment)

Problem:
If the function onClick throws an error it doesn't apply the method preventDefault to the click event. When this happens the click event keeps the normal behaviour jumping to the next route with a page refresh. Therefore it's hard to detect what is causing the problem, because the error was logged in the context of a different page.

Solution:
Prevent the <a /> default behaviour on a try/finally. With this we avoid weird bugs in SPA applications (hard to debug) and still delegate the error handling to the application