### PR TITLE
Adds failing test cases for Issue 5296

### DIFF
--- a/packages/react-router/modules/__tests__/Route-test.js
+++ b/packages/react-router/modules/__tests__/Route-test.js
@@ -183,14 +183,36 @@ describe('A <Route> with dynamic segments in the path', () => {
       })
 
       it('correctly decodes params which have an encoded :', () => {
-        props = prepHistoryAndGetProps('/foo%3abar/baz')
+        props = prepHistoryAndGetProps('/%3abar/baz')
         ReactDOM.render((
             <RouterComponent {...props}>
               <Route path="/:param1/baz" render={({ match }) => <div>{match.params.param1}</div>} />
             </RouterComponent>
         ), node)
 
-        expect(node.innerText).toBe('foo:bar')
+        expect(node.innerText).toBe(':bar')
+      })
+
+      it('matches paths which themselves contain a percent-encoded slash', () => {
+        props = prepHistoryAndGetProps('/foo%2fbar/baz')
+        ReactDOM.render((
+            <RouterComponent {...props}>
+              <Route path="/foo%2fbar/:param1" render={({ match }) => <div>{match.params.param1}</div>} />
+            </RouterComponent>
+        ), node)
+
+        expect(node.innerText).toBe('baz')
+      })
+
+      it('matches paths which themselves contain a percent-encoded colon', () => {
+        props = prepHistoryAndGetProps('/%3abar/baz')
+        ReactDOM.render((
+            <RouterComponent {...props}>
+              <Route path="/%3abar/:param1" render={({ match }) => <div>{match.params.param1}</div>} />
+            </RouterComponent>
+        ), node)
+
+        expect(node.innerText).toBe('baz')
       })
     })
   )

--- a/packages/react-router/modules/__tests__/matchPath-test.js
+++ b/packages/react-router/modules/__tests__/matchPath-test.js
@@ -61,4 +61,90 @@ describe('matchPath', () => {
       expect(!!falseTrue).toBe(false)
     })
   })
+
+  describe('with dynamic segments in the path', () => {
+    let url
+
+    it('decodes them', () => {
+      url = '/a%20dynamic%20segment'
+      const match = matchPath(url, {
+        path: '/:id',
+        exact: true,
+        strict: true
+      })
+
+      expect(match.isExact).toBe(true)
+      expect(match.params.id).toBe('a dynamic segment')
+    })
+
+    it('correctly finds multiple params', () => {
+      url = '/first/second'
+
+      const match = matchPath(url, {
+        path: '/:param1/:param2',
+        exact: true,
+        strict: true
+      })
+
+      expect(match.isExact).toBe(true)
+      expect(match.params.param1).toBe('first')
+      expect(match.params.param2).toBe('second')
+    })
+
+    it('correctly finds and decodes params in the middle of a complex path rule', () => {
+      // This test case is modeled after a real-world case where we'd seen some inconsistent behavior
+      url = '/foo/some%20param/edit'
+
+      const match = matchPath(url, {
+        path: '/foo/:param1/:param2(edit|view|history)?',
+        exact: true,
+        strict: false
+      })
+
+      expect(match.isExact).toBe(true)
+      expect(match.params.param1).toBe('some param')
+      expect(match.params.param2).toBe('edit')
+    })
+
+    it('correctly finds and decodes params in the middle of a complex path rule 2', () => {
+      // This test case is modeled after a real-world case where we'd seen some inconsistent behavior
+      url = '/foo/some%20param'
+
+      const match = matchPath(url, {
+        path: '/foo/:param1/:param2(edit|view|history)?',
+        exact: true,
+        strict: false
+      })
+
+      expect(match.isExact).toBe(true)
+      expect(match.params.param1).toBe('some param')
+      expect(match.params.param2).toBe(null)
+    })
+
+    it('correctly decodes params which have an encoded /', () => {
+      url = '/foo%2fbar/baz'
+
+      const match = matchPath(url, {
+        path: '/:param1/baz',
+        exact: true,
+        strict: true
+      })
+
+      expect(match.isExact).toBe(true)
+      expect(match.params.param1).toBe('foo/bar')
+    })
+
+    it('correctly decodes params which have an encoded :', () => {
+      url = '/foo%3abar/baz'
+
+      const match = matchPath(url, {
+        path: '/:param1/baz',
+        exact: true,
+        strict: true
+      })
+
+      expect(match.isExact).toBe(true)
+      expect(match.params.param1).toBe('foo:bar')
+    })
+  })
 })

--- a/packages/react-router/modules/__tests__/matchPath-test.js
+++ b/packages/react-router/modules/__tests__/matchPath-test.js
@@ -135,7 +135,7 @@ describe('matchPath', () => {
     })
 
     it('correctly decodes params which have an encoded :', () => {
-      url = '/foo%3abar/baz'
+      url = '/%3abar/baz'
 
       const match = matchPath(url, {
         path: '/:param1/baz',
@@ -144,7 +144,33 @@ describe('matchPath', () => {
       })
 
       expect(match.isExact).toBe(true)
-      expect(match.params.param1).toBe('foo:bar')
+      expect(match.params.param1).toBe(':bar')
+    })
+
+    it('matches paths which themselves contain a percent-encoded slash', () => {
+      url = '/foo%2fbar/baz'
+
+      const match = matchPath(url, {
+        path: '/foo%2fbar/:param1',
+        exact: true,
+        strict: true
+      })
+
+      expect(match.isExact).toBe(true)
+      expect(match.params.param1).toBe('baz')
+    })
+
+    it('matches paths which themselves contain a percent-encoded colon', () => {
+      url = '/%3abar/baz'
+
+      const match = matchPath(url, {
+        path: '/%3abar/:param1',
+        exact: true,
+        strict: true
+      })
+
+      expect(match.isExact).toBe(true)
+      expect(match.params.param1).toBe('baz')
     })
   })
 })


### PR DESCRIPTION
https://github.com/ReactTraining/react-router/issues/5296

Primarily, this test suite PR demonstrates inconsistencies in path matching depending on context (`matchParams`, `StaticRouter`, and `Router` at a minimum).  It is suggested that all path matching logic be consolidated into a single place to avoid this sort of problem.

Additional test cases were also added to cover some potentially tricky use cases I thought up while I was in there.