### PR TITLE
loader and modules cant be resoloved issues in `react-router-website`

### DIFF
--- a/packages/react-router-website/webpack.config.js
+++ b/packages/react-router-website/webpack.config.js
@@ -40,7 +40,16 @@ module.exports = {
   resolve: {
     alias: {
       'react-router-dom': path.resolve(__dirname, 'modules/ReactRouterDOMShim')
-    }
+    },
+    root: [
+      path.resolve('./node_modules'),
+    ]
+  },
+
+  resolveLoader: {
+    root: [
+      path.resolve('./node_modules'),
+    ]
   },
 
   module: {


### PR DESCRIPTION
According to [#5346](https://github.com/ReactTraining/react-router/pull/5346/files), `babel-loader`has been removed from `react-router-dom` due to switching to `rollup`. Then if you try to start `react-router-website`  package it will fail with following message 

```
ERROR in ../react-router-dom/index.js
Module not found: Error: Cannot resolve module 'babel' in /Users/ryu/Documents/git/react/react-router/packages/react-router-dom
 @ ../react-router-dom/index.js 6:22-48
```

This issue should be raised due to the `import` pattern in file `react-router-website/modules/ReactRouterDOMShim.js`. In my opinion,  `webpack` will resolve modules and loader based on the source files' location.  After execute `npm run build` on the top-level, every package will has its corresponding `node_modules` folder.  Recently, `babel-loader` is removed from `react-router-dom`, `webpack` could not resolve the modules correctly any more.

I think it should have two resolutions:

1. Retain `babel-loader` in `react-route-dom` package. I dont think this is the right thing you want. :)
2. Specify a clear path for `resolve modules` and `resolve loader`, It will benefit no matter where imported modules located, you just need to maintain a `package.json` in concerned package. for this situation, it's `react-router-website`.

I wonder if I have made a correct diagnosis. looking forward to your feedback. :)