### PR TITLE
Route must passed props to children when using component render method

### DIFF
--- a/packages/react-router/modules/Route.js
+++ b/packages/react-router/modules/Route.js
@@ -117,7 +117,7 @@ class Route extends React.Component {
         typeof children === 'function' ? (
           children(props)
         ) : !isEmptyChildren(children) ? (
-          React.Children.only(children)
+          React.cloneElement(React.Children.only(children), props)
         ) : (
           null
         )

--- a/packages/react-router/modules/__tests__/Route-test.js
+++ b/packages/react-router/modules/__tests__/Route-test.js
@@ -181,13 +181,42 @@ describe('<Route component>', () => {
     expect(node.innerHTML).toContain(TEXT)
   })
 
-  it('receives { match, location, history } props', () => {
+  it('receives { match, location, history } props with component', () => {
     let actual = null
     const Component = (props) => (actual = props) && null
 
     ReactDOM.render((
       <Router history={history}>
         <Route path="/" component={Component}/>
+      </Router>
+    ), node)
+
+    expect(actual.history).toBe(history)
+    expect(typeof actual.match).toBe('object')
+    expect(typeof actual.location).toBe('object')
+  })
+
+  it('receives { match, location, history } props with render', () => {
+    let actual = null
+
+    ReactDOM.render((
+      <Router history={history}>
+        <Route path="/" render={props => (actual = props) && null} />
+      </Router>
+    ), node)
+
+    expect(actual.history).toBe(history)
+    expect(typeof actual.match).toBe('object')
+    expect(typeof actual.location).toBe('object')
+  })
+
+  it('receives { match, location, history } props with children', () => {
+    let actual = null
+    const Component = (props) => (actual = props) && null
+
+    ReactDOM.render((
+      <Router history={history}>
+        <Route path="/"><Component /></Route>
       </Router>
     ), node)
 


### PR DESCRIPTION
Hello,

The documentation says at https://reacttraining.com/react-router/web/api/Route/render-func:
> There are 3 ways to render something with a <Route>:
> \<Route component>
> \<Route render>
> \<Route children>
> 
> All three render methods will be passed the same three route props
> match
> location
> history

However, with the current implementation, using `<Route><Component /></Route>`, the `Component` does not receive the three props.
This PR solves this issue.