### PR TITLE
Make withRouter HOC stateful to allow refs

### DIFF
--- a/packages/react-router/modules/__tests__/withRouter-test.js
+++ b/packages/react-router/modules/__tests__/withRouter-test.js
@@ -90,6 +90,26 @@ describe('withRouter', () => {
     expect(ref instanceof WrappedComponent).toBe(true)
   })
 
+  it('exposes the instance of the wrapper via ref', () => {
+    class WrappedComponent extends React.Component {
+      render() {
+        return null
+      }
+    }
+    const Component = withRouter(WrappedComponent)
+
+    let ref
+    ReactDOM.render((
+      <MemoryRouter initialEntries={[ '/bubblegum' ]}>
+        <Route path="/bubblegum" render={() => (
+          <Component ref={r => ref = r}/>
+        )}/>
+      </MemoryRouter>
+    ), node)
+
+    expect(ref instanceof Component).toBe(true)
+  })
+
   it('hoists non-react statics from the wrapped component', () => {
     class Component extends React.Component {
       static foo() {

--- a/packages/react-router/modules/withRouter.js
+++ b/packages/react-router/modules/withRouter.js
@@ -7,19 +7,23 @@ import Route from './Route'
  * A public higher-order component to access the imperative API
  */
 const withRouter = (Component) => {
-  const C = (props) => {
-    const { wrappedComponentRef, ...remainingProps } = props
-    return (
-      <Route render={routeComponentProps => (
-        <Component {...remainingProps} {...routeComponentProps} ref={wrappedComponentRef}/>
-      )}/>
-    )
-  }
+  class C extends React.Component {
+    static displayName = `withRouter(${Component.displayName || Component.name})`
 
-  C.displayName = `withRouter(${Component.displayName || Component.name})`
-  C.WrappedComponent = Component
-  C.propTypes = {
-    wrappedComponentRef: PropTypes.func
+    static WrappedComponent = Component
+
+    static propTypes = {
+      wrappedComponentRef: PropTypes.func
+    }
+
+    render() {
+      const { wrappedComponentRef, ...remainingProps } = this.props
+      return (
+        <Route render={routeComponentProps => (
+          <Component {...remainingProps} {...routeComponentProps} ref={wrappedComponentRef}/>
+        )}/>
+      )
+    }
   }
 
   return hoistStatics(C, Component)


### PR DESCRIPTION
Right now when you use withRouter on a component with ref it suddenly breaks because withRouter is a stateless component which doesn't allow refs.

There is `wrappedComponentRef` property but it forces container to know which child components use withRouter and which don't.

Components refs are mostly used to get a DOM node via ReactDOM.findDOMNode so usually it doesn't matter if ref points to withRouter HOC instead of wrapped component.