### PR TITLE
Update Link API docs

### DIFF
--- a/packages/react-router-dom/docs/api/Link.md
+++ b/packages/react-router-dom/docs/api/Link.md
@@ -18,7 +18,11 @@ The pathname or location to link to.
 
 ## to: object
 
-The location to link to.
+If it's an object it can have four keys:
+  * `pathname`: A string representing the path to link to.
+  * `query`: An object of key:value pairs to be stringified.
+  * `hash`: A hash to put in the URL, e.g. `#a-hash`.
+  * `state`: State to persist to the `location`.
 
 ```js
 <Link to={{

--- a/packages/react-router-native/docs/api/Link.md
+++ b/packages/react-router-native/docs/api/Link.md
@@ -18,7 +18,11 @@ The pathname or location to link to.
 
 ## to: object
 
-The location to link to.
+* If it's an object it can have four keys:
+  * `pathname`: A string representing the path to link to.
+  * `query`: An object of key:value pairs to be stringified.
+  * `hash`: A hash to put in the URL, e.g. `#a-hash`.
+  * `state`: State to persist to the `location`.
 
 ```js
 <Link to={{


### PR DESCRIPTION
Add missing description for Link component `to` object in react-router-dom and react-router-native.