### PR TITLE
Accept array of strings in route path

### DIFF
--- a/packages/react-router/modules/Route.js
+++ b/packages/react-router/modules/Route.js
@@ -13,7 +13,10 @@ const isEmptyChildren = (children) =>
 class Route extends React.Component {
   static propTypes = {
     computedMatch: PropTypes.object, // private, from <Switch>
-    path: PropTypes.string,
+    path: PropTypes.oneOfType([
+      PropTypes.string,
+      PropTypes.arrayOf(PropTypes.string)
+    ]),
     exact: PropTypes.bool,
     strict: PropTypes.bool,
     component: PropTypes.func,

--- a/packages/react-router/modules/__tests__/matchPath-test.js
+++ b/packages/react-router/modules/__tests__/matchPath-test.js
@@ -33,6 +33,36 @@ describe('matchPath', () => {
     })
   })
 
+  describe('with an array of paths', () => {
+    it('return the correct url at "/elsewhere"', () => {
+      const path = ['/somewhere', '/elsewhere']
+      const pathname = '/elsewhere'
+      const match = matchPath(pathname, { path })
+      expect(match.url).toBe('/elsewhere')
+    })
+
+    it('returns correct url at "/elsewhere/else"', () => {
+      const path = ['/somewhere', '/elsewhere']
+      const pathname = '/elsewhere/else'
+      const match = matchPath(pathname, { path })
+      expect(match.url).toBe('/elsewhere')
+    })
+
+    it('returns correct url at "/elsewhere/else" with path "/" in array', () => {
+      const path = ['/somewhere', '/']
+      const pathname = '/elsewhere/else'
+      const match = matchPath(pathname, { path })
+      expect(match.url).toBe('/')
+    })
+
+    it('returns correct url at "/somewhere" with path "/" in array', () => {
+      const path = ['/somewhere', '/']
+      const pathname = '/somewhere'
+      const match = matchPath(pathname, { path })
+      expect(match.url).toBe('/somewhere')
+    })
+  })
+
   describe('with no path', () => {
     it('matches the root URL', () => {
       const match = matchPath('/test-location/7', {})

--- a/packages/react-router/modules/matchPath.js
+++ b/packages/react-router/modules/matchPath.js
@@ -45,7 +45,7 @@ const matchPath = (pathname, options = {}) => {
 
   return {
     path, // the path pattern used to match
-    url: path === '/' && url === '' ? '/' : url, // the matched portion of the URL
+    url: url === '' ? '/' : url, // the matched portion of the URL
     isExact, // whether or not we matched exactly
     params: keys.reduce((memo, key, index) => {
       memo[key.name] = values[index]


### PR DESCRIPTION
The `path-to-regexp` library supports an array of strings as a pattern, however we are getting PropTypes warnings about this. This PR enables support for this.

It seems like we do not touch the path and just pass it on to the `path-to-regexp` library directly.

See these previous PR's and Issues for more context:
https://github.com/ReactTraining/react-router/pull/4159
https://github.com/ReactTraining/react-router/issues/4551