### PR TITLE
Update code splitting docs to use react-loadable.

### DIFF
--- a/packages/react-router-dom/docs/guides/code-splitting.md
+++ b/packages/react-router-dom/docs/guides/code-splitting.md
@@ -1,97 +1,35 @@
 # Code Splitting
 
 One great feature of the web is that we don't have to make our visitors
-download the entire app before they can use it. You can think of code splitting as incrementally downloading the app. While there are other tools for the job, we'll use [Webpack][Webpack] and the [bundle loader][bundle-loader] in this guide.
+download the entire app before they can use it. You can think of code splitting
+as incrementally downloading the app. To accomplish this we'll use [webpack],
+[`babel-plugin-syntax-dynamic-import`], and [`react-loadable`].
 
-Here's the way the website you're using right now does code splitting: `<Bundle>`. What's most notable is that the router actually has nothing to do with this. When you're "at a route" that simply means "you're rendering a component". So we can make a component that loads dynamic imports as the user navigates to it. This approach works for any part of your app.
+[webpack] has built-in support for [dynamic imports][import]; however, if you
+are using [Babel] (e.g., to compile JSX to JavaScript) then you will need to
+use the [`babel-plugin-syntax-dynamic-import`] plugin. This is a syntax-only
+plugin, meaning Babel won't do any additional transformations. The plugin
+simply allows Babel to parse dynamic imports so webpack can bundle them as a
+code split. Your `.babelrc` should look something like this:
 
-```js
-import loadSomething from 'bundle-loader?lazy!./Something'
-
-<Bundle load={loadSomething}>
-  {(mod) => (
-    // do something w/ the module
-  )}
-</Bundle>
-```
-
-If the module is a component, we can render it right there:
-
-```jsx
-<Bundle load={loadSomething}>
-  {(Comp) => (Comp
-    ? <Comp/>
-    : <Loading/>
-  )}
-</Bundle>
-```
-
-This component takes a prop called `load` we get from the webpack [bundle loader][bundle-loader]. We'll talk about why we use that in a minute. When the component mounts or gets a new load prop, it will call `load`, then place the returned value in state. Finally, it calls back in render with the module.
-
-```js
-import React, { Component } from 'react'
-
-class Bundle extends Component {
-  state = {
-    // short for "module" but that's a keyword in js, so "mod"
-    mod: null
-  }
-
-  componentWillMount() {
-    this.load(this.props)
-  }
-
-  componentWillReceiveProps(nextProps) {
-    if (nextProps.load !== this.props.load) {
-      this.load(nextProps)
-    }
-  }
-
-  load(props) {
-    this.setState({
-      mod: null
-    })
-    props.load((mod) => {
-      this.setState({
-        // handle both es imports and cjs
-        mod: mod.default ? mod.default : mod
-      })
-    })
-  }
-
-  render() {
-    return this.state.mod ? this.props.children(this.state.mod) : null
-  }
+```json
+{
+  "presets": [
+    "react"
+  ],
+  "plugins": [
+    "syntax-dynamic-import"
+  ]
 }
-
-export default Bundle
 ```
 
-You'll notice that `render` calls back with a null `state.mod` on any
-renders before the module has been fetched. This is important so you
-can indicate to the user we're waiting for something.
-
-**Why bundle loader, and not `import()`?**
-
-We've been using it [for years][for-years] and it continues to work while TC39 continues to come up with an official dynamic import. The latest proposal is [`import()`][import], and we could adjust our `Bundle` component to use `import()` instead:
-
-```jsx
-<Bundle load={() => import('./something')}>
-  {(mod) => ()}
-</Bundle>
-```
-
-Another **HUGE** benefit of bundle loader is that the second time it calls back synchronously, which prevents flashing the loading screen every time you visit a code-split screen.
-
-Regardless of the way you import, the idea is the same: a component that handles the code loading when it renders. Now all you do is render a `<Bundle>` wherever you want to load code dynamically.
-
-## Loading after rendering is complete
-
-The `Bundle` component is great for loading as you approach a new screen, but it's also beneficial to preload the rest of the app in the background.
+[`react-loadable`] is a higher-order component for loading components with
+dynamic imports. It handles all sorts of edge cases automatically and makes
+code splitting simple! Here's an example of how to use [`react-loadable`]:
 
 ```js
-import loadAbout from 'bundle-loader?lazy!./loadAbout'
-import loadDashboard from 'bundle-loader?lazy!./loadDashboard'
+import loadable from 'react-loadable';
+import Loading from './my-loading-component';
 
 // components load their module for initial visit
 const About = (props) => (
@@ -113,35 +51,44 @@ class App extends React.Component {
     loadDashboard(() => {})
   }
 
+export default class App extends React.Component {
   render() {
-    return (
-      <div>
-        <h1>Welcome!</h1>
-        <Route path="/about" component={About}/>
-        <Route path="/dashboard" component={Dashboard}/>
-      </div>
-    )
+    return <LoadableComponent/>;
   }
 }
 ```
 
-When, and how much, of your app to load is your own decision. It need not be tied to specific routes. Maybe you only want to do it when the user is inactive, maybe only when they visit a route, maybe you want to preload the rest of the app after the initial render:
+That's all there is to it! Simply use `LoadableComponent` (or whatever you
+named your component) and it will automatically be loaded and rendered when you
+use it in your application. The `loader` option is a function which actually
+loads the component, and `loading` is a placeholder component to show while the
+real component is loading.
 
-```js
-ReactDOM.render(<App/>, preloadTheRestOfTheApp)
+## Code Splitting and Server-Side Rendering
+
+[`react-loadable`] includes [a guide for server-side rendering][ssr]. All you
+should need to do is include [`babel-plugin-import-inspector`] in your
+`.babelrc` and server-side rendering should just work™. Here is an example
+`.babelrc` file:
+
+```json
+{
+  "presets": [
+    "react"
+  ],
+  "plugins": [
+    "syntax-dynamic-import",
+    ["import-inspector", {
+      "serverSideRequirePath": true
+    }]
+  ]
+}
 ```
 
-## Code-splitting + server rendering
-
-We've tried and failed a couple of times. What we learned:
-
-1. You need synchronous module resolution on the server so you can get those bundles in the initial render.
-2. You need to load all the bundles in the client that were involved in the server render before rendering so that the client render is the same as the server render. (The trickiest part, I think its possible but this is where I gave up.)
-3. You need asynchronous resolution for the rest of the client app's life.
-
-We determined that google was indexing our sites well enough for our needs without server rendering, so we dropped it in favor of code-splitting + service worker caching. Godspeed those who attempt the server-rendered, code-split apps.
-
-  [Webpack]:https://webpack.github.io/
-  [import]:https://github.com/tc39/proposal-dynamic-import
-  [bundle-loader]:https://github.com/webpack-contrib/bundle-loader
-  [for-years]:https://github.com/ReactTraining/react-router/blob/9f43019b26ad625ce4673e6abf5aa0093d7a7ef4/package.json#L17
+  [Babel]: https://babeljs.io/
+  [`babel-plugin-syntax-dynamic-import`]: https://babeljs.io/docs/plugins/syntax-dynamic-import/
+  [`babel-plugin-import-inspector`]: https://github.com/thejameskyle/react-loadable/tree/6902cc87f618446c54daa85d8fecec6836c9461a#babel-plugin-import-inspector
+  [`react-loadable`]: https://github.com/thejameskyle/react-loadable
+  [import]: https://github.com/tc39/proposal-dynamic-import
+  [webpack]: https://webpack.js.org/
+  [ssr]: https://github.com/thejameskyle/react-loadable/tree/6902cc87f618446c54daa85d8fecec6836c9461a#server-side-rendering


### PR DESCRIPTION
Addresses #5418.

I attempted to convert the site to use `react-loadable` which to use properly would require upgrading webpack. I got that updated but I think `lazy-loader` is unhappy. The nav links start to get populated but the guides are just arrays of `undefined`, i.e., the equivalent of the following:

```jsx
      {[undefined, undefined, undefined, ...].map(.map((item, i) => (
        <Block key={i} marginBottom="10px">
          <NavLink
            key={i}
            to={`/${environment}/api/${item.title.slug}`}
            triangleColor="white"
            children={item.title.text}
          />
            ))}
```