### PR TITLE
support null computedMatch prop

### DIFF
--- a/packages/react-router/modules/Route.js
+++ b/packages/react-router/modules/Route.js
@@ -54,7 +54,7 @@ class Route extends React.Component {
   }
 
   computeMatch({ computedMatch, location, path, strict, exact }, router) {
-    if (computedMatch)
+    if (computedMatch!==undefined)
       return computedMatch // <Switch> already computed the match for us
 
     invariant(


### PR DESCRIPTION
I am working on a an alternative Switch component which works with routes that render using children function property. For animation purposes but not using react-transition-group.
Normal Switch component renders only first matched component.
My version of Switch would render all routes but only one will get non-null computedMatch property.
This change is needed to not ignore null value produced by my Switch component.

If you are interested, there is a animated Switch version:

````
class Switch extends React.Component {
    static contextTypes = {
        router: PropTypes.shape({
            route: PropTypes.object.isRequired
        }).isRequired
    }

    static propTypes = {
        children: PropTypes.node,
        location: PropTypes.object
    }

    componentWillMount() {
        invariant(
            this.context.router,
            'You should not use <Switch> outside a <Router>'
        )
    }

    componentWillReceiveProps(nextProps) {
        warning(
            !(nextProps.location && !this.props.location),
            '<Switch> elements should not change from uncontrolled to controlled (or vice versa). You initially used no "location" prop and then provided one on a subsequent render.'
        )

        warning(
            !(!nextProps.location && this.props.location),
            '<Switch> elements should not change from controlled to uncontrolled (or vice versa). You provided a "location" prop initially but omitted it on a subsequent render.'
        )
    }

    render() {
        const {route} = this.context.router
        const {children} = this.props
        const location = this.props.location || route.location

        const routes = children.slice(0, -1);
        const defaultRoute = children[children.length - 1];

        let found = false;
        const newRoutes = React.Children.map(routes, element => {
            if (!React.isValidElement(element)) return;

            const {path: pathProp, exact, strict, from} = element.props;
            const path = pathProp || from;

            if (found) { // we do not need more active routes, just return unmatched route
                return React.cloneElement(element, {location, computedMatch: null});
            }

            const match = path ? matchPath(location.pathname, {path, exact, strict}) : route.match;

            if (match) {
                found = true;
            }
            return React.cloneElement(element, {location, computedMatch: match});
        });

        newRoutes.push(React.cloneElement(defaultRoute, {location, computedMatch: found ? null : route.match}));

        return <div>
            { newRoutes }
        </div>
    }
}

export default Switch
````