### PR TITLE
Update rollup config/deps

### DIFF
--- a/packages/react-router-config/package-lock.json
+++ b/packages/react-router-config/package-lock.json
@@ -1,21 +1,26 @@
 {
-	"requires": true,
+	"name": "react-router-config",
+	"version": "1.0.0-beta.3",
 	"lockfileVersion": 1,
+	"requires": true,
 	"dependencies": {
 		"abab": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/abab/-/abab-1.0.3.tgz",
-			"integrity": "sha1-uB3l9ydOxOdW15fNg08wNkJyTl0="
+			"integrity": "sha1-uB3l9ydOxOdW15fNg08wNkJyTl0=",
+			"dev": true
 		},
 		"acorn": {
 			"version": "5.1.1",
 			"resolved": "https://registry.npmjs.org/acorn/-/acorn-5.1.1.tgz",
-			"integrity": "sha512-vOk6uEMctu0vQrvuSqFdJyqj1Q0S5VTDL79qtjo+DhRr+1mmaD+tluFSCZqhvi/JUhXSzoZN2BhtstaPEeE8cw=="
+			"integrity": "sha512-vOk6uEMctu0vQrvuSqFdJyqj1Q0S5VTDL79qtjo+DhRr+1mmaD+tluFSCZqhvi/JUhXSzoZN2BhtstaPEeE8cw==",
+			"dev": true
 		},
 		"acorn-globals": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-3.1.0.tgz",
 			"integrity": "sha1-/YJw9x+7SZawBPqIDuXUZXOnMb8=",
+			"dev": true,
 			"requires": {
 				"acorn": "4.0.13"
 			},
@@ -23,7 +28,8 @@
 				"acorn": {
 					"version": "4.0.13",
 					"resolved": "https://registry.npmjs.org/acorn/-/acorn-4.0.13.tgz",
-					"integrity": "sha1-EFSVrlNh1pe9GVyCUZLhrX8lN4c="
+					"integrity": "sha1-EFSVrlNh1pe9GVyCUZLhrX8lN4c=",
+					"dev": true
 				}
 			}
 		},
@@ -31,6 +37,7 @@
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-3.0.1.tgz",
 			"integrity": "sha1-r9+UiPsezvyDSPb7IvRk4ypYs2s=",
+			"dev": true,
 			"requires": {
 				"acorn": "3.3.0"
 			},
@@ -38,7 +45,8 @@
 				"acorn": {
 					"version": "3.3.0",
 					"resolved": "https://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz",
-					"integrity": "sha1-ReN/s56No/JbruP/U2niu18iAXo="
+					"integrity": "sha1-ReN/s56No/JbruP/U2niu18iAXo=",
+					"dev": true
 				}
 			}
 		},
@@ -46,6 +54,7 @@
 			"version": "4.11.8",
 			"resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz",
 			"integrity": "sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY=",
+			"dev": true,
 			"requires": {
 				"co": "4.6.0",
 				"json-stable-stringify": "1.0.1"
@@ -54,12 +63,14 @@
 		"ajv-keywords": {
 			"version": "1.5.1",
 			"resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-1.5.1.tgz",
-			"integrity": "sha1-MU3QpLM2j609/NxU7eYXG4htrzw="
+			"integrity": "sha1-MU3QpLM2j609/NxU7eYXG4htrzw=",
+			"dev": true
 		},
 		"align-text": {
 			"version": "0.1.4",
 			"resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
 			"integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
+			"dev": true,
 			"requires": {
 				"kind-of": "3.2.2",
 				"longest": "1.0.1",
@@ -69,27 +80,32 @@
 		"amdefine": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
-			"integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU="
+			"integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU=",
+			"dev": true
 		},
 		"ansi-escapes": {
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-1.4.0.tgz",
-			"integrity": "sha1-06ioOzGapneTZisT52HHkRQiMG4="
+			"integrity": "sha1-06ioOzGapneTZisT52HHkRQiMG4=",
+			"dev": true
 		},
 		"ansi-regex": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-			"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
+			"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+			"dev": true
 		},
 		"ansi-styles": {
 			"version": "2.2.1",
 			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-			"integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
+			"integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+			"dev": true
 		},
 		"anymatch": {
 			"version": "1.3.2",
 			"resolved": "https://registry.npmjs.org/anymatch/-/anymatch-1.3.2.tgz",
 			"integrity": "sha512-0XNayC8lTHQ2OI8aljNCN3sSx6hsr/1+rlcDAotXJR7C1oZZHCNsfpbKwMjRA3Uqb5tF1Rae2oloTr4xpq+WjA==",
+			"dev": true,
 			"requires": {
 				"micromatch": "2.3.11",
 				"normalize-path": "2.1.1"
@@ -99,6 +115,7 @@
 			"version": "0.4.0",
 			"resolved": "https://registry.npmjs.org/append-transform/-/append-transform-0.4.0.tgz",
 			"integrity": "sha1-126/jKlNJ24keja61EpLdKthGZE=",
+			"dev": true,
 			"requires": {
 				"default-require-extensions": "1.0.0"
 			}
@@ -107,6 +124,7 @@
 			"version": "1.0.9",
 			"resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.9.tgz",
 			"integrity": "sha1-c9g7wmP4bpf4zE9rrhsOkKfSLIY=",
+			"dev": true,
 			"requires": {
 				"sprintf-js": "1.0.3"
 			}
@@ -115,6 +133,7 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
 			"integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
+			"dev": true,
 			"requires": {
 				"arr-flatten": "1.1.0"
 			}
@@ -122,17 +141,20 @@
 		"arr-flatten": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
-			"integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg=="
+			"integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg==",
+			"dev": true
 		},
 		"array-equal": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/array-equal/-/array-equal-1.0.0.tgz",
-			"integrity": "sha1-jCpe8kcv2ep0KwTHenUJO6J1fJM="
+			"integrity": "sha1-jCpe8kcv2ep0KwTHenUJO6J1fJM=",
+			"dev": true
 		},
 		"array-union": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
 			"integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
+			"dev": true,
 			"requires": {
 				"array-uniq": "1.0.3"
 			}
@@ -140,37 +162,44 @@
 		"array-uniq": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.3.tgz",
-			"integrity": "sha1-r2rId6Jcx/dOBYiUdThY39sk/bY="
+			"integrity": "sha1-r2rId6Jcx/dOBYiUdThY39sk/bY=",
+			"dev": true
 		},
 		"array-unique": {
 			"version": "0.2.1",
 			"resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
-			"integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM="
+			"integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM=",
+			"dev": true
 		},
 		"arrify": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
-			"integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0="
+			"integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
+			"dev": true
 		},
 		"asap": {
 			"version": "2.0.6",
 			"resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
-			"integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY="
+			"integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY=",
+			"dev": true
 		},
 		"asn1": {
 			"version": "0.2.3",
 			"resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
-			"integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y="
+			"integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y=",
+			"dev": true
 		},
 		"assert-plus": {
 			"version": "0.2.0",
 			"resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
-			"integrity": "sha1-104bh+ev/A24qttwIfP+SBAasjQ="
+			"integrity": "sha1-104bh+ev/A24qttwIfP+SBAasjQ=",
+			"dev": true
 		},
 		"async": {
 			"version": "2.5.0",
 			"resolved": "https://registry.npmjs.org/async/-/async-2.5.0.tgz",
 			"integrity": "sha512-e+lJAJeNWuPCNyxZKOBdaJGyLGHugXVQtrAwtuAe2vhxTYxFTKE73p8JuTmdH0qdQZtDvI4dhJwjZc5zsfIsYw==",
+			"dev": true,
 			"requires": {
 				"lodash": "4.17.4"
 			}
@@ -179,27 +208,32 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/async-each/-/async-each-1.0.1.tgz",
 			"integrity": "sha1-GdOGodntxufByF04iu28xW0zYC0=",
+			"dev": true,
 			"optional": true
 		},
 		"asynckit": {
 			"version": "0.4.0",
 			"resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-			"integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
+			"integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
+			"dev": true
 		},
 		"aws-sign2": {
 			"version": "0.6.0",
 			"resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
-			"integrity": "sha1-FDQt0428yU0OW4fXY81jYSwOeU8="
+			"integrity": "sha1-FDQt0428yU0OW4fXY81jYSwOeU8=",
+			"dev": true
 		},
 		"aws4": {
 			"version": "1.6.0",
 			"resolved": "https://registry.npmjs.org/aws4/-/aws4-1.6.0.tgz",
-			"integrity": "sha1-g+9cqGCysy5KDe7e6MdxudtXRx4="
+			"integrity": "sha1-g+9cqGCysy5KDe7e6MdxudtXRx4=",
+			"dev": true
 		},
 		"babel-cli": {
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-cli/-/babel-cli-6.24.1.tgz",
 			"integrity": "sha1-IHzXBbumFImy6kG1MSNBz2rKIoM=",
+			"dev": true,
 			"requires": {
 				"babel-core": "6.25.0",
 				"babel-polyfill": "6.23.0",
@@ -222,6 +256,7 @@
 			"version": "6.22.0",
 			"resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.22.0.tgz",
 			"integrity": "sha1-AnYgvuVnqIwyVhV05/0IAdMxGOQ=",
+			"dev": true,
 			"requires": {
 				"chalk": "1.1.3",
 				"esutils": "2.0.2",
@@ -232,6 +267,7 @@
 			"version": "6.25.0",
 			"resolved": "https://registry.npmjs.org/babel-core/-/babel-core-6.25.0.tgz",
 			"integrity": "sha1-fdQrBGPHQunVKW3rPsZ6kyLa1yk=",
+			"dev": true,
 			"requires": {
 				"babel-code-frame": "6.22.0",
 				"babel-generator": "6.25.0",
@@ -258,6 +294,7 @@
 			"version": "6.1.2",
 			"resolved": "https://registry.npmjs.org/babel-eslint/-/babel-eslint-6.1.2.tgz",
 			"integrity": "sha1-UpNBn+NnLWZZjTJ9qWlFZ7pqXy8=",
+			"dev": true,
 			"requires": {
 				"babel-traverse": "6.25.0",
 				"babel-types": "6.25.0",
@@ -270,6 +307,7 @@
 			"version": "6.25.0",
 			"resolved": "https://registry.npmjs.org/babel-generator/-/babel-generator-6.25.0.tgz",
 			"integrity": "sha1-M6GvcNXyiQrrRlpKd5PB32qeqfw=",
+			"dev": true,
 			"requires": {
 				"babel-messages": "6.23.0",
 				"babel-runtime": "6.25.0",
@@ -285,6 +323,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-helper-bindify-decorators/-/babel-helper-bindify-decorators-6.24.1.tgz",
 			"integrity": "sha1-FMGeXxQte0fxmlJDHlKxzLxAozA=",
+			"dev": true,
 			"requires": {
 				"babel-runtime": "6.25.0",
 				"babel-traverse": "6.25.0",
@@ -295,6 +334,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-helper-builder-binary-assignment-operator-visitor/-/babel-helper-builder-binary-assignment-operator-visitor-6.24.1.tgz",
 			"integrity": "sha1-zORReto1b0IgvK6KAsKzRvmlZmQ=",
+			"dev": true,
 			"requires": {
 				"babel-helper-explode-assignable-expression": "6.24.1",
 				"babel-runtime": "6.25.0",
@@ -305,6 +345,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-helper-builder-react-jsx/-/babel-helper-builder-react-jsx-6.24.1.tgz",
 			"integrity": "sha1-CteRfjPI11HmRtrKTnfMGTd9LLw=",
+			"dev": true,
 			"requires": {
 				"babel-runtime": "6.25.0",
 				"babel-types": "6.25.0",
@@ -315,6 +356,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-helper-call-delegate/-/babel-helper-call-delegate-6.24.1.tgz",
 			"integrity": "sha1-7Oaqzdx25Bw0YfiL/Fdb0Nqi340=",
+			"dev": true,
 			"requires": {
 				"babel-helper-hoist-variables": "6.24.1",
 				"babel-runtime": "6.25.0",
@@ -326,6 +368,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-helper-define-map/-/babel-helper-define-map-6.24.1.tgz",
 			"integrity": "sha1-epdH8ljYlH0y1RX2qhx70CIEoIA=",
+			"dev": true,
 			"requires": {
 				"babel-helper-function-name": "6.24.1",
 				"babel-runtime": "6.25.0",
@@ -337,6 +380,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-helper-explode-assignable-expression/-/babel-helper-explode-assignable-expression-6.24.1.tgz",
 			"integrity": "sha1-8luCz33BBDPFX3BZLVdGQArCLKo=",
+			"dev": true,
 			"requires": {
 				"babel-runtime": "6.25.0",
 				"babel-traverse": "6.25.0",
@@ -347,6 +391,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-helper-explode-class/-/babel-helper-explode-class-6.24.1.tgz",
 			"integrity": "sha1-fcKjkQ3uAHBW4eMdZAztPVTqqes=",
+			"dev": true,
 			"requires": {
 				"babel-helper-bindify-decorators": "6.24.1",
 				"babel-runtime": "6.25.0",
@@ -358,6 +403,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-helper-function-name/-/babel-helper-function-name-6.24.1.tgz",
 			"integrity": "sha1-00dbjAPtmCQqJbSDUasYOZ01gKk=",
+			"dev": true,
 			"requires": {
 				"babel-helper-get-function-arity": "6.24.1",
 				"babel-runtime": "6.25.0",
@@ -370,6 +416,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-helper-get-function-arity/-/babel-helper-get-function-arity-6.24.1.tgz",
 			"integrity": "sha1-j3eCqpNAfEHTqlCQj4mwMbG2hT0=",
+			"dev": true,
 			"requires": {
 				"babel-runtime": "6.25.0",
 				"babel-types": "6.25.0"
@@ -379,6 +426,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-helper-hoist-variables/-/babel-helper-hoist-variables-6.24.1.tgz",
 			"integrity": "sha1-HssnaJydJVE+rbyZFKc/VAi+enY=",
+			"dev": true,
 			"requires": {
 				"babel-runtime": "6.25.0",
 				"babel-types": "6.25.0"
@@ -388,6 +436,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-helper-optimise-call-expression/-/babel-helper-optimise-call-expression-6.24.1.tgz",
 			"integrity": "sha1-96E0J7qfc/j0+pk8VKl4gtEkQlc=",
+			"dev": true,
 			"requires": {
 				"babel-runtime": "6.25.0",
 				"babel-types": "6.25.0"
@@ -397,6 +446,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-helper-regex/-/babel-helper-regex-6.24.1.tgz",
 			"integrity": "sha1-024i+rEAjXnYhkjjIRaGgShFbOg=",
+			"dev": true,
 			"requires": {
 				"babel-runtime": "6.25.0",
 				"babel-types": "6.25.0",
@@ -407,6 +457,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-helper-remap-async-to-generator/-/babel-helper-remap-async-to-generator-6.24.1.tgz",
 			"integrity": "sha1-XsWBgnrXI/7N04HxySg5BnbkVRs=",
+			"dev": true,
 			"requires": {
 				"babel-helper-function-name": "6.24.1",
 				"babel-runtime": "6.25.0",
@@ -419,6 +470,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-helper-replace-supers/-/babel-helper-replace-supers-6.24.1.tgz",
 			"integrity": "sha1-v22/5Dk40XNpohPKiov3S2qQqxo=",
+			"dev": true,
 			"requires": {
 				"babel-helper-optimise-call-expression": "6.24.1",
 				"babel-messages": "6.23.0",
@@ -432,6 +484,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-helpers/-/babel-helpers-6.24.1.tgz",
 			"integrity": "sha1-NHHenK7DiOXIUOWX5Yom3fN2ArI=",
+			"dev": true,
 			"requires": {
 				"babel-runtime": "6.25.0",
 				"babel-template": "6.25.0"
@@ -441,6 +494,7 @@
 			"version": "20.0.3",
 			"resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-20.0.3.tgz",
 			"integrity": "sha1-5KA7E9wQOJ4UD8ZF0J/8TO0wFnE=",
+			"dev": true,
 			"requires": {
 				"babel-core": "6.25.0",
 				"babel-plugin-istanbul": "4.1.4",
@@ -451,6 +505,7 @@
 			"version": "6.23.0",
 			"resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz",
 			"integrity": "sha1-8830cDhYA1sqKVHG7F7fbGLyYw4=",
+			"dev": true,
 			"requires": {
 				"babel-runtime": "6.25.0"
 			}
@@ -459,6 +514,7 @@
 			"version": "6.22.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-check-es2015-constants/-/babel-plugin-check-es2015-constants-6.22.0.tgz",
 			"integrity": "sha1-NRV7EBQm/S/9PaP3XH0ekYNbv4o=",
+			"dev": true,
 			"requires": {
 				"babel-runtime": "6.25.0"
 			}
@@ -466,12 +522,14 @@
 		"babel-plugin-dev-expression": {
 			"version": "0.2.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-dev-expression/-/babel-plugin-dev-expression-0.2.1.tgz",
-			"integrity": "sha1-1Ke+7++7UOPyc0mQqCokhs+eue4="
+			"integrity": "sha1-1Ke+7++7UOPyc0mQqCokhs+eue4=",
+			"dev": true
 		},
 		"babel-plugin-external-helpers": {
 			"version": "6.22.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-external-helpers/-/babel-plugin-external-helpers-6.22.0.tgz",
 			"integrity": "sha1-IoX0iwK9Xe3oUXXK+MYuhq3M76E=",
+			"dev": true,
 			"requires": {
 				"babel-runtime": "6.25.0"
 			}
@@ -480,6 +538,7 @@
 			"version": "4.1.4",
 			"resolved": "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-4.1.4.tgz",
 			"integrity": "sha1-GN3oS/POMp/d8/QQP66SFFbY5Yc=",
+			"dev": true,
 			"requires": {
 				"find-up": "2.1.0",
 				"istanbul-lib-instrument": "1.7.4",
@@ -490,6 +549,7 @@
 					"version": "2.1.0",
 					"resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
 					"integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+					"dev": true,
 					"requires": {
 						"locate-path": "2.0.0"
 					}
@@ -499,72 +559,86 @@
 		"babel-plugin-jest-hoist": {
 			"version": "20.0.3",
 			"resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-20.0.3.tgz",
-			"integrity": "sha1-r+3IU70/jcNUjqZx++adA8wsF2c="
+			"integrity": "sha1-r+3IU70/jcNUjqZx++adA8wsF2c=",
+			"dev": true
 		},
 		"babel-plugin-syntax-async-functions": {
 			"version": "6.13.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-syntax-async-functions/-/babel-plugin-syntax-async-functions-6.13.0.tgz",
-			"integrity": "sha1-ytnK0RkbWtY0vzCuCHI5HgZHvpU="
+			"integrity": "sha1-ytnK0RkbWtY0vzCuCHI5HgZHvpU=",
+			"dev": true
 		},
 		"babel-plugin-syntax-async-generators": {
 			"version": "6.13.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-syntax-async-generators/-/babel-plugin-syntax-async-generators-6.13.0.tgz",
-			"integrity": "sha1-a8lj67FuzLrmuStZbrfzXDQqi5o="
+			"integrity": "sha1-a8lj67FuzLrmuStZbrfzXDQqi5o=",
+			"dev": true
 		},
 		"babel-plugin-syntax-class-constructor-call": {
 			"version": "6.18.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-syntax-class-constructor-call/-/babel-plugin-syntax-class-constructor-call-6.18.0.tgz",
-			"integrity": "sha1-nLnTn+Q8hgC+yBRkVt3L1OGnZBY="
+			"integrity": "sha1-nLnTn+Q8hgC+yBRkVt3L1OGnZBY=",
+			"dev": true
 		},
 		"babel-plugin-syntax-class-properties": {
 			"version": "6.13.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-syntax-class-properties/-/babel-plugin-syntax-class-properties-6.13.0.tgz",
-			"integrity": "sha1-1+sjt5oxf4VDlixQW4J8fWysJ94="
+			"integrity": "sha1-1+sjt5oxf4VDlixQW4J8fWysJ94=",
+			"dev": true
 		},
 		"babel-plugin-syntax-decorators": {
 			"version": "6.13.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-syntax-decorators/-/babel-plugin-syntax-decorators-6.13.0.tgz",
-			"integrity": "sha1-MSVjtNvePMgGzuPkFszurd0RrAs="
+			"integrity": "sha1-MSVjtNvePMgGzuPkFszurd0RrAs=",
+			"dev": true
 		},
 		"babel-plugin-syntax-dynamic-import": {
 			"version": "6.18.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-syntax-dynamic-import/-/babel-plugin-syntax-dynamic-import-6.18.0.tgz",
-			"integrity": "sha1-jWomIpyDdFqZgqRBBRVyyqF5sdo="
+			"integrity": "sha1-jWomIpyDdFqZgqRBBRVyyqF5sdo=",
+			"dev": true
 		},
 		"babel-plugin-syntax-exponentiation-operator": {
 			"version": "6.13.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-syntax-exponentiation-operator/-/babel-plugin-syntax-exponentiation-operator-6.13.0.tgz",
-			"integrity": "sha1-nufoM3KQ2pUoggGmpX9BcDF4MN4="
+			"integrity": "sha1-nufoM3KQ2pUoggGmpX9BcDF4MN4=",
+			"dev": true
 		},
 		"babel-plugin-syntax-export-extensions": {
 			"version": "6.13.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-syntax-export-extensions/-/babel-plugin-syntax-export-extensions-6.13.0.tgz",
-			"integrity": "sha1-cKFITw+QiaToStRLrDU8lbmxJyE="
+			"integrity": "sha1-cKFITw+QiaToStRLrDU8lbmxJyE=",
+			"dev": true
 		},
 		"babel-plugin-syntax-flow": {
 			"version": "6.18.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-syntax-flow/-/babel-plugin-syntax-flow-6.18.0.tgz",
-			"integrity": "sha1-TDqyCiryaqIM0lmVw5jE63AxDI0="
+			"integrity": "sha1-TDqyCiryaqIM0lmVw5jE63AxDI0=",
+			"dev": true
 		},
 		"babel-plugin-syntax-jsx": {
 			"version": "6.18.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-syntax-jsx/-/babel-plugin-syntax-jsx-6.18.0.tgz",
-			"integrity": "sha1-CvMqmm4Tyno/1QaeYtew9Y0NiUY="
+			"integrity": "sha1-CvMqmm4Tyno/1QaeYtew9Y0NiUY=",
+			"dev": true
 		},
 		"babel-plugin-syntax-object-rest-spread": {
 			"version": "6.13.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-syntax-object-rest-spread/-/babel-plugin-syntax-object-rest-spread-6.13.0.tgz",
-			"integrity": "sha1-/WU28rzhODb/o6VFjEkDpZe7O/U="
+			"integrity": "sha1-/WU28rzhODb/o6VFjEkDpZe7O/U=",
+			"dev": true
 		},
 		"babel-plugin-syntax-trailing-function-commas": {
 			"version": "6.22.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-syntax-trailing-function-commas/-/babel-plugin-syntax-trailing-function-commas-6.22.0.tgz",
-			"integrity": "sha1-ugNgk3+NBuQBgKQ/4NVhb/9TLPM="
+			"integrity": "sha1-ugNgk3+NBuQBgKQ/4NVhb/9TLPM=",
+			"dev": true
 		},
 		"babel-plugin-transform-async-generator-functions": {
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-async-generator-functions/-/babel-plugin-transform-async-generator-functions-6.24.1.tgz",
 			"integrity": "sha1-8FiQAUX9PpkHpt3yjaWfIVJYpds=",
+			"dev": true,
 			"requires": {
 				"babel-helper-remap-async-to-generator": "6.24.1",
 				"babel-plugin-syntax-async-generators": "6.13.0",
@@ -575,6 +649,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-async-to-generator/-/babel-plugin-transform-async-to-generator-6.24.1.tgz",
 			"integrity": "sha1-ZTbjeK/2yx1VF6wOQOs+n8jQh2E=",
+			"dev": true,
 			"requires": {
 				"babel-helper-remap-async-to-generator": "6.24.1",
 				"babel-plugin-syntax-async-functions": "6.13.0",
@@ -585,6 +660,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-class-constructor-call/-/babel-plugin-transform-class-constructor-call-6.24.1.tgz",
 			"integrity": "sha1-gNwoVQWsBn3LjWxl4vbxGrd2Xvk=",
+			"dev": true,
 			"requires": {
 				"babel-plugin-syntax-class-constructor-call": "6.18.0",
 				"babel-runtime": "6.25.0",
@@ -595,6 +671,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-class-properties/-/babel-plugin-transform-class-properties-6.24.1.tgz",
 			"integrity": "sha1-anl2PqYdM9NvN7YRqp3vgagbRqw=",
+			"dev": true,
 			"requires": {
 				"babel-helper-function-name": "6.24.1",
 				"babel-plugin-syntax-class-properties": "6.13.0",
@@ -606,6 +683,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-decorators/-/babel-plugin-transform-decorators-6.24.1.tgz",
 			"integrity": "sha1-eIAT2PjGtSIr33s0Q5Df13Vp4k0=",
+			"dev": true,
 			"requires": {
 				"babel-helper-explode-class": "6.24.1",
 				"babel-plugin-syntax-decorators": "6.13.0",
@@ -618,6 +696,7 @@
 			"version": "6.22.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-arrow-functions/-/babel-plugin-transform-es2015-arrow-functions-6.22.0.tgz",
 			"integrity": "sha1-RSaSy3EdX3ncf4XkQM5BufJE0iE=",
+			"dev": true,
 			"requires": {
 				"babel-runtime": "6.25.0"
 			}
@@ -626,6 +705,7 @@
 			"version": "6.22.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoped-functions/-/babel-plugin-transform-es2015-block-scoped-functions-6.22.0.tgz",
 			"integrity": "sha1-u8UbSflk1wy42OC5ToICRs46YUE=",
+			"dev": true,
 			"requires": {
 				"babel-runtime": "6.25.0"
 			}
@@ -634,6 +714,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoping/-/babel-plugin-transform-es2015-block-scoping-6.24.1.tgz",
 			"integrity": "sha1-dsKV3DpHQbFmWt/TFnIV3P8ypXY=",
+			"dev": true,
 			"requires": {
 				"babel-runtime": "6.25.0",
 				"babel-template": "6.25.0",
@@ -646,6 +727,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-classes/-/babel-plugin-transform-es2015-classes-6.24.1.tgz",
 			"integrity": "sha1-WkxYpQyclGHlZLSyo7+ryXolhNs=",
+			"dev": true,
 			"requires": {
 				"babel-helper-define-map": "6.24.1",
 				"babel-helper-function-name": "6.24.1",
@@ -662,6 +744,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-computed-properties/-/babel-plugin-transform-es2015-computed-properties-6.24.1.tgz",
 			"integrity": "sha1-b+Ko0WiV1WNPTNmZttNICjCBWbM=",
+			"dev": true,
 			"requires": {
 				"babel-runtime": "6.25.0",
 				"babel-template": "6.25.0"
@@ -671,6 +754,7 @@
 			"version": "6.23.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-destructuring/-/babel-plugin-transform-es2015-destructuring-6.23.0.tgz",
 			"integrity": "sha1-mXux8auWf2gtKwh2/jWNYOdlxW0=",
+			"dev": true,
 			"requires": {
 				"babel-runtime": "6.25.0"
 			}
@@ -679,6 +763,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-duplicate-keys/-/babel-plugin-transform-es2015-duplicate-keys-6.24.1.tgz",
 			"integrity": "sha1-c+s9MQypaePvnskcU3QabxV2Qj4=",
+			"dev": true,
 			"requires": {
 				"babel-runtime": "6.25.0",
 				"babel-types": "6.25.0"
@@ -688,6 +773,7 @@
 			"version": "6.23.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-for-of/-/babel-plugin-transform-es2015-for-of-6.23.0.tgz",
 			"integrity": "sha1-9HyVsrYT3x0+zC/bdXNiPHUkhpE=",
+			"dev": true,
 			"requires": {
 				"babel-runtime": "6.25.0"
 			}
@@ -696,6 +782,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-function-name/-/babel-plugin-transform-es2015-function-name-6.24.1.tgz",
 			"integrity": "sha1-g0yJhTvDaxrw86TF26qU/Y6sqos=",
+			"dev": true,
 			"requires": {
 				"babel-helper-function-name": "6.24.1",
 				"babel-runtime": "6.25.0",
@@ -706,6 +793,7 @@
 			"version": "6.22.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-literals/-/babel-plugin-transform-es2015-literals-6.22.0.tgz",
 			"integrity": "sha1-T1SgLWzWbPkVKAAZox0xklN3yi4=",
+			"dev": true,
 			"requires": {
 				"babel-runtime": "6.25.0"
 			}
@@ -714,6 +802,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-amd/-/babel-plugin-transform-es2015-modules-amd-6.24.1.tgz",
 			"integrity": "sha1-Oz5UAXI5hC1tGcMBHEvS8AoA0VQ=",
+			"dev": true,
 			"requires": {
 				"babel-plugin-transform-es2015-modules-commonjs": "6.24.1",
 				"babel-runtime": "6.25.0",
@@ -724,6 +813,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-commonjs/-/babel-plugin-transform-es2015-modules-commonjs-6.24.1.tgz",
 			"integrity": "sha1-0+MQtA72ZKNmIiAAl8bUQCmPK/4=",
+			"dev": true,
 			"requires": {
 				"babel-plugin-transform-strict-mode": "6.24.1",
 				"babel-runtime": "6.25.0",
@@ -735,6 +825,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-systemjs/-/babel-plugin-transform-es2015-modules-systemjs-6.24.1.tgz",
 			"integrity": "sha1-/4mhQrkRmpBhlfXxBuzzBdlAfSM=",
+			"dev": true,
 			"requires": {
 				"babel-helper-hoist-variables": "6.24.1",
 				"babel-runtime": "6.25.0",
@@ -745,6 +836,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-umd/-/babel-plugin-transform-es2015-modules-umd-6.24.1.tgz",
 			"integrity": "sha1-rJl+YoXNGO1hdq22B9YCNErThGg=",
+			"dev": true,
 			"requires": {
 				"babel-plugin-transform-es2015-modules-amd": "6.24.1",
 				"babel-runtime": "6.25.0",
@@ -755,6 +847,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-object-super/-/babel-plugin-transform-es2015-object-super-6.24.1.tgz",
 			"integrity": "sha1-JM72muIcuDp/hgPa0CH1cusnj40=",
+			"dev": true,
 			"requires": {
 				"babel-helper-replace-supers": "6.24.1",
 				"babel-runtime": "6.25.0"
@@ -764,6 +857,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-parameters/-/babel-plugin-transform-es2015-parameters-6.24.1.tgz",
 			"integrity": "sha1-V6w1GrScrxSpfNE7CfZv3wpiXys=",
+			"dev": true,
 			"requires": {
 				"babel-helper-call-delegate": "6.24.1",
 				"babel-helper-get-function-arity": "6.24.1",
@@ -777,6 +871,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-shorthand-properties/-/babel-plugin-transform-es2015-shorthand-properties-6.24.1.tgz",
 			"integrity": "sha1-JPh11nIch2YbvZmkYi5R8U3jiqA=",
+			"dev": true,
 			"requires": {
 				"babel-runtime": "6.25.0",
 				"babel-types": "6.25.0"
@@ -786,6 +881,7 @@
 			"version": "6.22.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-spread/-/babel-plugin-transform-es2015-spread-6.22.0.tgz",
 			"integrity": "sha1-1taKmfia7cRTbIGlQujdnxdG+NE=",
+			"dev": true,
 			"requires": {
 				"babel-runtime": "6.25.0"
 			}
@@ -794,6 +890,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-sticky-regex/-/babel-plugin-transform-es2015-sticky-regex-6.24.1.tgz",
 			"integrity": "sha1-AMHNsaynERLN8M9hJsLta0V8zbw=",
+			"dev": true,
 			"requires": {
 				"babel-helper-regex": "6.24.1",
 				"babel-runtime": "6.25.0",
@@ -804,6 +901,7 @@
 			"version": "6.22.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-template-literals/-/babel-plugin-transform-es2015-template-literals-6.22.0.tgz",
 			"integrity": "sha1-qEs0UPfp+PH2g51taH2oS7EjbY0=",
+			"dev": true,
 			"requires": {
 				"babel-runtime": "6.25.0"
 			}
@@ -812,6 +910,7 @@
 			"version": "6.23.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-typeof-symbol/-/babel-plugin-transform-es2015-typeof-symbol-6.23.0.tgz",
 			"integrity": "sha1-3sCfHN3/lLUqxz1QXITfWdzOs3I=",
+			"dev": true,
 			"requires": {
 				"babel-runtime": "6.25.0"
 			}
@@ -820,6 +919,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-unicode-regex/-/babel-plugin-transform-es2015-unicode-regex-6.24.1.tgz",
 			"integrity": "sha1-04sS9C6nMj9yk4fxinxa4frrNek=",
+			"dev": true,
 			"requires": {
 				"babel-helper-regex": "6.24.1",
 				"babel-runtime": "6.25.0",
@@ -830,6 +930,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-exponentiation-operator/-/babel-plugin-transform-exponentiation-operator-6.24.1.tgz",
 			"integrity": "sha1-KrDJx/MJj6SJB3cruBP+QejeOg4=",
+			"dev": true,
 			"requires": {
 				"babel-helper-builder-binary-assignment-operator-visitor": "6.24.1",
 				"babel-plugin-syntax-exponentiation-operator": "6.13.0",
@@ -840,6 +941,7 @@
 			"version": "6.22.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-export-extensions/-/babel-plugin-transform-export-extensions-6.22.0.tgz",
 			"integrity": "sha1-U3OLR+deghhYnuqUbLvTkQm75lM=",
+			"dev": true,
 			"requires": {
 				"babel-plugin-syntax-export-extensions": "6.13.0",
 				"babel-runtime": "6.25.0"
@@ -849,6 +951,7 @@
 			"version": "6.22.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-flow-strip-types/-/babel-plugin-transform-flow-strip-types-6.22.0.tgz",
 			"integrity": "sha1-hMtnKTXUNxT9wyvOhFaNh0Qc988=",
+			"dev": true,
 			"requires": {
 				"babel-plugin-syntax-flow": "6.18.0",
 				"babel-runtime": "6.25.0"
@@ -858,6 +961,7 @@
 			"version": "6.23.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-object-rest-spread/-/babel-plugin-transform-object-rest-spread-6.23.0.tgz",
 			"integrity": "sha1-h11ryb52HFiirj/u5dxIldjH+SE=",
+			"dev": true,
 			"requires": {
 				"babel-plugin-syntax-object-rest-spread": "6.13.0",
 				"babel-runtime": "6.25.0"
@@ -867,6 +971,7 @@
 			"version": "6.25.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-react-display-name/-/babel-plugin-transform-react-display-name-6.25.0.tgz",
 			"integrity": "sha1-Z+K/Hx6ck6sI25Z5LgU5K/LMKNE=",
+			"dev": true,
 			"requires": {
 				"babel-runtime": "6.25.0"
 			}
@@ -875,6 +980,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-react-jsx/-/babel-plugin-transform-react-jsx-6.24.1.tgz",
 			"integrity": "sha1-hAoCjn30YN/DotKfDA2R9jduZqM=",
+			"dev": true,
 			"requires": {
 				"babel-helper-builder-react-jsx": "6.24.1",
 				"babel-plugin-syntax-jsx": "6.18.0",
@@ -885,6 +991,7 @@
 			"version": "6.22.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-react-jsx-self/-/babel-plugin-transform-react-jsx-self-6.22.0.tgz",
 			"integrity": "sha1-322AqdomEqEh5t3XVYvL7PBuY24=",
+			"dev": true,
 			"requires": {
 				"babel-plugin-syntax-jsx": "6.18.0",
 				"babel-runtime": "6.25.0"
@@ -894,6 +1001,7 @@
 			"version": "6.22.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-react-jsx-source/-/babel-plugin-transform-react-jsx-source-6.22.0.tgz",
 			"integrity": "sha1-ZqwSFT9c0tF7PBkmj0vwGX9E7NY=",
+			"dev": true,
 			"requires": {
 				"babel-plugin-syntax-jsx": "6.18.0",
 				"babel-runtime": "6.25.0"
@@ -902,12 +1010,14 @@
 		"babel-plugin-transform-react-remove-prop-types": {
 			"version": "0.2.12",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-react-remove-prop-types/-/babel-plugin-transform-react-remove-prop-types-0.2.12.tgz",
-			"integrity": "sha1-NAZpbfC4tFYIn51ybSfn4SPS+Sk="
+			"integrity": "sha1-NAZpbfC4tFYIn51ybSfn4SPS+Sk=",
+			"dev": true
 		},
 		"babel-plugin-transform-regenerator": {
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-regenerator/-/babel-plugin-transform-regenerator-6.24.1.tgz",
 			"integrity": "sha1-uNowWtQ8PJm0hI5P5AN7dw0jxBg=",
+			"dev": true,
 			"requires": {
 				"regenerator-transform": "0.9.11"
 			}
@@ -916,6 +1026,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-strict-mode/-/babel-plugin-transform-strict-mode-6.24.1.tgz",
 			"integrity": "sha1-1fr3qleKZbvlkc9e2uBKDGcCB1g=",
+			"dev": true,
 			"requires": {
 				"babel-runtime": "6.25.0",
 				"babel-types": "6.25.0"
@@ -925,6 +1036,7 @@
 			"version": "6.23.0",
 			"resolved": "https://registry.npmjs.org/babel-polyfill/-/babel-polyfill-6.23.0.tgz",
 			"integrity": "sha1-g2TKYt+Or7gwSZ9pkXdGbDsDSZ0=",
+			"dev": true,
 			"requires": {
 				"babel-runtime": "6.25.0",
 				"core-js": "2.4.1",
@@ -935,6 +1047,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-preset-es2015/-/babel-preset-es2015-6.24.1.tgz",
 			"integrity": "sha1-1EBQ1rwsn+6nAqrzjXJ6AhBTiTk=",
+			"dev": true,
 			"requires": {
 				"babel-plugin-check-es2015-constants": "6.22.0",
 				"babel-plugin-transform-es2015-arrow-functions": "6.22.0",
@@ -966,6 +1079,7 @@
 			"version": "6.23.0",
 			"resolved": "https://registry.npmjs.org/babel-preset-flow/-/babel-preset-flow-6.23.0.tgz",
 			"integrity": "sha1-5xIYiHCFrpoktb5Baa/7WZgWxJ0=",
+			"dev": true,
 			"requires": {
 				"babel-plugin-transform-flow-strip-types": "6.22.0"
 			}
@@ -974,6 +1088,7 @@
 			"version": "20.0.3",
 			"resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-20.0.3.tgz",
 			"integrity": "sha1-y6yq3stdaJyh4d4TYOv8ZoYsF4o=",
+			"dev": true,
 			"requires": {
 				"babel-plugin-jest-hoist": "20.0.3"
 			}
@@ -982,6 +1097,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-preset-react/-/babel-preset-react-6.24.1.tgz",
 			"integrity": "sha1-umnfrqRfw+xjm2pOzqbhdwLJE4A=",
+			"dev": true,
 			"requires": {
 				"babel-plugin-syntax-jsx": "6.18.0",
 				"babel-plugin-transform-react-display-name": "6.25.0",
@@ -995,6 +1111,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-preset-stage-1/-/babel-preset-stage-1-6.24.1.tgz",
 			"integrity": "sha1-dpLNfc1oSZB+auSgqFWJz7niv7A=",
+			"dev": true,
 			"requires": {
 				"babel-plugin-transform-class-constructor-call": "6.24.1",
 				"babel-plugin-transform-export-extensions": "6.22.0",
@@ -1005,6 +1122,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-preset-stage-2/-/babel-preset-stage-2-6.24.1.tgz",
 			"integrity": "sha1-2eKWD7PXEYfw5k7sYrwHdnIZvcE=",
+			"dev": true,
 			"requires": {
 				"babel-plugin-syntax-dynamic-import": "6.18.0",
 				"babel-plugin-transform-class-properties": "6.24.1",
@@ -1016,6 +1134,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-preset-stage-3/-/babel-preset-stage-3-6.24.1.tgz",
 			"integrity": "sha1-g2raCp56f6N8sTj7kyb4eTSkg5U=",
+			"dev": true,
 			"requires": {
 				"babel-plugin-syntax-trailing-function-commas": "6.22.0",
 				"babel-plugin-transform-async-generator-functions": "6.24.1",
@@ -1028,6 +1147,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-register/-/babel-register-6.24.1.tgz",
 			"integrity": "sha1-fhDhOi9xBlvfrVoXh7pFvKbe118=",
+			"dev": true,
 			"requires": {
 				"babel-core": "6.25.0",
 				"babel-runtime": "6.25.0",
@@ -1042,6 +1162,7 @@
 			"version": "6.25.0",
 			"resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.25.0.tgz",
 			"integrity": "sha1-M7mOql1IK7AajRqmtDetKwGuxBw=",
+			"dev": true,
 			"requires": {
 				"core-js": "2.4.1",
 				"regenerator-runtime": "0.10.5"
@@ -1051,6 +1172,7 @@
 			"version": "6.25.0",
 			"resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.25.0.tgz",
 			"integrity": "sha1-ZlJBFmt8KqTGGdceGSlpVSsQwHE=",
+			"dev": true,
 			"requires": {
 				"babel-runtime": "6.25.0",
 				"babel-traverse": "6.25.0",
@@ -1063,6 +1185,7 @@
 			"version": "6.25.0",
 			"resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.25.0.tgz",
 			"integrity": "sha1-IldJfi/NGbie3BPEyROB+VEklvE=",
+			"dev": true,
 			"requires": {
 				"babel-code-frame": "6.22.0",
 				"babel-messages": "6.23.0",
@@ -1079,6 +1202,7 @@
 			"version": "6.25.0",
 			"resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.25.0.tgz",
 			"integrity": "sha1-cK+ySNVmDl0Y+BHZHIMDtUE0oY4=",
+			"dev": true,
 			"requires": {
 				"babel-runtime": "6.25.0",
 				"esutils": "2.0.2",
@@ -1089,17 +1213,20 @@
 		"babylon": {
 			"version": "6.17.4",
 			"resolved": "https://registry.npmjs.org/babylon/-/babylon-6.17.4.tgz",
-			"integrity": "sha512-kChlV+0SXkjE0vUn9OZ7pBMWRFd8uq3mZe8x1K6jhuNcAFAtEnjchFAqB+dYEXKyd+JpT6eppRR78QAr5gTsUw=="
+			"integrity": "sha512-kChlV+0SXkjE0vUn9OZ7pBMWRFd8uq3mZe8x1K6jhuNcAFAtEnjchFAqB+dYEXKyd+JpT6eppRR78QAr5gTsUw==",
+			"dev": true
 		},
 		"balanced-match": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-			"integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
+			"integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+			"dev": true
 		},
 		"bcrypt-pbkdf": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
 			"integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
+			"dev": true,
 			"optional": true,
 			"requires": {
 				"tweetnacl": "0.14.5"
@@ -1109,12 +1236,14 @@
 			"version": "1.9.0",
 			"resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.9.0.tgz",
 			"integrity": "sha1-ZlBsFs5vTWkopbPNajPKQelB43s=",
+			"dev": true,
 			"optional": true
 		},
 		"boom": {
 			"version": "2.10.1",
 			"resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
 			"integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
+			"dev": true,
 			"requires": {
 				"hoek": "2.16.3"
 			}
@@ -1123,6 +1252,7 @@
 			"version": "1.1.8",
 			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
 			"integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
+			"dev": true,
 			"requires": {
 				"balanced-match": "1.0.0",
 				"concat-map": "0.0.1"
@@ -1132,6 +1262,7 @@
 			"version": "1.8.5",
 			"resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
 			"integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
+			"dev": true,
 			"requires": {
 				"expand-range": "1.8.2",
 				"preserve": "0.2.0",
@@ -1142,6 +1273,7 @@
 			"version": "1.11.2",
 			"resolved": "https://registry.npmjs.org/browser-resolve/-/browser-resolve-1.11.2.tgz",
 			"integrity": "sha1-j/CbCixCFxihBRwmCzLkj0QpOM4=",
+			"dev": true,
 			"requires": {
 				"resolve": "1.1.7"
 			},
@@ -1149,7 +1281,8 @@
 				"resolve": {
 					"version": "1.1.7",
 					"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
-					"integrity": "sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs="
+					"integrity": "sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs=",
+					"dev": true
 				}
 			}
 		},
@@ -1157,6 +1290,7 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/bser/-/bser-2.0.0.tgz",
 			"integrity": "sha1-mseNPtXZFYBP2HrLFYvHlxR6Fxk=",
+			"dev": true,
 			"requires": {
 				"node-int64": "0.4.0"
 			}
@@ -1164,12 +1298,14 @@
 		"builtin-modules": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
-			"integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8="
+			"integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=",
+			"dev": true
 		},
 		"caller-path": {
 			"version": "0.1.0",
 			"resolved": "https://registry.npmjs.org/caller-path/-/caller-path-0.1.0.tgz",
 			"integrity": "sha1-lAhe9jWB7NPaqSREqP6U6CV3dR8=",
+			"dev": true,
 			"requires": {
 				"callsites": "0.2.0"
 			}
@@ -1177,23 +1313,27 @@
 		"callsites": {
 			"version": "0.2.0",
 			"resolved": "https://registry.npmjs.org/callsites/-/callsites-0.2.0.tgz",
-			"integrity": "sha1-r6uWJikQp/M8GaV3WCXGnzTjUMo="
+			"integrity": "sha1-r6uWJikQp/M8GaV3WCXGnzTjUMo=",
+			"dev": true
 		},
 		"camelcase": {
 			"version": "1.2.1",
 			"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
 			"integrity": "sha1-m7UwTS4LVmmLLHWLCKPqqdqlijk=",
+			"dev": true,
 			"optional": true
 		},
 		"caseless": {
 			"version": "0.12.0",
 			"resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
-			"integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
+			"integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
+			"dev": true
 		},
 		"center-align": {
 			"version": "0.1.3",
 			"resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
 			"integrity": "sha1-qg0yYptu6XIgBBHL1EYckHvCt60=",
+			"dev": true,
 			"optional": true,
 			"requires": {
 				"align-text": "0.1.4",
@@ -1204,6 +1344,7 @@
 			"version": "1.1.3",
 			"resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
 			"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+			"dev": true,
 			"requires": {
 				"ansi-styles": "2.2.1",
 				"escape-string-regexp": "1.0.5",
@@ -1216,11 +1357,11 @@
 			"version": "1.7.0",
 			"resolved": "https://registry.npmjs.org/chokidar/-/chokidar-1.7.0.tgz",
 			"integrity": "sha1-eY5ol3gVHIB2tLNg5e3SjNortGg=",
+			"dev": true,
 			"optional": true,
 			"requires": {
 				"anymatch": "1.3.2",
 				"async-each": "1.0.1",
-				"fsevents": "1.1.2",
 				"glob-parent": "2.0.0",
 				"inherits": "2.0.3",
 				"is-binary-path": "1.0.1",
@@ -1232,17 +1373,20 @@
 		"ci-info": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/ci-info/-/ci-info-1.0.0.tgz",
-			"integrity": "sha1-3FKF8rTiUYIWg2gcOBwziPRuxTQ="
+			"integrity": "sha1-3FKF8rTiUYIWg2gcOBwziPRuxTQ=",
+			"dev": true
 		},
 		"circular-json": {
 			"version": "0.3.3",
 			"resolved": "https://registry.npmjs.org/circular-json/-/circular-json-0.3.3.tgz",
-			"integrity": "sha512-UZK3NBx2Mca+b5LsG7bY183pHWt5Y1xts4P3Pz7ENTwGVnJOUWbRb3ocjvX7hx9tq/yTAdclXm9sZ38gNuem4A=="
+			"integrity": "sha512-UZK3NBx2Mca+b5LsG7bY183pHWt5Y1xts4P3Pz7ENTwGVnJOUWbRb3ocjvX7hx9tq/yTAdclXm9sZ38gNuem4A==",
+			"dev": true
 		},
 		"cli-cursor": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-1.0.2.tgz",
 			"integrity": "sha1-ZNo/fValRBLll5S9Ytw1KV6PKYc=",
+			"dev": true,
 			"requires": {
 				"restore-cursor": "1.0.1"
 			}
@@ -1250,12 +1394,14 @@
 		"cli-width": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.1.0.tgz",
-			"integrity": "sha1-sjTKIJsp72b8UY2bmNWEewDt8Ao="
+			"integrity": "sha1-sjTKIJsp72b8UY2bmNWEewDt8Ao=",
+			"dev": true
 		},
 		"cliui": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
 			"integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
+			"dev": true,
 			"optional": true,
 			"requires": {
 				"center-align": "0.1.3",
@@ -1267,6 +1413,7 @@
 					"version": "0.0.2",
 					"resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
 					"integrity": "sha1-t5Zpu0LstAn4PVg8rVLKF+qhZD8=",
+					"dev": true,
 					"optional": true
 				}
 			}
@@ -1274,17 +1421,20 @@
 		"co": {
 			"version": "4.6.0",
 			"resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
-			"integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ="
+			"integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
+			"dev": true
 		},
 		"code-point-at": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
-			"integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
+			"integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
+			"dev": true
 		},
 		"color-convert": {
 			"version": "1.9.0",
 			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.0.tgz",
 			"integrity": "sha1-Gsz5fdc5uYO/mU1W/sj5WFNkG3o=",
+			"dev": true,
 			"requires": {
 				"color-name": "1.1.3"
 			}
@@ -1292,12 +1442,14 @@
 		"color-name": {
 			"version": "1.1.3",
 			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-			"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
+			"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+			"dev": true
 		},
 		"combined-stream": {
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
 			"integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
+			"dev": true,
 			"requires": {
 				"delayed-stream": "1.0.0"
 			}
@@ -1305,17 +1457,20 @@
 		"commander": {
 			"version": "2.11.0",
 			"resolved": "https://registry.npmjs.org/commander/-/commander-2.11.0.tgz",
-			"integrity": "sha512-b0553uYA5YAEGgyYIGYROzKQ7X5RAqedkfjiZxwi0kL1g3bOaBNNZfYkzt/CL0umgD5wc9Jec2FbB98CjkMRvQ=="
+			"integrity": "sha512-b0553uYA5YAEGgyYIGYROzKQ7X5RAqedkfjiZxwi0kL1g3bOaBNNZfYkzt/CL0umgD5wc9Jec2FbB98CjkMRvQ==",
+			"dev": true
 		},
 		"concat-map": {
 			"version": "0.0.1",
 			"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-			"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+			"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+			"dev": true
 		},
 		"concat-stream": {
 			"version": "1.6.0",
 			"resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.0.tgz",
 			"integrity": "sha1-CqxmL9Ur54lk1VMvaUeE5wEQrPc=",
+			"dev": true,
 			"requires": {
 				"inherits": "2.0.3",
 				"readable-stream": "2.3.3",
@@ -1325,32 +1480,38 @@
 		"contains-path": {
 			"version": "0.1.0",
 			"resolved": "https://registry.npmjs.org/contains-path/-/contains-path-0.1.0.tgz",
-			"integrity": "sha1-/ozxhP9mcLa67wGp1IYaXL7EEgo="
+			"integrity": "sha1-/ozxhP9mcLa67wGp1IYaXL7EEgo=",
+			"dev": true
 		},
 		"content-type-parser": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/content-type-parser/-/content-type-parser-1.0.1.tgz",
-			"integrity": "sha1-w+VpiMU8ZRJ/tG1AMqOpACRv3JQ="
+			"integrity": "sha1-w+VpiMU8ZRJ/tG1AMqOpACRv3JQ=",
+			"dev": true
 		},
 		"convert-source-map": {
 			"version": "1.5.0",
 			"resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.5.0.tgz",
-			"integrity": "sha1-ms1whRxtXf3ZPZKC5e35SgP/RrU="
+			"integrity": "sha1-ms1whRxtXf3ZPZKC5e35SgP/RrU=",
+			"dev": true
 		},
 		"core-js": {
 			"version": "2.4.1",
 			"resolved": "https://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz",
-			"integrity": "sha1-TekR5mew6ukSTjQlS1OupvxhjT4="
+			"integrity": "sha1-TekR5mew6ukSTjQlS1OupvxhjT4=",
+			"dev": true
 		},
 		"core-util-is": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-			"integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+			"integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+			"dev": true
 		},
 		"create-react-class": {
 			"version": "15.6.0",
 			"resolved": "https://registry.npmjs.org/create-react-class/-/create-react-class-15.6.0.tgz",
 			"integrity": "sha1-q0SEl8JlZuHilBPogyB9V8/nvtQ=",
+			"dev": true,
 			"requires": {
 				"fbjs": "0.8.14",
 				"loose-envify": "1.3.1",
@@ -1361,6 +1522,7 @@
 			"version": "2.0.5",
 			"resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
 			"integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
+			"dev": true,
 			"requires": {
 				"boom": "2.10.1"
 			}
@@ -1368,12 +1530,14 @@
 		"cssom": {
 			"version": "0.3.2",
 			"resolved": "https://registry.npmjs.org/cssom/-/cssom-0.3.2.tgz",
-			"integrity": "sha1-uANhcMefB6kP8vFuIihAJ6JDhIs="
+			"integrity": "sha1-uANhcMefB6kP8vFuIihAJ6JDhIs=",
+			"dev": true
 		},
 		"cssstyle": {
 			"version": "0.2.37",
 			"resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-0.2.37.tgz",
 			"integrity": "sha1-VBCXI0yyUTyDzu06zdwn/yeYfVQ=",
+			"dev": true,
 			"requires": {
 				"cssom": "0.3.2"
 			}
@@ -1382,6 +1546,7 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/d/-/d-1.0.0.tgz",
 			"integrity": "sha1-dUu1v+VUUdpppYuU1F9MWwRi1Y8=",
+			"dev": true,
 			"requires": {
 				"es5-ext": "0.10.26"
 			}
@@ -1390,6 +1555,7 @@
 			"version": "1.14.1",
 			"resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
 			"integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
+			"dev": true,
 			"requires": {
 				"assert-plus": "1.0.0"
 			},
@@ -1397,7 +1563,8 @@
 				"assert-plus": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-					"integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
+					"integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+					"dev": true
 				}
 			}
 		},
@@ -1405,6 +1572,7 @@
 			"version": "2.6.8",
 			"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
 			"integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw=",
+			"dev": true,
 			"requires": {
 				"ms": "2.0.0"
 			}
@@ -1412,17 +1580,20 @@
 		"decamelize": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
-			"integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA="
+			"integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
+			"dev": true
 		},
 		"deep-is": {
 			"version": "0.1.3",
 			"resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
-			"integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ="
+			"integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
+			"dev": true
 		},
 		"default-require-extensions": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/default-require-extensions/-/default-require-extensions-1.0.0.tgz",
 			"integrity": "sha1-836hXT4T/9m0N9M+GnW1+5eHTLg=",
+			"dev": true,
 			"requires": {
 				"strip-bom": "2.0.0"
 			}
@@ -1431,6 +1602,7 @@
 			"version": "2.2.2",
 			"resolved": "https://registry.npmjs.org/del/-/del-2.2.2.tgz",
 			"integrity": "sha1-wSyYHQZ4RshLyvhiz/kw2Qf/0ag=",
+			"dev": true,
 			"requires": {
 				"globby": "5.0.0",
 				"is-path-cwd": "1.0.0",
@@ -1444,12 +1616,14 @@
 		"delayed-stream": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-			"integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
+			"integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
+			"dev": true
 		},
 		"detect-indent": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-4.0.0.tgz",
 			"integrity": "sha1-920GQ1LN9Docts5hnE7jqUdd4gg=",
+			"dev": true,
 			"requires": {
 				"repeating": "2.0.1"
 			}
@@ -1457,12 +1631,14 @@
 		"diff": {
 			"version": "3.3.0",
 			"resolved": "https://registry.npmjs.org/diff/-/diff-3.3.0.tgz",
-			"integrity": "sha512-w0XZubFWn0Adlsapj9EAWX0FqWdO4tz8kc3RiYdWLh4k/V8PTb6i0SMgXt0vRM3zyKnT8tKO7mUlieRQHIjMNg=="
+			"integrity": "sha512-w0XZubFWn0Adlsapj9EAWX0FqWdO4tz8kc3RiYdWLh4k/V8PTb6i0SMgXt0vRM3zyKnT8tKO7mUlieRQHIjMNg==",
+			"dev": true
 		},
 		"doctrine": {
 			"version": "1.5.0",
 			"resolved": "https://registry.npmjs.org/doctrine/-/doctrine-1.5.0.tgz",
 			"integrity": "sha1-N53Ocw9hZvds76TmcHoVmwLFpvo=",
+			"dev": true,
 			"requires": {
 				"esutils": "2.0.2",
 				"isarray": "1.0.0"
@@ -1471,12 +1647,14 @@
 		"duplexer": {
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz",
-			"integrity": "sha1-rOb/gIwc5mtX0ev5eXessCM0z8E="
+			"integrity": "sha1-rOb/gIwc5mtX0ev5eXessCM0z8E=",
+			"dev": true
 		},
 		"ecc-jsbn": {
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
 			"integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
+			"dev": true,
 			"optional": true,
 			"requires": {
 				"jsbn": "0.1.1"
@@ -1486,6 +1664,7 @@
 			"version": "0.1.12",
 			"resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
 			"integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
+			"dev": true,
 			"requires": {
 				"iconv-lite": "0.4.13"
 			}
@@ -1494,6 +1673,7 @@
 			"version": "0.1.4",
 			"resolved": "https://registry.npmjs.org/errno/-/errno-0.1.4.tgz",
 			"integrity": "sha1-uJbiOp5ei6M4cfyZar02NfyaHH0=",
+			"dev": true,
 			"requires": {
 				"prr": "0.0.0"
 			}
@@ -1502,6 +1682,7 @@
 			"version": "1.3.1",
 			"resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.1.tgz",
 			"integrity": "sha1-+FWobOYa3E6GIcPNoh56dhLDqNw=",
+			"dev": true,
 			"requires": {
 				"is-arrayish": "0.2.1"
 			}
@@ -1510,6 +1691,7 @@
 			"version": "0.10.26",
 			"resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.26.tgz",
 			"integrity": "sha1-UbISilMbcMT2dkCTpzy+u4IYY3I=",
+			"dev": true,
 			"requires": {
 				"es6-iterator": "2.0.1",
 				"es6-symbol": "3.1.1"
@@ -1519,6 +1701,7 @@
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.1.tgz",
 			"integrity": "sha1-jjGcnwRTv1ddN0lAplWSDlnKVRI=",
+			"dev": true,
 			"requires": {
 				"d": "1.0.0",
 				"es5-ext": "0.10.26",
@@ -1529,6 +1712,7 @@
 			"version": "0.1.5",
 			"resolved": "https://registry.npmjs.org/es6-map/-/es6-map-0.1.5.tgz",
 			"integrity": "sha1-kTbgUD3MBqMBaQ8LsU/042TpSfA=",
+			"dev": true,
 			"requires": {
 				"d": "1.0.0",
 				"es5-ext": "0.10.26",
@@ -1542,6 +1726,7 @@
 			"version": "0.1.5",
 			"resolved": "https://registry.npmjs.org/es6-set/-/es6-set-0.1.5.tgz",
 			"integrity": "sha1-0rPsXU2ADO2BjbU40ol02wpzzLE=",
+			"dev": true,
 			"requires": {
 				"d": "1.0.0",
 				"es5-ext": "0.10.26",
@@ -1554,6 +1739,7 @@
 			"version": "3.1.1",
 			"resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.1.tgz",
 			"integrity": "sha1-vwDvT9q2uhtG7Le2KbTH7VcVzHc=",
+			"dev": true,
 			"requires": {
 				"d": "1.0.0",
 				"es5-ext": "0.10.26"
@@ -1563,6 +1749,7 @@
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-2.0.2.tgz",
 			"integrity": "sha1-XjqzIlH/0VOKH45f+hNXdy+S2W8=",
+			"dev": true,
 			"requires": {
 				"d": "1.0.0",
 				"es5-ext": "0.10.26",
@@ -1573,12 +1760,14 @@
 		"escape-string-regexp": {
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-			"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
+			"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+			"dev": true
 		},
 		"escodegen": {
 			"version": "1.8.1",
 			"resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.8.1.tgz",
 			"integrity": "sha1-WltTr0aTEQvrsIZ6o0MN07cKEBg=",
+			"dev": true,
 			"requires": {
 				"esprima": "2.7.3",
 				"estraverse": "1.9.3",
@@ -1590,17 +1779,20 @@
 				"esprima": {
 					"version": "2.7.3",
 					"resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.3.tgz",
-					"integrity": "sha1-luO3DVd59q1JzQMmc9HDEnZ7pYE="
+					"integrity": "sha1-luO3DVd59q1JzQMmc9HDEnZ7pYE=",
+					"dev": true
 				},
 				"estraverse": {
 					"version": "1.9.3",
 					"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-1.9.3.tgz",
-					"integrity": "sha1-r2fy3JIlgkFZUJJgkaQAXSnJu0Q="
+					"integrity": "sha1-r2fy3JIlgkFZUJJgkaQAXSnJu0Q=",
+					"dev": true
 				},
 				"source-map": {
 					"version": "0.2.0",
 					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.2.0.tgz",
 					"integrity": "sha1-2rc/vPwrqBm03gO9b26qSBZLP50=",
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"amdefine": "1.0.1"
@@ -1612,6 +1804,7 @@
 			"version": "3.6.0",
 			"resolved": "https://registry.npmjs.org/escope/-/escope-3.6.0.tgz",
 			"integrity": "sha1-4Bl16BJ4GhY6ba392AOY3GTIicM=",
+			"dev": true,
 			"requires": {
 				"es6-map": "0.1.5",
 				"es6-weak-map": "2.0.2",
@@ -1623,6 +1816,7 @@
 			"version": "2.13.1",
 			"resolved": "https://registry.npmjs.org/eslint/-/eslint-2.13.1.tgz",
 			"integrity": "sha1-5MyPoPAJ+4KaquI4VaKTYL4fbBE=",
+			"dev": true,
 			"requires": {
 				"chalk": "1.1.3",
 				"concat-stream": "1.6.0",
@@ -1663,6 +1857,7 @@
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/user-home/-/user-home-2.0.0.tgz",
 					"integrity": "sha1-nHC/2Babwdy/SGBODwS4tJzenp8=",
+					"dev": true,
 					"requires": {
 						"os-homedir": "1.0.2"
 					}
@@ -1673,6 +1868,7 @@
 			"version": "0.2.3",
 			"resolved": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.2.3.tgz",
 			"integrity": "sha1-Wt2BBujJKNssuiMrzZ76hG49oWw=",
+			"dev": true,
 			"requires": {
 				"debug": "2.6.8",
 				"object-assign": "4.1.1",
@@ -1683,6 +1879,7 @@
 			"version": "1.16.0",
 			"resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-1.16.0.tgz",
 			"integrity": "sha1-svoH68xTUE0PKkR3WC7Iv/GHG58=",
+			"dev": true,
 			"requires": {
 				"builtin-modules": "1.1.1",
 				"contains-path": "0.1.0",
@@ -1706,6 +1903,7 @@
 					"version": "1.3.0",
 					"resolved": "https://registry.npmjs.org/doctrine/-/doctrine-1.3.0.tgz",
 					"integrity": "sha1-E+dWgrVVGEJCdvfBc3g0Vu+RPSY=",
+					"dev": true,
 					"requires": {
 						"esutils": "2.0.2",
 						"isarray": "1.0.0"
@@ -1717,6 +1915,7 @@
 			"version": "5.2.2",
 			"resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-5.2.2.tgz",
 			"integrity": "sha1-fbBo4fVIf2hx5N7vNqOBwwPqwWE=",
+			"dev": true,
 			"requires": {
 				"doctrine": "1.5.0",
 				"jsx-ast-utils": "1.4.1"
@@ -1726,6 +1925,7 @@
 			"version": "3.4.3",
 			"resolved": "https://registry.npmjs.org/espree/-/espree-3.4.3.tgz",
 			"integrity": "sha1-KRC1zNSc6JPC//+qtP2LOjG4I3Q=",
+			"dev": true,
 			"requires": {
 				"acorn": "5.1.1",
 				"acorn-jsx": "3.0.1"
@@ -1734,12 +1934,14 @@
 		"esprima": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.0.tgz",
-			"integrity": "sha512-oftTcaMu/EGrEIu904mWteKIv8vMuOgGYo7EhVJJN00R/EED9DCua/xxHRdYnKtcECzVg7xOWhflvJMnqcFZjw=="
+			"integrity": "sha512-oftTcaMu/EGrEIu904mWteKIv8vMuOgGYo7EhVJJN00R/EED9DCua/xxHRdYnKtcECzVg7xOWhflvJMnqcFZjw==",
+			"dev": true
 		},
 		"esrecurse": {
 			"version": "4.2.0",
 			"resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.2.0.tgz",
 			"integrity": "sha1-+pVo2Y04I/mkHZHpAtyrnqblsWM=",
+			"dev": true,
 			"requires": {
 				"estraverse": "4.2.0",
 				"object-assign": "4.1.1"
@@ -1748,22 +1950,26 @@
 		"estraverse": {
 			"version": "4.2.0",
 			"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.2.0.tgz",
-			"integrity": "sha1-De4/7TH81GlhjOc0IJn8GvoL2xM="
+			"integrity": "sha1-De4/7TH81GlhjOc0IJn8GvoL2xM=",
+			"dev": true
 		},
 		"estree-walker": {
 			"version": "0.2.1",
 			"resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-0.2.1.tgz",
-			"integrity": "sha1-va/oCVOD2EFNXcLs9MkXO225QS4="
+			"integrity": "sha1-va/oCVOD2EFNXcLs9MkXO225QS4=",
+			"dev": true
 		},
 		"esutils": {
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
-			"integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs="
+			"integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
+			"dev": true
 		},
 		"event-emitter": {
 			"version": "0.3.5",
 			"resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.5.tgz",
 			"integrity": "sha1-34xp7vFkeSPHFXuc6DhAYQsCzDk=",
+			"dev": true,
 			"requires": {
 				"d": "1.0.0",
 				"es5-ext": "0.10.26"
@@ -1773,6 +1979,7 @@
 			"version": "0.2.0",
 			"resolved": "https://registry.npmjs.org/exec-sh/-/exec-sh-0.2.0.tgz",
 			"integrity": "sha1-FPdd4/INKG75MwmbLOUKkDWc7xA=",
+			"dev": true,
 			"requires": {
 				"merge": "1.2.0"
 			}
@@ -1780,12 +1987,14 @@
 		"exit-hook": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/exit-hook/-/exit-hook-1.1.1.tgz",
-			"integrity": "sha1-8FyiM7SMBdVP/wd2XfhQfpXAL/g="
+			"integrity": "sha1-8FyiM7SMBdVP/wd2XfhQfpXAL/g=",
+			"dev": true
 		},
 		"expand-brackets": {
 			"version": "0.1.5",
 			"resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
 			"integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
+			"dev": true,
 			"requires": {
 				"is-posix-bracket": "0.1.1"
 			}
@@ -1794,6 +2003,7 @@
 			"version": "1.8.2",
 			"resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
 			"integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
+			"dev": true,
 			"requires": {
 				"fill-range": "2.2.3"
 			}
@@ -1801,12 +2011,14 @@
 		"extend": {
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
-			"integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ="
+			"integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ=",
+			"dev": true
 		},
 		"extglob": {
 			"version": "0.3.2",
 			"resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
 			"integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
+			"dev": true,
 			"requires": {
 				"is-extglob": "1.0.0"
 			}
@@ -1814,17 +2026,20 @@
 		"extsprintf": {
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
-			"integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU="
+			"integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
+			"dev": true
 		},
 		"fast-levenshtein": {
 			"version": "2.0.6",
 			"resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
-			"integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc="
+			"integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
+			"dev": true
 		},
 		"fb-watchman": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/fb-watchman/-/fb-watchman-2.0.0.tgz",
 			"integrity": "sha1-VOmr99+i8mzZsWNsWIwa/AXeXVg=",
+			"dev": true,
 			"requires": {
 				"bser": "2.0.0"
 			}
@@ -1833,6 +2048,7 @@
 			"version": "0.8.14",
 			"resolved": "https://registry.npmjs.org/fbjs/-/fbjs-0.8.14.tgz",
 			"integrity": "sha1-0dviviVMNakeCfMfnNUKQLKg7Rw=",
+			"dev": true,
 			"requires": {
 				"core-js": "1.2.7",
 				"isomorphic-fetch": "2.2.1",
@@ -1846,7 +2062,8 @@
 				"core-js": {
 					"version": "1.2.7",
 					"resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
-					"integrity": "sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY="
+					"integrity": "sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY=",
+					"dev": true
 				}
 			}
 		},
@@ -1854,6 +2071,7 @@
 			"version": "1.7.0",
 			"resolved": "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
 			"integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
+			"dev": true,
 			"requires": {
 				"escape-string-regexp": "1.0.5",
 				"object-assign": "4.1.1"
@@ -1863,6 +2081,7 @@
 			"version": "1.3.1",
 			"resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-1.3.1.tgz",
 			"integrity": "sha1-RMYepgeuS+nBQC9B9EJwy/4zT/g=",
+			"dev": true,
 			"requires": {
 				"flat-cache": "1.2.2",
 				"object-assign": "4.1.1"
@@ -1871,12 +2090,14 @@
 		"filename-regex": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.1.tgz",
-			"integrity": "sha1-wcS5vuPglyXdsQa3XB4wH+LxiyY="
+			"integrity": "sha1-wcS5vuPglyXdsQa3XB4wH+LxiyY=",
+			"dev": true
 		},
 		"fileset": {
 			"version": "2.0.3",
 			"resolved": "https://registry.npmjs.org/fileset/-/fileset-2.0.3.tgz",
 			"integrity": "sha1-jnVIqW08wjJ+5eZ0FocjozO7oqA=",
+			"dev": true,
 			"requires": {
 				"glob": "7.1.2",
 				"minimatch": "3.0.4"
@@ -1886,6 +2107,7 @@
 			"version": "2.2.3",
 			"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.3.tgz",
 			"integrity": "sha1-ULd9/X5Gm8dJJHCWNpn+eoSFpyM=",
+			"dev": true,
 			"requires": {
 				"is-number": "2.1.0",
 				"isobject": "2.1.0",
@@ -1898,6 +2120,7 @@
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
 			"integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
+			"dev": true,
 			"requires": {
 				"path-exists": "2.1.0",
 				"pinkie-promise": "2.0.1"
@@ -1907,6 +2130,7 @@
 			"version": "1.2.2",
 			"resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-1.2.2.tgz",
 			"integrity": "sha1-+oZxTnLCHbiGAXYezy9VXRq8a5Y=",
+			"dev": true,
 			"requires": {
 				"circular-json": "0.3.3",
 				"del": "2.2.2",
@@ -1917,12 +2141,14 @@
 		"for-in": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
-			"integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA="
+			"integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA=",
+			"dev": true
 		},
 		"for-own": {
 			"version": "0.1.5",
 			"resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
 			"integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
+			"dev": true,
 			"requires": {
 				"for-in": "1.0.2"
 			}
@@ -1930,12 +2156,14 @@
 		"forever-agent": {
 			"version": "0.6.1",
 			"resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
-			"integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE="
+			"integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
+			"dev": true
 		},
 		"form-data": {
 			"version": "2.1.4",
 			"resolved": "https://registry.npmjs.org/form-data/-/form-data-2.1.4.tgz",
 			"integrity": "sha1-M8GDrPGTJ27KqYFDpp6Uv+4XUNE=",
+			"dev": true,
 			"requires": {
 				"asynckit": "0.4.0",
 				"combined-stream": "1.0.5",
@@ -1945,812 +2173,32 @@
 		"fs-readdir-recursive": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/fs-readdir-recursive/-/fs-readdir-recursive-1.0.0.tgz",
-			"integrity": "sha1-jNF0XItPiinIyuw5JHaSG6GV9WA="
+			"integrity": "sha1-jNF0XItPiinIyuw5JHaSG6GV9WA=",
+			"dev": true
 		},
 		"fs.realpath": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-			"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
-		},
-		"fsevents": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.1.2.tgz",
-			"integrity": "sha512-Sn44E5wQW4bTHXvQmvSHwqbuiXtduD6Rrjm2ZtUEGbyrig+nUH3t/QD4M4/ZXViY556TBpRgZkHLDx3JxPwxiw==",
-			"optional": true,
-			"requires": {
-				"nan": "2.6.2",
-				"node-pre-gyp": "0.6.36"
-			},
-			"dependencies": {
-				"abbrev": {
-					"version": "1.1.0",
-					"bundled": true,
-					"optional": true
-				},
-				"ajv": {
-					"version": "4.11.8",
-					"bundled": true,
-					"optional": true,
-					"requires": {
-						"co": "4.6.0",
-						"json-stable-stringify": "1.0.1"
-					}
-				},
-				"ansi-regex": {
-					"version": "2.1.1",
-					"bundled": true
-				},
-				"aproba": {
-					"version": "1.1.1",
-					"bundled": true,
-					"optional": true
-				},
-				"are-we-there-yet": {
-					"version": "1.1.4",
-					"bundled": true,
-					"optional": true,
-					"requires": {
-						"delegates": "1.0.0",
-						"readable-stream": "2.2.9"
-					}
-				},
-				"asn1": {
-					"version": "0.2.3",
-					"bundled": true,
-					"optional": true
-				},
-				"assert-plus": {
-					"version": "0.2.0",
-					"bundled": true,
-					"optional": true
-				},
-				"asynckit": {
-					"version": "0.4.0",
-					"bundled": true,
-					"optional": true
-				},
-				"aws-sign2": {
-					"version": "0.6.0",
-					"bundled": true,
-					"optional": true
-				},
-				"aws4": {
-					"version": "1.6.0",
-					"bundled": true,
-					"optional": true
-				},
-				"balanced-match": {
-					"version": "0.4.2",
-					"bundled": true
-				},
-				"bcrypt-pbkdf": {
-					"version": "1.0.1",
-					"bundled": true,
-					"optional": true,
-					"requires": {
-						"tweetnacl": "0.14.5"
-					}
-				},
-				"block-stream": {
-					"version": "0.0.9",
-					"bundled": true,
-					"requires": {
-						"inherits": "2.0.3"
-					}
-				},
-				"boom": {
-					"version": "2.10.1",
-					"bundled": true,
-					"requires": {
-						"hoek": "2.16.3"
-					}
-				},
-				"brace-expansion": {
-					"version": "1.1.7",
-					"bundled": true,
-					"requires": {
-						"balanced-match": "0.4.2",
-						"concat-map": "0.0.1"
-					}
-				},
-				"buffer-shims": {
-					"version": "1.0.0",
-					"bundled": true
-				},
-				"caseless": {
-					"version": "0.12.0",
-					"bundled": true,
-					"optional": true
-				},
-				"co": {
-					"version": "4.6.0",
-					"bundled": true,
-					"optional": true
-				},
-				"code-point-at": {
-					"version": "1.1.0",
-					"bundled": true
-				},
-				"combined-stream": {
-					"version": "1.0.5",
-					"bundled": true,
-					"requires": {
-						"delayed-stream": "1.0.0"
-					}
-				},
-				"concat-map": {
-					"version": "0.0.1",
-					"bundled": true
-				},
-				"console-control-strings": {
-					"version": "1.1.0",
-					"bundled": true
-				},
-				"core-util-is": {
-					"version": "1.0.2",
-					"bundled": true
-				},
-				"cryptiles": {
-					"version": "2.0.5",
-					"bundled": true,
-					"optional": true,
-					"requires": {
-						"boom": "2.10.1"
-					}
-				},
-				"dashdash": {
-					"version": "1.14.1",
-					"bundled": true,
-					"optional": true,
-					"requires": {
-						"assert-plus": "1.0.0"
-					},
-					"dependencies": {
-						"assert-plus": {
-							"version": "1.0.0",
-							"bundled": true,
-							"optional": true
-						}
-					}
-				},
-				"debug": {
-					"version": "2.6.8",
-					"bundled": true,
-					"optional": true,
-					"requires": {
-						"ms": "2.0.0"
-					}
-				},
-				"deep-extend": {
-					"version": "0.4.2",
-					"bundled": true,
-					"optional": true
-				},
-				"delayed-stream": {
-					"version": "1.0.0",
-					"bundled": true
-				},
-				"delegates": {
-					"version": "1.0.0",
-					"bundled": true,
-					"optional": true
-				},
-				"ecc-jsbn": {
-					"version": "0.1.1",
-					"bundled": true,
-					"optional": true,
-					"requires": {
-						"jsbn": "0.1.1"
-					}
-				},
-				"extend": {
-					"version": "3.0.1",
-					"bundled": true,
-					"optional": true
-				},
-				"extsprintf": {
-					"version": "1.0.2",
-					"bundled": true
-				},
-				"forever-agent": {
-					"version": "0.6.1",
-					"bundled": true,
-					"optional": true
-				},
-				"form-data": {
-					"version": "2.1.4",
-					"bundled": true,
-					"optional": true,
-					"requires": {
-						"asynckit": "0.4.0",
-						"combined-stream": "1.0.5",
-						"mime-types": "2.1.15"
-					}
-				},
-				"fs.realpath": {
-					"version": "1.0.0",
-					"bundled": true
-				},
-				"fstream": {
-					"version": "1.0.11",
-					"bundled": true,
-					"requires": {
-						"graceful-fs": "4.1.11",
-						"inherits": "2.0.3",
-						"mkdirp": "0.5.1",
-						"rimraf": "2.6.1"
-					}
-				},
-				"fstream-ignore": {
-					"version": "1.0.5",
-					"bundled": true,
-					"optional": true,
-					"requires": {
-						"fstream": "1.0.11",
-						"inherits": "2.0.3",
-						"minimatch": "3.0.4"
-					}
-				},
-				"gauge": {
-					"version": "2.7.4",
-					"bundled": true,
-					"optional": true,
-					"requires": {
-						"aproba": "1.1.1",
-						"console-control-strings": "1.1.0",
-						"has-unicode": "2.0.1",
-						"object-assign": "4.1.1",
-						"signal-exit": "3.0.2",
-						"string-width": "1.0.2",
-						"strip-ansi": "3.0.1",
-						"wide-align": "1.1.2"
-					}
-				},
-				"getpass": {
-					"version": "0.1.7",
-					"bundled": true,
-					"optional": true,
-					"requires": {
-						"assert-plus": "1.0.0"
-					},
-					"dependencies": {
-						"assert-plus": {
-							"version": "1.0.0",
-							"bundled": true,
-							"optional": true
-						}
-					}
-				},
-				"glob": {
-					"version": "7.1.2",
-					"bundled": true,
-					"requires": {
-						"fs.realpath": "1.0.0",
-						"inflight": "1.0.6",
-						"inherits": "2.0.3",
-						"minimatch": "3.0.4",
-						"once": "1.4.0",
-						"path-is-absolute": "1.0.1"
-					}
-				},
-				"graceful-fs": {
-					"version": "4.1.11",
-					"bundled": true
-				},
-				"har-schema": {
-					"version": "1.0.5",
-					"bundled": true,
-					"optional": true
-				},
-				"har-validator": {
-					"version": "4.2.1",
-					"bundled": true,
-					"optional": true,
-					"requires": {
-						"ajv": "4.11.8",
-						"har-schema": "1.0.5"
-					}
-				},
-				"has-unicode": {
-					"version": "2.0.1",
-					"bundled": true,
-					"optional": true
-				},
-				"hawk": {
-					"version": "3.1.3",
-					"bundled": true,
-					"optional": true,
-					"requires": {
-						"boom": "2.10.1",
-						"cryptiles": "2.0.5",
-						"hoek": "2.16.3",
-						"sntp": "1.0.9"
-					}
-				},
-				"hoek": {
-					"version": "2.16.3",
-					"bundled": true
-				},
-				"http-signature": {
-					"version": "1.1.1",
-					"bundled": true,
-					"optional": true,
-					"requires": {
-						"assert-plus": "0.2.0",
-						"jsprim": "1.4.0",
-						"sshpk": "1.13.0"
-					}
-				},
-				"inflight": {
-					"version": "1.0.6",
-					"bundled": true,
-					"requires": {
-						"once": "1.4.0",
-						"wrappy": "1.0.2"
-					}
-				},
-				"inherits": {
-					"version": "2.0.3",
-					"bundled": true
-				},
-				"ini": {
-					"version": "1.3.4",
-					"bundled": true,
-					"optional": true
-				},
-				"is-fullwidth-code-point": {
-					"version": "1.0.0",
-					"bundled": true,
-					"requires": {
-						"number-is-nan": "1.0.1"
-					}
-				},
-				"is-typedarray": {
-					"version": "1.0.0",
-					"bundled": true,
-					"optional": true
-				},
-				"isarray": {
-					"version": "1.0.0",
-					"bundled": true
-				},
-				"isstream": {
-					"version": "0.1.2",
-					"bundled": true,
-					"optional": true
-				},
-				"jodid25519": {
-					"version": "1.0.2",
-					"bundled": true,
-					"optional": true,
-					"requires": {
-						"jsbn": "0.1.1"
-					}
-				},
-				"jsbn": {
-					"version": "0.1.1",
-					"bundled": true,
-					"optional": true
-				},
-				"json-schema": {
-					"version": "0.2.3",
-					"bundled": true,
-					"optional": true
-				},
-				"json-stable-stringify": {
-					"version": "1.0.1",
-					"bundled": true,
-					"optional": true,
-					"requires": {
-						"jsonify": "0.0.0"
-					}
-				},
-				"json-stringify-safe": {
-					"version": "5.0.1",
-					"bundled": true,
-					"optional": true
-				},
-				"jsonify": {
-					"version": "0.0.0",
-					"bundled": true,
-					"optional": true
-				},
-				"jsprim": {
-					"version": "1.4.0",
-					"bundled": true,
-					"optional": true,
-					"requires": {
-						"assert-plus": "1.0.0",
-						"extsprintf": "1.0.2",
-						"json-schema": "0.2.3",
-						"verror": "1.3.6"
-					},
-					"dependencies": {
-						"assert-plus": {
-							"version": "1.0.0",
-							"bundled": true,
-							"optional": true
-						}
-					}
-				},
-				"mime-db": {
-					"version": "1.27.0",
-					"bundled": true
-				},
-				"mime-types": {
-					"version": "2.1.15",
-					"bundled": true,
-					"requires": {
-						"mime-db": "1.27.0"
-					}
-				},
-				"minimatch": {
-					"version": "3.0.4",
-					"bundled": true,
-					"requires": {
-						"brace-expansion": "1.1.7"
-					}
-				},
-				"minimist": {
-					"version": "0.0.8",
-					"bundled": true
-				},
-				"mkdirp": {
-					"version": "0.5.1",
-					"bundled": true,
-					"requires": {
-						"minimist": "0.0.8"
-					}
-				},
-				"ms": {
-					"version": "2.0.0",
-					"bundled": true,
-					"optional": true
-				},
-				"node-pre-gyp": {
-					"version": "0.6.36",
-					"bundled": true,
-					"optional": true,
-					"requires": {
-						"mkdirp": "0.5.1",
-						"nopt": "4.0.1",
-						"npmlog": "4.1.0",
-						"rc": "1.2.1",
-						"request": "2.81.0",
-						"rimraf": "2.6.1",
-						"semver": "5.3.0",
-						"tar": "2.2.1",
-						"tar-pack": "3.4.0"
-					}
-				},
-				"nopt": {
-					"version": "4.0.1",
-					"bundled": true,
-					"optional": true,
-					"requires": {
-						"abbrev": "1.1.0",
-						"osenv": "0.1.4"
-					}
-				},
-				"npmlog": {
-					"version": "4.1.0",
-					"bundled": true,
-					"optional": true,
-					"requires": {
-						"are-we-there-yet": "1.1.4",
-						"console-control-strings": "1.1.0",
-						"gauge": "2.7.4",
-						"set-blocking": "2.0.0"
-					}
-				},
-				"number-is-nan": {
-					"version": "1.0.1",
-					"bundled": true
-				},
-				"oauth-sign": {
-					"version": "0.8.2",
-					"bundled": true,
-					"optional": true
-				},
-				"object-assign": {
-					"version": "4.1.1",
-					"bundled": true,
-					"optional": true
-				},
-				"once": {
-					"version": "1.4.0",
-					"bundled": true,
-					"requires": {
-						"wrappy": "1.0.2"
-					}
-				},
-				"os-homedir": {
-					"version": "1.0.2",
-					"bundled": true,
-					"optional": true
-				},
-				"os-tmpdir": {
-					"version": "1.0.2",
-					"bundled": true,
-					"optional": true
-				},
-				"osenv": {
-					"version": "0.1.4",
-					"bundled": true,
-					"optional": true,
-					"requires": {
-						"os-homedir": "1.0.2",
-						"os-tmpdir": "1.0.2"
-					}
-				},
-				"path-is-absolute": {
-					"version": "1.0.1",
-					"bundled": true
-				},
-				"performance-now": {
-					"version": "0.2.0",
-					"bundled": true,
-					"optional": true
-				},
-				"process-nextick-args": {
-					"version": "1.0.7",
-					"bundled": true
-				},
-				"punycode": {
-					"version": "1.4.1",
-					"bundled": true,
-					"optional": true
-				},
-				"qs": {
-					"version": "6.4.0",
-					"bundled": true,
-					"optional": true
-				},
-				"rc": {
-					"version": "1.2.1",
-					"bundled": true,
-					"optional": true,
-					"requires": {
-						"deep-extend": "0.4.2",
-						"ini": "1.3.4",
-						"minimist": "1.2.0",
-						"strip-json-comments": "2.0.1"
-					},
-					"dependencies": {
-						"minimist": {
-							"version": "1.2.0",
-							"bundled": true,
-							"optional": true
-						}
-					}
-				},
-				"readable-stream": {
-					"version": "2.2.9",
-					"bundled": true,
-					"requires": {
-						"buffer-shims": "1.0.0",
-						"core-util-is": "1.0.2",
-						"inherits": "2.0.3",
-						"isarray": "1.0.0",
-						"process-nextick-args": "1.0.7",
-						"string_decoder": "1.0.1",
-						"util-deprecate": "1.0.2"
-					}
-				},
-				"request": {
-					"version": "2.81.0",
-					"bundled": true,
-					"optional": true,
-					"requires": {
-						"aws-sign2": "0.6.0",
-						"aws4": "1.6.0",
-						"caseless": "0.12.0",
-						"combined-stream": "1.0.5",
-						"extend": "3.0.1",
-						"forever-agent": "0.6.1",
-						"form-data": "2.1.4",
-						"har-validator": "4.2.1",
-						"hawk": "3.1.3",
-						"http-signature": "1.1.1",
-						"is-typedarray": "1.0.0",
-						"isstream": "0.1.2",
-						"json-stringify-safe": "5.0.1",
-						"mime-types": "2.1.15",
-						"oauth-sign": "0.8.2",
-						"performance-now": "0.2.0",
-						"qs": "6.4.0",
-						"safe-buffer": "5.0.1",
-						"stringstream": "0.0.5",
-						"tough-cookie": "2.3.2",
-						"tunnel-agent": "0.6.0",
-						"uuid": "3.0.1"
-					}
-				},
-				"rimraf": {
-					"version": "2.6.1",
-					"bundled": true,
-					"requires": {
-						"glob": "7.1.2"
-					}
-				},
-				"safe-buffer": {
-					"version": "5.0.1",
-					"bundled": true
-				},
-				"semver": {
-					"version": "5.3.0",
-					"bundled": true,
-					"optional": true
-				},
-				"set-blocking": {
-					"version": "2.0.0",
-					"bundled": true,
-					"optional": true
-				},
-				"signal-exit": {
-					"version": "3.0.2",
-					"bundled": true,
-					"optional": true
-				},
-				"sntp": {
-					"version": "1.0.9",
-					"bundled": true,
-					"optional": true,
-					"requires": {
-						"hoek": "2.16.3"
-					}
-				},
-				"sshpk": {
-					"version": "1.13.0",
-					"bundled": true,
-					"optional": true,
-					"requires": {
-						"asn1": "0.2.3",
-						"assert-plus": "1.0.0",
-						"bcrypt-pbkdf": "1.0.1",
-						"dashdash": "1.14.1",
-						"ecc-jsbn": "0.1.1",
-						"getpass": "0.1.7",
-						"jodid25519": "1.0.2",
-						"jsbn": "0.1.1",
-						"tweetnacl": "0.14.5"
-					},
-					"dependencies": {
-						"assert-plus": {
-							"version": "1.0.0",
-							"bundled": true,
-							"optional": true
-						}
-					}
-				},
-				"string_decoder": {
-					"version": "1.0.1",
-					"bundled": true,
-					"requires": {
-						"safe-buffer": "5.0.1"
-					}
-				},
-				"string-width": {
-					"version": "1.0.2",
-					"bundled": true,
-					"requires": {
-						"code-point-at": "1.1.0",
-						"is-fullwidth-code-point": "1.0.0",
-						"strip-ansi": "3.0.1"
-					}
-				},
-				"stringstream": {
-					"version": "0.0.5",
-					"bundled": true,
-					"optional": true
-				},
-				"strip-ansi": {
-					"version": "3.0.1",
-					"bundled": true,
-					"requires": {
-						"ansi-regex": "2.1.1"
-					}
-				},
-				"strip-json-comments": {
-					"version": "2.0.1",
-					"bundled": true,
-					"optional": true
-				},
-				"tar": {
-					"version": "2.2.1",
-					"bundled": true,
-					"requires": {
-						"block-stream": "0.0.9",
-						"fstream": "1.0.11",
-						"inherits": "2.0.3"
-					}
-				},
-				"tar-pack": {
-					"version": "3.4.0",
-					"bundled": true,
-					"optional": true,
-					"requires": {
-						"debug": "2.6.8",
-						"fstream": "1.0.11",
-						"fstream-ignore": "1.0.5",
-						"once": "1.4.0",
-						"readable-stream": "2.2.9",
-						"rimraf": "2.6.1",
-						"tar": "2.2.1",
-						"uid-number": "0.0.6"
-					}
-				},
-				"tough-cookie": {
-					"version": "2.3.2",
-					"bundled": true,
-					"optional": true,
-					"requires": {
-						"punycode": "1.4.1"
-					}
-				},
-				"tunnel-agent": {
-					"version": "0.6.0",
-					"bundled": true,
-					"optional": true,
-					"requires": {
-						"safe-buffer": "5.0.1"
-					}
-				},
-				"tweetnacl": {
-					"version": "0.14.5",
-					"bundled": true,
-					"optional": true
-				},
-				"uid-number": {
-					"version": "0.0.6",
-					"bundled": true,
-					"optional": true
-				},
-				"util-deprecate": {
-					"version": "1.0.2",
-					"bundled": true
-				},
-				"uuid": {
-					"version": "3.0.1",
-					"bundled": true,
-					"optional": true
-				},
-				"verror": {
-					"version": "1.3.6",
-					"bundled": true,
-					"optional": true,
-					"requires": {
-						"extsprintf": "1.0.2"
-					}
-				},
-				"wide-align": {
-					"version": "1.1.2",
-					"bundled": true,
-					"optional": true,
-					"requires": {
-						"string-width": "1.0.2"
-					}
-				},
-				"wrappy": {
-					"version": "1.0.2",
-					"bundled": true
-				}
-			}
+			"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+			"dev": true
 		},
 		"function-bind": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.0.tgz",
-			"integrity": "sha1-FhdnFMgBeY5Ojyz391KUZ7tKV3E="
+			"integrity": "sha1-FhdnFMgBeY5Ojyz391KUZ7tKV3E=",
+			"dev": true
 		},
 		"generate-function": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz",
-			"integrity": "sha1-aFj+fAlpt9TpCTM3ZHrHn2DfvnQ="
+			"integrity": "sha1-aFj+fAlpt9TpCTM3ZHrHn2DfvnQ=",
+			"dev": true
 		},
 		"generate-object-property": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
 			"integrity": "sha1-nA4cQDCM6AT0eDYYuTf6iPmdUNA=",
+			"dev": true,
 			"requires": {
 				"is-property": "1.0.2"
 			}
@@ -2758,12 +2206,14 @@
 		"get-caller-file": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.2.tgz",
-			"integrity": "sha1-9wLmMSfn4jHBYKgMFVSstw1QR+U="
+			"integrity": "sha1-9wLmMSfn4jHBYKgMFVSstw1QR+U=",
+			"dev": true
 		},
 		"getpass": {
 			"version": "0.1.7",
 			"resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
 			"integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
+			"dev": true,
 			"requires": {
 				"assert-plus": "1.0.0"
 			},
@@ -2771,7 +2221,8 @@
 				"assert-plus": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-					"integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
+					"integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+					"dev": true
 				}
 			}
 		},
@@ -2779,6 +2230,7 @@
 			"version": "7.1.2",
 			"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
 			"integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+			"dev": true,
 			"requires": {
 				"fs.realpath": "1.0.0",
 				"inflight": "1.0.6",
@@ -2792,6 +2244,7 @@
 			"version": "0.3.0",
 			"resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz",
 			"integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
+			"dev": true,
 			"requires": {
 				"glob-parent": "2.0.0",
 				"is-glob": "2.0.1"
@@ -2801,6 +2254,7 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
 			"integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
+			"dev": true,
 			"requires": {
 				"is-glob": "2.0.1"
 			}
@@ -2808,12 +2262,14 @@
 		"globals": {
 			"version": "9.18.0",
 			"resolved": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz",
-			"integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ=="
+			"integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ==",
+			"dev": true
 		},
 		"globby": {
 			"version": "5.0.0",
 			"resolved": "https://registry.npmjs.org/globby/-/globby-5.0.0.tgz",
 			"integrity": "sha1-69hGZ8oNuzMLmbz8aOrCvFQ3Dg0=",
+			"dev": true,
 			"requires": {
 				"array-union": "1.0.2",
 				"arrify": "1.0.1",
@@ -2826,17 +2282,20 @@
 		"graceful-fs": {
 			"version": "4.1.11",
 			"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
-			"integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg="
+			"integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
+			"dev": true
 		},
 		"growly": {
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/growly/-/growly-1.3.0.tgz",
-			"integrity": "sha1-8QdIy+dq+WS3yWyTxrzCivEgwIE="
+			"integrity": "sha1-8QdIy+dq+WS3yWyTxrzCivEgwIE=",
+			"dev": true
 		},
 		"gzip-size": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/gzip-size/-/gzip-size-3.0.0.tgz",
 			"integrity": "sha1-VGGI6b3DN/Zzdy+BZgRks4nc5SA=",
+			"dev": true,
 			"requires": {
 				"duplexer": "0.1.1"
 			}
@@ -2845,6 +2304,7 @@
 			"version": "4.0.10",
 			"resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.10.tgz",
 			"integrity": "sha1-PTDHGLCaPZbyPqTMH0A8TTup/08=",
+			"dev": true,
 			"requires": {
 				"async": "1.5.2",
 				"optimist": "0.6.1",
@@ -2855,12 +2315,14 @@
 				"async": {
 					"version": "1.5.2",
 					"resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
-					"integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo="
+					"integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
+					"dev": true
 				},
 				"source-map": {
 					"version": "0.4.4",
 					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
 					"integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
+					"dev": true,
 					"requires": {
 						"amdefine": "1.0.1"
 					}
@@ -2870,12 +2332,14 @@
 		"har-schema": {
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/har-schema/-/har-schema-1.0.5.tgz",
-			"integrity": "sha1-0mMTX0MwfALGAq/I/pWXDAFRNp4="
+			"integrity": "sha1-0mMTX0MwfALGAq/I/pWXDAFRNp4=",
+			"dev": true
 		},
 		"har-validator": {
 			"version": "4.2.1",
 			"resolved": "https://registry.npmjs.org/har-validator/-/har-validator-4.2.1.tgz",
 			"integrity": "sha1-M0gdDxu/9gDdID11gSpqX7oALio=",
+			"dev": true,
 			"requires": {
 				"ajv": "4.11.8",
 				"har-schema": "1.0.5"
@@ -2885,6 +2349,7 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/has/-/has-1.0.1.tgz",
 			"integrity": "sha1-hGFzP1OLCDfJNh45qauelwTcLyg=",
+			"dev": true,
 			"requires": {
 				"function-bind": "1.1.0"
 			}
@@ -2893,6 +2358,7 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
 			"integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+			"dev": true,
 			"requires": {
 				"ansi-regex": "2.1.1"
 			}
@@ -2900,12 +2366,14 @@
 		"has-flag": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
-			"integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo="
+			"integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
+			"dev": true
 		},
 		"hawk": {
 			"version": "3.1.3",
 			"resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
 			"integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
+			"dev": true,
 			"requires": {
 				"boom": "2.10.1",
 				"cryptiles": "2.0.5",
@@ -2916,12 +2384,14 @@
 		"hoek": {
 			"version": "2.16.3",
 			"resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
-			"integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0="
+			"integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0=",
+			"dev": true
 		},
 		"home-or-tmp": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-2.0.0.tgz",
 			"integrity": "sha1-42w/LSyufXRqhX440Y1fMqeILbg=",
+			"dev": true,
 			"requires": {
 				"os-homedir": "1.0.2",
 				"os-tmpdir": "1.0.2"
@@ -2930,12 +2400,14 @@
 		"hosted-git-info": {
 			"version": "2.5.0",
 			"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.5.0.tgz",
-			"integrity": "sha512-pNgbURSuab90KbTqvRPsseaTxOJCZBD0a7t+haSN33piP9cCM4l0CqdzAif2hUqm716UovKB2ROmiabGAKVXyg=="
+			"integrity": "sha512-pNgbURSuab90KbTqvRPsseaTxOJCZBD0a7t+haSN33piP9cCM4l0CqdzAif2hUqm716UovKB2ROmiabGAKVXyg==",
+			"dev": true
 		},
 		"html-encoding-sniffer": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-1.0.1.tgz",
 			"integrity": "sha1-eb96eF6klf5mFl5zQVPzY/9UN9o=",
+			"dev": true,
 			"requires": {
 				"whatwg-encoding": "1.0.1"
 			}
@@ -2944,6 +2416,7 @@
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
 			"integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
+			"dev": true,
 			"requires": {
 				"assert-plus": "0.2.0",
 				"jsprim": "1.4.1",
@@ -2953,22 +2426,26 @@
 		"iconv-lite": {
 			"version": "0.4.13",
 			"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.13.tgz",
-			"integrity": "sha1-H4irpKsLFQjoMSrMOTRfNumS4vI="
+			"integrity": "sha1-H4irpKsLFQjoMSrMOTRfNumS4vI=",
+			"dev": true
 		},
 		"ignore": {
 			"version": "3.3.3",
 			"resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.3.tgz",
-			"integrity": "sha1-QyNS5XrM2HqzEQ6C0/6g5HgSFW0="
+			"integrity": "sha1-QyNS5XrM2HqzEQ6C0/6g5HgSFW0=",
+			"dev": true
 		},
 		"imurmurhash": {
 			"version": "0.1.4",
 			"resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
-			"integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o="
+			"integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
+			"dev": true
 		},
 		"inflight": {
 			"version": "1.0.6",
 			"resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
 			"integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+			"dev": true,
 			"requires": {
 				"once": "1.4.0",
 				"wrappy": "1.0.2"
@@ -2977,12 +2454,14 @@
 		"inherits": {
 			"version": "2.0.3",
 			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-			"integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+			"integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+			"dev": true
 		},
 		"inquirer": {
 			"version": "0.12.0",
 			"resolved": "https://registry.npmjs.org/inquirer/-/inquirer-0.12.0.tgz",
 			"integrity": "sha1-HvK/1jUE3wvHV4X/+MLEHfEvB34=",
+			"dev": true,
 			"requires": {
 				"ansi-escapes": "1.4.0",
 				"ansi-regex": "2.1.1",
@@ -3003,6 +2482,7 @@
 			"version": "2.2.2",
 			"resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.2.tgz",
 			"integrity": "sha1-nh9WrArNtr8wMwbzOL47IErmA2A=",
+			"dev": true,
 			"requires": {
 				"loose-envify": "1.3.1"
 			}
@@ -3010,17 +2490,20 @@
 		"invert-kv": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
-			"integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY="
+			"integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY=",
+			"dev": true
 		},
 		"is-arrayish": {
 			"version": "0.2.1",
 			"resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
-			"integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0="
+			"integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
+			"dev": true
 		},
 		"is-binary-path": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
 			"integrity": "sha1-dfFmQrSA8YenEcgUFh/TpKdlWJg=",
+			"dev": true,
 			"optional": true,
 			"requires": {
 				"binary-extensions": "1.9.0"
@@ -3029,12 +2512,14 @@
 		"is-buffer": {
 			"version": "1.1.5",
 			"resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.5.tgz",
-			"integrity": "sha1-Hzsm72E7IUuIy8ojzGwB2Hlh7sw="
+			"integrity": "sha1-Hzsm72E7IUuIy8ojzGwB2Hlh7sw=",
+			"dev": true
 		},
 		"is-builtin-module": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
 			"integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
+			"dev": true,
 			"requires": {
 				"builtin-modules": "1.1.1"
 			}
@@ -3043,6 +2528,7 @@
 			"version": "1.0.10",
 			"resolved": "https://registry.npmjs.org/is-ci/-/is-ci-1.0.10.tgz",
 			"integrity": "sha1-9zkzayYyNlBhqdSCcM1WrjNpMY4=",
+			"dev": true,
 			"requires": {
 				"ci-info": "1.0.0"
 			}
@@ -3050,12 +2536,14 @@
 		"is-dotfile": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.3.tgz",
-			"integrity": "sha1-pqLzL/0t+wT1yiXs0Pa4PPeYoeE="
+			"integrity": "sha1-pqLzL/0t+wT1yiXs0Pa4PPeYoeE=",
+			"dev": true
 		},
 		"is-equal-shallow": {
 			"version": "0.1.3",
 			"resolved": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
 			"integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
+			"dev": true,
 			"requires": {
 				"is-primitive": "2.0.0"
 			}
@@ -3063,17 +2551,20 @@
 		"is-extendable": {
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
-			"integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik="
+			"integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik=",
+			"dev": true
 		},
 		"is-extglob": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-			"integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA="
+			"integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
+			"dev": true
 		},
 		"is-finite": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
 			"integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
+			"dev": true,
 			"requires": {
 				"number-is-nan": "1.0.1"
 			}
@@ -3082,6 +2573,7 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
 			"integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+			"dev": true,
 			"requires": {
 				"number-is-nan": "1.0.1"
 			}
@@ -3090,6 +2582,7 @@
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
 			"integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
+			"dev": true,
 			"requires": {
 				"is-extglob": "1.0.0"
 			}
@@ -3097,12 +2590,14 @@
 		"is-module": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/is-module/-/is-module-1.0.0.tgz",
-			"integrity": "sha1-Mlj7afeMFNW4FdZkM2tM/7ZEFZE="
+			"integrity": "sha1-Mlj7afeMFNW4FdZkM2tM/7ZEFZE=",
+			"dev": true
 		},
 		"is-my-json-valid": {
 			"version": "2.16.0",
 			"resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.16.0.tgz",
 			"integrity": "sha1-8Hndm/2uZe4gOKrorLyGqxCeNpM=",
+			"dev": true,
 			"requires": {
 				"generate-function": "2.0.0",
 				"generate-object-property": "1.2.0",
@@ -3114,6 +2609,7 @@
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
 			"integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
+			"dev": true,
 			"requires": {
 				"kind-of": "3.2.2"
 			}
@@ -3121,12 +2617,14 @@
 		"is-path-cwd": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/is-path-cwd/-/is-path-cwd-1.0.0.tgz",
-			"integrity": "sha1-0iXsIxMuie3Tj9p2dHLmLmXxEG0="
+			"integrity": "sha1-0iXsIxMuie3Tj9p2dHLmLmXxEG0=",
+			"dev": true
 		},
 		"is-path-in-cwd": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/is-path-in-cwd/-/is-path-in-cwd-1.0.0.tgz",
 			"integrity": "sha1-ZHdYK4IU1gI0YJRWcAO+ip6sBNw=",
+			"dev": true,
 			"requires": {
 				"is-path-inside": "1.0.0"
 			}
@@ -3135,6 +2633,7 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.0.tgz",
 			"integrity": "sha1-/AbloWg/vaE95mev9xe7wQpI838=",
+			"dev": true,
 			"requires": {
 				"path-is-inside": "1.0.2"
 			}
@@ -3142,22 +2641,26 @@
 		"is-posix-bracket": {
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz",
-			"integrity": "sha1-MzTceXdDaOkvAW5vvAqI9c1ua8Q="
+			"integrity": "sha1-MzTceXdDaOkvAW5vvAqI9c1ua8Q=",
+			"dev": true
 		},
 		"is-primitive": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz",
-			"integrity": "sha1-IHurkWOEmcB7Kt8kCkGochADRXU="
+			"integrity": "sha1-IHurkWOEmcB7Kt8kCkGochADRXU=",
+			"dev": true
 		},
 		"is-property": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
-			"integrity": "sha1-V/4cTkhHTt1lsJkR8msc1Ald2oQ="
+			"integrity": "sha1-V/4cTkhHTt1lsJkR8msc1Ald2oQ=",
+			"dev": true
 		},
 		"is-resolvable": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/is-resolvable/-/is-resolvable-1.0.0.tgz",
 			"integrity": "sha1-jfV8YeouPFAUCNEA+wE8+NbgzGI=",
+			"dev": true,
 			"requires": {
 				"tryit": "1.0.3"
 			}
@@ -3165,32 +2668,38 @@
 		"is-stream": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
-			"integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
+			"integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
+			"dev": true
 		},
 		"is-typedarray": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-			"integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
+			"integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
+			"dev": true
 		},
 		"is-utf8": {
 			"version": "0.2.1",
 			"resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
-			"integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI="
+			"integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI=",
+			"dev": true
 		},
 		"isarray": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-			"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+			"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+			"dev": true
 		},
 		"isexe": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-			"integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
+			"integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
+			"dev": true
 		},
 		"isobject": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
 			"integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
+			"dev": true,
 			"requires": {
 				"isarray": "1.0.0"
 			}
@@ -3199,6 +2708,7 @@
 			"version": "2.2.1",
 			"resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz",
 			"integrity": "sha1-YRrhrPFPXoH3KVB0coGf6XM1WKk=",
+			"dev": true,
 			"requires": {
 				"node-fetch": "1.7.1",
 				"whatwg-fetch": "2.0.3"
@@ -3207,12 +2717,14 @@
 		"isstream": {
 			"version": "0.1.2",
 			"resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
-			"integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
+			"integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
+			"dev": true
 		},
 		"istanbul-api": {
 			"version": "1.1.11",
 			"resolved": "https://registry.npmjs.org/istanbul-api/-/istanbul-api-1.1.11.tgz",
 			"integrity": "sha1-/MC0YeKzvaceMFFVE4I4doJX2d4=",
+			"dev": true,
 			"requires": {
 				"async": "2.5.0",
 				"fileset": "2.0.3",
@@ -3230,12 +2742,14 @@
 		"istanbul-lib-coverage": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-1.1.1.tgz",
-			"integrity": "sha512-0+1vDkmzxqJIn5rcoEqapSB4DmPxE31EtI2dF2aCkV5esN9EWHxZ0dwgDClivMXJqE7zaYQxq30hj5L0nlTN5Q=="
+			"integrity": "sha512-0+1vDkmzxqJIn5rcoEqapSB4DmPxE31EtI2dF2aCkV5esN9EWHxZ0dwgDClivMXJqE7zaYQxq30hj5L0nlTN5Q==",
+			"dev": true
 		},
 		"istanbul-lib-hook": {
 			"version": "1.0.7",
 			"resolved": "https://registry.npmjs.org/istanbul-lib-hook/-/istanbul-lib-hook-1.0.7.tgz",
 			"integrity": "sha512-3U2HB9y1ZV9UmFlE12Fx+nPtFqIymzrqCksrXujm3NVbAZIJg/RfYgO1XiIa0mbmxTjWpVEVlkIZJ25xVIAfkQ==",
+			"dev": true,
 			"requires": {
 				"append-transform": "0.4.0"
 			}
@@ -3244,6 +2758,7 @@
 			"version": "1.7.4",
 			"resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-1.7.4.tgz",
 			"integrity": "sha1-6f2SDkdn89Ge3HZeLWs/XMvQ7qg=",
+			"dev": true,
 			"requires": {
 				"babel-generator": "6.25.0",
 				"babel-template": "6.25.0",
@@ -3258,6 +2773,7 @@
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-1.1.1.tgz",
 			"integrity": "sha512-tvF+YmCmH4thnez6JFX06ujIA19WPa9YUiwjc1uALF2cv5dmE3It8b5I8Ob7FHJ70H9Y5yF+TDkVa/mcADuw1Q==",
+			"dev": true,
 			"requires": {
 				"istanbul-lib-coverage": "1.1.1",
 				"mkdirp": "0.5.1",
@@ -3269,6 +2785,7 @@
 					"version": "3.2.3",
 					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
 					"integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
+					"dev": true,
 					"requires": {
 						"has-flag": "1.0.0"
 					}
@@ -3279,6 +2796,7 @@
 			"version": "1.2.1",
 			"resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-1.2.1.tgz",
 			"integrity": "sha512-mukVvSXCn9JQvdJl8wP/iPhqig0MRtuWuD4ZNKo6vB2Ik//AmhAKe3QnPN02dmkRe3lTudFk3rzoHhwU4hb94w==",
+			"dev": true,
 			"requires": {
 				"debug": "2.6.8",
 				"istanbul-lib-coverage": "1.1.1",
@@ -3291,6 +2809,7 @@
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-1.1.1.tgz",
 			"integrity": "sha512-P8G873A0kW24XRlxHVGhMJBhQ8gWAec+dae7ZxOBzxT4w+a9ATSPvRVK3LB1RAJ9S8bg2tOyWHAGW40Zd2dKfw==",
+			"dev": true,
 			"requires": {
 				"handlebars": "4.0.10"
 			}
@@ -3299,6 +2818,7 @@
 			"version": "20.0.4",
 			"resolved": "https://registry.npmjs.org/jest/-/jest-20.0.4.tgz",
 			"integrity": "sha1-PdJgwpidba1nix6cxNkZRPbWAqw=",
+			"dev": true,
 			"requires": {
 				"jest-cli": "20.0.4"
 			},
@@ -3306,12 +2826,14 @@
 				"callsites": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/callsites/-/callsites-2.0.0.tgz",
-					"integrity": "sha1-BuuE8A7qQT2oav/vrL/7Ngk7PFA="
+					"integrity": "sha1-BuuE8A7qQT2oav/vrL/7Ngk7PFA=",
+					"dev": true
 				},
 				"jest-cli": {
 					"version": "20.0.4",
 					"resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-20.0.4.tgz",
 					"integrity": "sha1-5TKxnYiuW8bEF+iwWTpv6VSx3JM=",
+					"dev": true,
 					"requires": {
 						"ansi-escapes": "1.4.0",
 						"callsites": "2.0.0",
@@ -3350,12 +2872,14 @@
 		"jest-changed-files": {
 			"version": "20.0.3",
 			"resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-20.0.3.tgz",
-			"integrity": "sha1-k5TVzGXEOEBhSb7xv01Sto4D4/g="
+			"integrity": "sha1-k5TVzGXEOEBhSb7xv01Sto4D4/g=",
+			"dev": true
 		},
 		"jest-config": {
 			"version": "20.0.4",
 			"resolved": "https://registry.npmjs.org/jest-config/-/jest-config-20.0.4.tgz",
 			"integrity": "sha1-43kwqyIXyRNgXv8T5712PsSPruo=",
+			"dev": true,
 			"requires": {
 				"chalk": "1.1.3",
 				"glob": "7.1.2",
@@ -3373,6 +2897,7 @@
 			"version": "20.0.3",
 			"resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-20.0.3.tgz",
 			"integrity": "sha1-gfKI/Z5nXw+yPHXxwrGURf5YZhc=",
+			"dev": true,
 			"requires": {
 				"chalk": "1.1.3",
 				"diff": "3.3.0",
@@ -3383,12 +2908,14 @@
 		"jest-docblock": {
 			"version": "20.0.3",
 			"resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-20.0.3.tgz",
-			"integrity": "sha1-F76phDQswz2DxQ++FUXqDvqkRxI="
+			"integrity": "sha1-F76phDQswz2DxQ++FUXqDvqkRxI=",
+			"dev": true
 		},
 		"jest-environment-jsdom": {
 			"version": "20.0.3",
 			"resolved": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-20.0.3.tgz",
 			"integrity": "sha1-BIqKwS7iJfcZBBdxODS7mZeH3pk=",
+			"dev": true,
 			"requires": {
 				"jest-mock": "20.0.3",
 				"jest-util": "20.0.3",
@@ -3399,6 +2926,7 @@
 			"version": "20.0.3",
 			"resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-20.0.3.tgz",
 			"integrity": "sha1-1Ii8RhKvLCRumG6K52caCZFj1AM=",
+			"dev": true,
 			"requires": {
 				"jest-mock": "20.0.3",
 				"jest-util": "20.0.3"
@@ -3408,6 +2936,7 @@
 			"version": "20.0.4",
 			"resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-20.0.4.tgz",
 			"integrity": "sha1-ZT61XIic48Ah97lGk/IKQVm63wM=",
+			"dev": true,
 			"requires": {
 				"fb-watchman": "2.0.0",
 				"graceful-fs": "4.1.11",
@@ -3421,6 +2950,7 @@
 			"version": "20.0.4",
 			"resolved": "https://registry.npmjs.org/jest-jasmine2/-/jest-jasmine2-20.0.4.tgz",
 			"integrity": "sha1-/MWxQReA2RHQQpAu8YWehS5g1eE=",
+			"dev": true,
 			"requires": {
 				"chalk": "1.1.3",
 				"graceful-fs": "4.1.11",
@@ -3437,6 +2967,7 @@
 			"version": "20.0.3",
 			"resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-20.0.3.tgz",
 			"integrity": "sha1-s6a443yld4A7CDKpixZPRLeBVhI=",
+			"dev": true,
 			"requires": {
 				"chalk": "1.1.3",
 				"pretty-format": "20.0.3"
@@ -3446,6 +2977,7 @@
 			"version": "20.0.3",
 			"resolved": "https://registry.npmjs.org/jest-matchers/-/jest-matchers-20.0.3.tgz",
 			"integrity": "sha1-ymnbHDLbWm9wf6XgQBq7VXAN/WA=",
+			"dev": true,
 			"requires": {
 				"jest-diff": "20.0.3",
 				"jest-matcher-utils": "20.0.3",
@@ -3457,6 +2989,7 @@
 			"version": "20.0.3",
 			"resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-20.0.3.tgz",
 			"integrity": "sha1-auwoRDBvyw5udNV5bBAG2W/dgxw=",
+			"dev": true,
 			"requires": {
 				"chalk": "1.1.3",
 				"micromatch": "2.3.11",
@@ -3466,17 +2999,20 @@
 		"jest-mock": {
 			"version": "20.0.3",
 			"resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-20.0.3.tgz",
-			"integrity": "sha1-i8Bw6QQUqhVcEajWTIaaDVxx2lk="
+			"integrity": "sha1-i8Bw6QQUqhVcEajWTIaaDVxx2lk=",
+			"dev": true
 		},
 		"jest-regex-util": {
 			"version": "20.0.3",
 			"resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-20.0.3.tgz",
-			"integrity": "sha1-hburXRM+RGJbGfr4xqpRItCF12I="
+			"integrity": "sha1-hburXRM+RGJbGfr4xqpRItCF12I=",
+			"dev": true
 		},
 		"jest-resolve": {
 			"version": "20.0.4",
 			"resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-20.0.4.tgz",
 			"integrity": "sha1-lEiz6La6/BVHlETGSZBFt//ll6U=",
+			"dev": true,
 			"requires": {
 				"browser-resolve": "1.11.2",
 				"is-builtin-module": "1.0.0",
@@ -3487,6 +3023,7 @@
 			"version": "20.0.3",
 			"resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-20.0.3.tgz",
 			"integrity": "sha1-bhSntxevDyyzZnxUneQK8Bexcjo=",
+			"dev": true,
 			"requires": {
 				"jest-regex-util": "20.0.3"
 			}
@@ -3495,6 +3032,7 @@
 			"version": "20.0.4",
 			"resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-20.0.4.tgz",
 			"integrity": "sha1-osgCIZxCA/dU3xQE5JAYYWnRJNg=",
+			"dev": true,
 			"requires": {
 				"babel-core": "6.25.0",
 				"babel-jest": "20.0.3",
@@ -3516,7 +3054,8 @@
 				"strip-bom": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
-					"integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM="
+					"integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
+					"dev": true
 				}
 			}
 		},
@@ -3524,6 +3063,7 @@
 			"version": "20.0.3",
 			"resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-20.0.3.tgz",
 			"integrity": "sha1-W4R+GtsaTZCFKn+fElCG4YfHZWY=",
+			"dev": true,
 			"requires": {
 				"chalk": "1.1.3",
 				"jest-diff": "20.0.3",
@@ -3537,6 +3077,7 @@
 			"version": "20.0.3",
 			"resolved": "https://registry.npmjs.org/jest-util/-/jest-util-20.0.3.tgz",
 			"integrity": "sha1-DAf32A2C9OWmfG+LnD/n9lz9Mq0=",
+			"dev": true,
 			"requires": {
 				"chalk": "1.1.3",
 				"graceful-fs": "4.1.11",
@@ -3551,6 +3092,7 @@
 			"version": "20.0.3",
 			"resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-20.0.3.tgz",
 			"integrity": "sha1-0M/R3k9XnymEhJJcKA+PHZTsPKs=",
+			"dev": true,
 			"requires": {
 				"chalk": "1.1.3",
 				"jest-matcher-utils": "20.0.3",
@@ -3561,12 +3103,14 @@
 		"js-tokens": {
 			"version": "3.0.2",
 			"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
-			"integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls="
+			"integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls=",
+			"dev": true
 		},
 		"js-yaml": {
 			"version": "3.9.1",
 			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.9.1.tgz",
 			"integrity": "sha512-CbcG379L1e+mWBnLvHWWeLs8GyV/EMw862uLI3c+GxVyDHWZcjZinwuBd3iW2pgxgIlksW/1vNJa4to+RvDOww==",
+			"dev": true,
 			"requires": {
 				"argparse": "1.0.9",
 				"esprima": "4.0.0"
@@ -3576,12 +3120,14 @@
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
 			"integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
+			"dev": true,
 			"optional": true
 		},
 		"jsdom": {
 			"version": "9.12.0",
 			"resolved": "https://registry.npmjs.org/jsdom/-/jsdom-9.12.0.tgz",
 			"integrity": "sha1-6MVG//ywbADUgzyoRBD+1/igl9Q=",
+			"dev": true,
 			"requires": {
 				"abab": "1.0.3",
 				"acorn": "4.0.13",
@@ -3607,24 +3153,28 @@
 				"acorn": {
 					"version": "4.0.13",
 					"resolved": "https://registry.npmjs.org/acorn/-/acorn-4.0.13.tgz",
-					"integrity": "sha1-EFSVrlNh1pe9GVyCUZLhrX8lN4c="
+					"integrity": "sha1-EFSVrlNh1pe9GVyCUZLhrX8lN4c=",
+					"dev": true
 				}
 			}
 		},
 		"jsesc": {
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/jsesc/-/jsesc-1.3.0.tgz",
-			"integrity": "sha1-RsP+yMGJKxKwgz25vHYiF226s0s="
+			"integrity": "sha1-RsP+yMGJKxKwgz25vHYiF226s0s=",
+			"dev": true
 		},
 		"json-schema": {
 			"version": "0.2.3",
 			"resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
-			"integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM="
+			"integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
+			"dev": true
 		},
 		"json-stable-stringify": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
 			"integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
+			"dev": true,
 			"requires": {
 				"jsonify": "0.0.0"
 			}
@@ -3632,27 +3182,32 @@
 		"json-stringify-safe": {
 			"version": "5.0.1",
 			"resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-			"integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
+			"integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
+			"dev": true
 		},
 		"json5": {
 			"version": "0.5.1",
 			"resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
-			"integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE="
+			"integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE=",
+			"dev": true
 		},
 		"jsonify": {
 			"version": "0.0.0",
 			"resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
-			"integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM="
+			"integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=",
+			"dev": true
 		},
 		"jsonpointer": {
 			"version": "4.0.1",
 			"resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-4.0.1.tgz",
-			"integrity": "sha1-T9kss04OnbPInIYi7PUfm5eMbLk="
+			"integrity": "sha1-T9kss04OnbPInIYi7PUfm5eMbLk=",
+			"dev": true
 		},
 		"jsprim": {
 			"version": "1.4.1",
 			"resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
 			"integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
+			"dev": true,
 			"requires": {
 				"assert-plus": "1.0.0",
 				"extsprintf": "1.3.0",
@@ -3663,19 +3218,22 @@
 				"assert-plus": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-					"integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
+					"integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+					"dev": true
 				}
 			}
 		},
 		"jsx-ast-utils": {
 			"version": "1.4.1",
 			"resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-1.4.1.tgz",
-			"integrity": "sha1-OGchPo3Xm/Ho8jAMDPwe+xgsDfE="
+			"integrity": "sha1-OGchPo3Xm/Ho8jAMDPwe+xgsDfE=",
+			"dev": true
 		},
 		"kind-of": {
 			"version": "3.2.2",
 			"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
 			"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+			"dev": true,
 			"requires": {
 				"is-buffer": "1.1.5"
 			}
@@ -3684,12 +3242,14 @@
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz",
 			"integrity": "sha1-odePw6UEdMuAhF07O24dpJpEbo4=",
+			"dev": true,
 			"optional": true
 		},
 		"lcid": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
 			"integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
+			"dev": true,
 			"requires": {
 				"invert-kv": "1.0.0"
 			}
@@ -3697,12 +3257,14 @@
 		"leven": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/leven/-/leven-2.1.0.tgz",
-			"integrity": "sha1-wuep93IJTe6dNCAq6KzORoeHVYA="
+			"integrity": "sha1-wuep93IJTe6dNCAq6KzORoeHVYA=",
+			"dev": true
 		},
 		"levn": {
 			"version": "0.3.0",
 			"resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
 			"integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
+			"dev": true,
 			"requires": {
 				"prelude-ls": "1.1.2",
 				"type-check": "0.3.2"
@@ -3712,6 +3274,7 @@
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
 			"integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
+			"dev": true,
 			"requires": {
 				"graceful-fs": "4.1.11",
 				"parse-json": "2.2.0",
@@ -3724,6 +3287,7 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
 			"integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
+			"dev": true,
 			"requires": {
 				"p-locate": "2.0.0",
 				"path-exists": "3.0.0"
@@ -3732,62 +3296,73 @@
 				"path-exists": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
-					"integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU="
+					"integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
+					"dev": true
 				}
 			}
 		},
 		"lodash": {
 			"version": "4.17.4",
 			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
-			"integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4="
+			"integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4=",
+			"dev": true
 		},
 		"lodash.assign": {
 			"version": "4.2.0",
 			"resolved": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-4.2.0.tgz",
-			"integrity": "sha1-DZnzzNem0mHRm9rrkkUAXShYCOc="
+			"integrity": "sha1-DZnzzNem0mHRm9rrkkUAXShYCOc=",
+			"dev": true
 		},
 		"lodash.cond": {
 			"version": "4.5.2",
 			"resolved": "https://registry.npmjs.org/lodash.cond/-/lodash.cond-4.5.2.tgz",
-			"integrity": "sha1-9HGh2khr5g9quVXRcRVSPdHSVdU="
+			"integrity": "sha1-9HGh2khr5g9quVXRcRVSPdHSVdU=",
+			"dev": true
 		},
 		"lodash.endswith": {
 			"version": "4.2.1",
 			"resolved": "https://registry.npmjs.org/lodash.endswith/-/lodash.endswith-4.2.1.tgz",
-			"integrity": "sha1-/tWawXOO0+I27dcGTsRWRIs3vAk="
+			"integrity": "sha1-/tWawXOO0+I27dcGTsRWRIs3vAk=",
+			"dev": true
 		},
 		"lodash.find": {
 			"version": "4.6.0",
 			"resolved": "https://registry.npmjs.org/lodash.find/-/lodash.find-4.6.0.tgz",
-			"integrity": "sha1-ywcE1Hq3F4n/oN6Ll92Sb7iLE7E="
+			"integrity": "sha1-ywcE1Hq3F4n/oN6Ll92Sb7iLE7E=",
+			"dev": true
 		},
 		"lodash.findindex": {
 			"version": "4.6.0",
 			"resolved": "https://registry.npmjs.org/lodash.findindex/-/lodash.findindex-4.6.0.tgz",
-			"integrity": "sha1-oyRd7mH7m24GJLU1ElYku2nBEQY="
+			"integrity": "sha1-oyRd7mH7m24GJLU1ElYku2nBEQY=",
+			"dev": true
 		},
 		"lodash.pickby": {
 			"version": "4.6.0",
 			"resolved": "https://registry.npmjs.org/lodash.pickby/-/lodash.pickby-4.6.0.tgz",
-			"integrity": "sha1-feoh2MGNdwOifHBMFdO4SmfjOv8="
+			"integrity": "sha1-feoh2MGNdwOifHBMFdO4SmfjOv8=",
+			"dev": true
 		},
 		"longest": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
-			"integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc="
+			"integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc=",
+			"dev": true
 		},
 		"loose-envify": {
 			"version": "1.3.1",
 			"resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
 			"integrity": "sha1-0aitM/qc4OcT1l/dCsi3SNR4yEg=",
+			"dev": true,
 			"requires": {
 				"js-tokens": "3.0.2"
 			}
 		},
 		"magic-string": {
-			"version": "0.19.1",
-			"resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.19.1.tgz",
-			"integrity": "sha1-FNdoATyvLsj96hakmvgvw3fnUgE=",
+			"version": "0.22.4",
+			"resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.22.4.tgz",
+			"integrity": "sha512-kxBL06p6iO2qPBHsqGK2b3cRwiRGpnmSuVWNhwHcMX7qJOUr1HvricYP1LZOCdkQBUp0jiWg2d6WJwR3vYgByw==",
+			"dev": true,
 			"requires": {
 				"vlq": "0.2.2"
 			}
@@ -3796,6 +3371,7 @@
 			"version": "1.0.11",
 			"resolved": "https://registry.npmjs.org/makeerror/-/makeerror-1.0.11.tgz",
 			"integrity": "sha1-4BpckQnyr3lmDk6LlYd5AYT1qWw=",
+			"dev": true,
 			"requires": {
 				"tmpl": "1.0.4"
 			}
@@ -3803,12 +3379,14 @@
 		"merge": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/merge/-/merge-1.2.0.tgz",
-			"integrity": "sha1-dTHjnUlJwoGma4xabgJl6LBYlNo="
+			"integrity": "sha1-dTHjnUlJwoGma4xabgJl6LBYlNo=",
+			"dev": true
 		},
 		"micromatch": {
 			"version": "2.3.11",
 			"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
 			"integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
+			"dev": true,
 			"requires": {
 				"arr-diff": "2.0.0",
 				"array-unique": "0.2.1",
@@ -3828,12 +3406,14 @@
 		"mime-db": {
 			"version": "1.29.0",
 			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.29.0.tgz",
-			"integrity": "sha1-SNJtI1WJZRcErFkWygYAGRQmaHg="
+			"integrity": "sha1-SNJtI1WJZRcErFkWygYAGRQmaHg=",
+			"dev": true
 		},
 		"mime-types": {
 			"version": "2.1.16",
 			"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.16.tgz",
 			"integrity": "sha1-K4WKUuXs1RbbiXrCvodIeDBpjiM=",
+			"dev": true,
 			"requires": {
 				"mime-db": "1.29.0"
 			}
@@ -3842,6 +3422,7 @@
 			"version": "3.0.4",
 			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
 			"integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+			"dev": true,
 			"requires": {
 				"brace-expansion": "1.1.8"
 			}
@@ -3849,12 +3430,14 @@
 		"minimist": {
 			"version": "0.0.8",
 			"resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-			"integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
+			"integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+			"dev": true
 		},
 		"mkdirp": {
 			"version": "0.5.1",
 			"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
 			"integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+			"dev": true,
 			"requires": {
 				"minimist": "0.0.8"
 			}
@@ -3862,28 +3445,26 @@
 		"ms": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-			"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+			"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+			"dev": true
 		},
 		"mute-stream": {
 			"version": "0.0.5",
 			"resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.5.tgz",
-			"integrity": "sha1-j7+rsKmKJT0xhDMfno3rc3L6xsA="
-		},
-		"nan": {
-			"version": "2.6.2",
-			"resolved": "https://registry.npmjs.org/nan/-/nan-2.6.2.tgz",
-			"integrity": "sha1-5P805slf37WuzAjeZZb0NgWn20U=",
-			"optional": true
+			"integrity": "sha1-j7+rsKmKJT0xhDMfno3rc3L6xsA=",
+			"dev": true
 		},
 		"natural-compare": {
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
-			"integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc="
+			"integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
+			"dev": true
 		},
 		"node-fetch": {
 			"version": "1.7.1",
 			"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.1.tgz",
 			"integrity": "sha512-j8XsFGCLw79vWXkZtMSmmLaOk9z5SQ9bV/tkbZVCqvgwzrjAGq66igobLofHtF63NvMTp2WjytpsNTGKa+XRIQ==",
+			"dev": true,
 			"requires": {
 				"encoding": "0.1.12",
 				"is-stream": "1.1.0"
@@ -3892,12 +3473,14 @@
 		"node-int64": {
 			"version": "0.4.0",
 			"resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
-			"integrity": "sha1-h6kGXNs1XTGC2PlM4RGIuCXGijs="
+			"integrity": "sha1-h6kGXNs1XTGC2PlM4RGIuCXGijs=",
+			"dev": true
 		},
 		"node-notifier": {
 			"version": "5.1.2",
 			"resolved": "https://registry.npmjs.org/node-notifier/-/node-notifier-5.1.2.tgz",
 			"integrity": "sha1-L6nhJgX6EACdRFSdb82KY93g5P8=",
+			"dev": true,
 			"requires": {
 				"growly": "1.3.0",
 				"semver": "5.4.1",
@@ -3909,6 +3492,7 @@
 			"version": "2.4.0",
 			"resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
 			"integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
+			"dev": true,
 			"requires": {
 				"hosted-git-info": "2.5.0",
 				"is-builtin-module": "1.0.0",
@@ -3920,6 +3504,7 @@
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
 			"integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
+			"dev": true,
 			"requires": {
 				"remove-trailing-separator": "1.0.2"
 			}
@@ -3927,27 +3512,32 @@
 		"number-is-nan": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-			"integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
+			"integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
+			"dev": true
 		},
 		"nwmatcher": {
 			"version": "1.4.1",
 			"resolved": "https://registry.npmjs.org/nwmatcher/-/nwmatcher-1.4.1.tgz",
-			"integrity": "sha1-eumwew6oBNt+JfBctf5Al9TklJ8="
+			"integrity": "sha1-eumwew6oBNt+JfBctf5Al9TklJ8=",
+			"dev": true
 		},
 		"oauth-sign": {
 			"version": "0.8.2",
 			"resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
-			"integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM="
+			"integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM=",
+			"dev": true
 		},
 		"object-assign": {
 			"version": "4.1.1",
 			"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-			"integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
+			"integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+			"dev": true
 		},
 		"object.omit": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
 			"integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
+			"dev": true,
 			"requires": {
 				"for-own": "0.1.5",
 				"is-extendable": "0.1.1"
@@ -3957,6 +3547,7 @@
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
 			"integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+			"dev": true,
 			"requires": {
 				"wrappy": "1.0.2"
 			}
@@ -3964,12 +3555,14 @@
 		"onetime": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
-			"integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k="
+			"integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k=",
+			"dev": true
 		},
 		"optimist": {
 			"version": "0.6.1",
 			"resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
 			"integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
+			"dev": true,
 			"requires": {
 				"minimist": "0.0.8",
 				"wordwrap": "0.0.3"
@@ -3978,7 +3571,8 @@
 				"wordwrap": {
 					"version": "0.0.3",
 					"resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
-					"integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc="
+					"integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc=",
+					"dev": true
 				}
 			}
 		},
@@ -3986,6 +3580,7 @@
 			"version": "0.8.2",
 			"resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
 			"integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
+			"dev": true,
 			"requires": {
 				"deep-is": "0.1.3",
 				"fast-levenshtein": "2.0.6",
@@ -3998,12 +3593,14 @@
 		"os-homedir": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
-			"integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M="
+			"integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
+			"dev": true
 		},
 		"os-locale": {
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
 			"integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
+			"dev": true,
 			"requires": {
 				"lcid": "1.0.0"
 			}
@@ -4011,12 +3608,14 @@
 		"os-tmpdir": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
-			"integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ="
+			"integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
+			"dev": true
 		},
 		"output-file-sync": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/output-file-sync/-/output-file-sync-1.1.2.tgz",
 			"integrity": "sha1-0KM+7+YaIF+suQCS6CZZjVJFznY=",
+			"dev": true,
 			"requires": {
 				"graceful-fs": "4.1.11",
 				"mkdirp": "0.5.1",
@@ -4026,12 +3625,14 @@
 		"p-limit": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.1.0.tgz",
-			"integrity": "sha1-sH/y2aXYi+yAYDWJWiurZqJ5iLw="
+			"integrity": "sha1-sH/y2aXYi+yAYDWJWiurZqJ5iLw=",
+			"dev": true
 		},
 		"p-locate": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
 			"integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
+			"dev": true,
 			"requires": {
 				"p-limit": "1.1.0"
 			}
@@ -4039,12 +3640,14 @@
 		"p-map": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/p-map/-/p-map-1.1.1.tgz",
-			"integrity": "sha1-BfXkrpegaDcbwqXMhr+9vBnErno="
+			"integrity": "sha1-BfXkrpegaDcbwqXMhr+9vBnErno=",
+			"dev": true
 		},
 		"parse-glob": {
 			"version": "3.0.4",
 			"resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
 			"integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
+			"dev": true,
 			"requires": {
 				"glob-base": "0.3.0",
 				"is-dotfile": "1.0.3",
@@ -4056,6 +3659,7 @@
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
 			"integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
+			"dev": true,
 			"requires": {
 				"error-ex": "1.3.1"
 			}
@@ -4063,12 +3667,14 @@
 		"parse5": {
 			"version": "1.5.1",
 			"resolved": "https://registry.npmjs.org/parse5/-/parse5-1.5.1.tgz",
-			"integrity": "sha1-m387DeMr543CQBsXVzzK8Pb1nZQ="
+			"integrity": "sha1-m387DeMr543CQBsXVzzK8Pb1nZQ=",
+			"dev": true
 		},
 		"path-exists": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
 			"integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
+			"dev": true,
 			"requires": {
 				"pinkie-promise": "2.0.1"
 			}
@@ -4076,22 +3682,26 @@
 		"path-is-absolute": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-			"integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
+			"integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+			"dev": true
 		},
 		"path-is-inside": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.2.tgz",
-			"integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM="
+			"integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM=",
+			"dev": true
 		},
 		"path-parse": {
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.5.tgz",
-			"integrity": "sha1-PBrfhx6pzWyUMbbqK9dKD/BVxME="
+			"integrity": "sha1-PBrfhx6pzWyUMbbqK9dKD/BVxME=",
+			"dev": true
 		},
 		"path-type": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
 			"integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
+			"dev": true,
 			"requires": {
 				"graceful-fs": "4.1.11",
 				"pify": "2.3.0",
@@ -4101,22 +3711,26 @@
 		"performance-now": {
 			"version": "0.2.0",
 			"resolved": "https://registry.npmjs.org/performance-now/-/performance-now-0.2.0.tgz",
-			"integrity": "sha1-M+8wxcd9TqIcWlOGnZG1bY8lVeU="
+			"integrity": "sha1-M+8wxcd9TqIcWlOGnZG1bY8lVeU=",
+			"dev": true
 		},
 		"pify": {
 			"version": "2.3.0",
 			"resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-			"integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
+			"integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+			"dev": true
 		},
 		"pinkie": {
 			"version": "2.0.4",
 			"resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
-			"integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA="
+			"integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
+			"dev": true
 		},
 		"pinkie-promise": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
 			"integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
+			"dev": true,
 			"requires": {
 				"pinkie": "2.0.4"
 			}
@@ -4125,6 +3739,7 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-1.0.0.tgz",
 			"integrity": "sha1-ektQio1bstYp1EcFb/TpyTFM89Q=",
+			"dev": true,
 			"requires": {
 				"find-up": "1.1.2"
 			}
@@ -4133,6 +3748,7 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/pkg-up/-/pkg-up-1.0.0.tgz",
 			"integrity": "sha1-Pgj7RhUlxEIWJKM7n35tCvWwWiY=",
+			"dev": true,
 			"requires": {
 				"find-up": "1.1.2"
 			}
@@ -4140,22 +3756,26 @@
 		"pluralize": {
 			"version": "1.2.1",
 			"resolved": "https://registry.npmjs.org/pluralize/-/pluralize-1.2.1.tgz",
-			"integrity": "sha1-0aIUg/0iu0HlihL6NCGCMUCJfEU="
+			"integrity": "sha1-0aIUg/0iu0HlihL6NCGCMUCJfEU=",
+			"dev": true
 		},
 		"prelude-ls": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
-			"integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ="
+			"integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
+			"dev": true
 		},
 		"preserve": {
 			"version": "0.2.0",
 			"resolved": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz",
-			"integrity": "sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks="
+			"integrity": "sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks=",
+			"dev": true
 		},
 		"pretty-bytes": {
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-3.0.1.tgz",
 			"integrity": "sha1-J9AAjXeAY6C0gRuzXHnxvV1fvM8=",
+			"dev": true,
 			"requires": {
 				"number-is-nan": "1.0.1"
 			}
@@ -4164,6 +3784,7 @@
 			"version": "20.0.3",
 			"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-20.0.3.tgz",
 			"integrity": "sha1-Ag41ClYKH+GpjcO+tsz/s4beixQ=",
+			"dev": true,
 			"requires": {
 				"ansi-regex": "2.1.1",
 				"ansi-styles": "3.2.0"
@@ -4173,6 +3794,7 @@
 					"version": "3.2.0",
 					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
 					"integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+					"dev": true,
 					"requires": {
 						"color-convert": "1.9.0"
 					}
@@ -4182,22 +3804,26 @@
 		"private": {
 			"version": "0.1.7",
 			"resolved": "https://registry.npmjs.org/private/-/private-0.1.7.tgz",
-			"integrity": "sha1-aM5eih7woju1cMwoU3tTMqumPvE="
+			"integrity": "sha1-aM5eih7woju1cMwoU3tTMqumPvE=",
+			"dev": true
 		},
 		"process-nextick-args": {
 			"version": "1.0.7",
 			"resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
-			"integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M="
+			"integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M=",
+			"dev": true
 		},
 		"progress": {
 			"version": "1.1.8",
 			"resolved": "https://registry.npmjs.org/progress/-/progress-1.1.8.tgz",
-			"integrity": "sha1-4mDHj2Fhzdmw5WzD4Khd4Xx6V74="
+			"integrity": "sha1-4mDHj2Fhzdmw5WzD4Khd4Xx6V74=",
+			"dev": true
 		},
 		"promise": {
 			"version": "7.3.1",
 			"resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
 			"integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==",
+			"dev": true,
 			"requires": {
 				"asap": "2.0.6"
 			}
@@ -4206,6 +3832,7 @@
 			"version": "15.5.10",
 			"resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.5.10.tgz",
 			"integrity": "sha1-J5ffwxJhguOpXj37suiT3ddFYVQ=",
+			"dev": true,
 			"requires": {
 				"fbjs": "0.8.14",
 				"loose-envify": "1.3.1"
@@ -4214,22 +3841,26 @@
 		"prr": {
 			"version": "0.0.0",
 			"resolved": "https://registry.npmjs.org/prr/-/prr-0.0.0.tgz",
-			"integrity": "sha1-GoS4WQgyVQFBGFPQCB7j+obikmo="
+			"integrity": "sha1-GoS4WQgyVQFBGFPQCB7j+obikmo=",
+			"dev": true
 		},
 		"punycode": {
 			"version": "1.4.1",
 			"resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
-			"integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
+			"integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
+			"dev": true
 		},
 		"qs": {
 			"version": "6.4.0",
 			"resolved": "https://registry.npmjs.org/qs/-/qs-6.4.0.tgz",
-			"integrity": "sha1-E+JtKK1rD/qpExLNO/cI7TUecjM="
+			"integrity": "sha1-E+JtKK1rD/qpExLNO/cI7TUecjM=",
+			"dev": true
 		},
 		"randomatic": {
 			"version": "1.1.7",
 			"resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.7.tgz",
 			"integrity": "sha512-D5JUjPyJbaJDkuAazpVnSfVkLlpeO3wDlPROTMLGKG1zMFNFRgrciKo1ltz/AzNTkqE0HzDx655QOL51N06how==",
+			"dev": true,
 			"requires": {
 				"is-number": "3.0.0",
 				"kind-of": "4.0.0"
@@ -4239,6 +3870,7 @@
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
 					"integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+					"dev": true,
 					"requires": {
 						"kind-of": "3.2.2"
 					},
@@ -4247,6 +3879,7 @@
 							"version": "3.2.2",
 							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
 							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+							"dev": true,
 							"requires": {
 								"is-buffer": "1.1.5"
 							}
@@ -4257,6 +3890,7 @@
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
 					"integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
+					"dev": true,
 					"requires": {
 						"is-buffer": "1.1.5"
 					}
@@ -4267,6 +3901,7 @@
 			"version": "15.6.1",
 			"resolved": "https://registry.npmjs.org/react/-/react-15.6.1.tgz",
 			"integrity": "sha1-uqhDTsZ4C96ZfNw4C3nNM7ljk98=",
+			"dev": true,
 			"requires": {
 				"create-react-class": "15.6.0",
 				"fbjs": "0.8.14",
@@ -4278,12 +3913,14 @@
 		"react-addons-test-utils": {
 			"version": "15.6.0",
 			"resolved": "https://registry.npmjs.org/react-addons-test-utils/-/react-addons-test-utils-15.6.0.tgz",
-			"integrity": "sha1-Bi02EX/o0Y87peBuszODsLhepbk="
+			"integrity": "sha1-Bi02EX/o0Y87peBuszODsLhepbk=",
+			"dev": true
 		},
 		"react-dom": {
 			"version": "15.6.1",
 			"resolved": "https://registry.npmjs.org/react-dom/-/react-dom-15.6.1.tgz",
 			"integrity": "sha1-LLDtQZEDjlPCCes6eaI+Kkz5lHA=",
+			"dev": true,
 			"requires": {
 				"fbjs": "0.8.14",
 				"loose-envify": "1.3.1",
@@ -4295,6 +3932,7 @@
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
 			"integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
+			"dev": true,
 			"requires": {
 				"load-json-file": "1.1.0",
 				"normalize-package-data": "2.4.0",
@@ -4305,6 +3943,7 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
 			"integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
+			"dev": true,
 			"requires": {
 				"find-up": "1.1.2",
 				"read-pkg": "1.1.0"
@@ -4314,6 +3953,7 @@
 			"version": "2.3.3",
 			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
 			"integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
+			"dev": true,
 			"requires": {
 				"core-util-is": "1.0.2",
 				"inherits": "2.0.3",
@@ -4328,6 +3968,7 @@
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/readdirp/-/readdirp-2.1.0.tgz",
 			"integrity": "sha1-TtCtBg3zBzMAxIRANz9y0cxkLXg=",
+			"dev": true,
 			"optional": true,
 			"requires": {
 				"graceful-fs": "4.1.11",
@@ -4340,6 +3981,7 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/readline2/-/readline2-1.0.1.tgz",
 			"integrity": "sha1-QQWWCP/BVHV7cV2ZidGZ/783LjU=",
+			"dev": true,
 			"requires": {
 				"code-point-at": "1.1.0",
 				"is-fullwidth-code-point": "1.0.0",
@@ -4349,17 +3991,20 @@
 		"regenerate": {
 			"version": "1.3.2",
 			"resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.3.2.tgz",
-			"integrity": "sha1-0ZQcZ7rUN+G+dkM63Vs4X5WxkmA="
+			"integrity": "sha1-0ZQcZ7rUN+G+dkM63Vs4X5WxkmA=",
+			"dev": true
 		},
 		"regenerator-runtime": {
 			"version": "0.10.5",
 			"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz",
-			"integrity": "sha1-M2w+/BIgrc7dosn6tntaeVWjNlg="
+			"integrity": "sha1-M2w+/BIgrc7dosn6tntaeVWjNlg=",
+			"dev": true
 		},
 		"regenerator-transform": {
 			"version": "0.9.11",
 			"resolved": "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.9.11.tgz",
 			"integrity": "sha1-On0GdSDLe3F2dp61/4aGkb7+EoM=",
+			"dev": true,
 			"requires": {
 				"babel-runtime": "6.25.0",
 				"babel-types": "6.25.0",
@@ -4370,6 +4015,7 @@
 			"version": "0.4.3",
 			"resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.3.tgz",
 			"integrity": "sha1-mxpsNdTQ3871cRrmUejp09cRQUU=",
+			"dev": true,
 			"requires": {
 				"is-equal-shallow": "0.1.3",
 				"is-primitive": "2.0.0"
@@ -4379,6 +4025,7 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-2.0.0.tgz",
 			"integrity": "sha1-SdA4g3uNz4v6W5pCE5k45uoq4kA=",
+			"dev": true,
 			"requires": {
 				"regenerate": "1.3.2",
 				"regjsgen": "0.2.0",
@@ -4388,12 +4035,14 @@
 		"regjsgen": {
 			"version": "0.2.0",
 			"resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.2.0.tgz",
-			"integrity": "sha1-bAFq3qxVT3WCP+N6wFuS1aTtsfc="
+			"integrity": "sha1-bAFq3qxVT3WCP+N6wFuS1aTtsfc=",
+			"dev": true
 		},
 		"regjsparser": {
 			"version": "0.1.5",
 			"resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.1.5.tgz",
 			"integrity": "sha1-fuj4Tcb6eS0/0K4ijSS9lJ6tIFw=",
+			"dev": true,
 			"requires": {
 				"jsesc": "0.5.0"
 			},
@@ -4401,29 +4050,34 @@
 				"jsesc": {
 					"version": "0.5.0",
 					"resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
-					"integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0="
+					"integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0=",
+					"dev": true
 				}
 			}
 		},
 		"remove-trailing-separator": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.0.2.tgz",
-			"integrity": "sha1-abBi2XhyetFNxrVrpKt3L9jXBRE="
+			"integrity": "sha1-abBi2XhyetFNxrVrpKt3L9jXBRE=",
+			"dev": true
 		},
 		"repeat-element": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz",
-			"integrity": "sha1-7wiaF40Ug7quTZPrmLT55OEdmQo="
+			"integrity": "sha1-7wiaF40Ug7quTZPrmLT55OEdmQo=",
+			"dev": true
 		},
 		"repeat-string": {
 			"version": "1.6.1",
 			"resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
-			"integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc="
+			"integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
+			"dev": true
 		},
 		"repeating": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
 			"integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
+			"dev": true,
 			"requires": {
 				"is-finite": "1.0.2"
 			}
@@ -4432,6 +4086,7 @@
 			"version": "2.81.0",
 			"resolved": "https://registry.npmjs.org/request/-/request-2.81.0.tgz",
 			"integrity": "sha1-xpKJRqDgbF+Nb4qTM0af/aRimKA=",
+			"dev": true,
 			"requires": {
 				"aws-sign2": "0.6.0",
 				"aws4": "1.6.0",
@@ -4460,17 +4115,20 @@
 		"require-directory": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
-			"integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I="
+			"integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
+			"dev": true
 		},
 		"require-main-filename": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
-			"integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE="
+			"integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE=",
+			"dev": true
 		},
 		"require-uncached": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/require-uncached/-/require-uncached-1.0.3.tgz",
 			"integrity": "sha1-Tg1W1slmL9MeQwEcS5WqSZVUIdM=",
+			"dev": true,
 			"requires": {
 				"caller-path": "0.1.0",
 				"resolve-from": "1.0.1"
@@ -4480,6 +4138,7 @@
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.4.0.tgz",
 			"integrity": "sha512-aW7sVKPufyHqOmyyLzg/J+8606v5nevBgaliIlV7nUpVMsDnoBGV/cbSLNjZAg9q0Cfd/+easKVKQ8vOu8fn1Q==",
+			"dev": true,
 			"requires": {
 				"path-parse": "1.0.5"
 			}
@@ -4487,12 +4146,14 @@
 		"resolve-from": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-1.0.1.tgz",
-			"integrity": "sha1-Jsv+k10a7uq7Kbw/5a6wHpPUQiY="
+			"integrity": "sha1-Jsv+k10a7uq7Kbw/5a6wHpPUQiY=",
+			"dev": true
 		},
 		"restore-cursor": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-1.0.1.tgz",
 			"integrity": "sha1-NGYfRohjJ/7SmRR5FSJS35LapUE=",
+			"dev": true,
 			"requires": {
 				"exit-hook": "1.1.1",
 				"onetime": "1.1.0"
@@ -4502,6 +4163,7 @@
 			"version": "0.1.3",
 			"resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
 			"integrity": "sha1-YTObci/mo1FWiSENJOFMlhSGE+8=",
+			"dev": true,
 			"optional": true,
 			"requires": {
 				"align-text": "0.1.4"
@@ -4511,58 +4173,61 @@
 			"version": "2.6.1",
 			"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.1.tgz",
 			"integrity": "sha1-wjOOxkPfeht/5cVPqG9XQopV8z0=",
+			"dev": true,
 			"requires": {
 				"glob": "7.1.2"
 			}
 		},
 		"rollup": {
-			"version": "0.45.2",
-			"resolved": "https://registry.npmjs.org/rollup/-/rollup-0.45.2.tgz",
-			"integrity": "sha512-2+bq5GQSrocdhr+M92mOQRmF1evtLRzv9NdmEC2wo7BILvTG8irHCtD0q+zg8ikNu63iJicdN5IzyxAXRTFKOQ==",
-			"requires": {
-				"source-map-support": "0.4.15"
-			}
+			"version": "0.48.2",
+			"resolved": "https://registry.npmjs.org/rollup/-/rollup-0.48.2.tgz",
+			"integrity": "sha512-5IOVEA87/OWQlojaAPN0WStLAhlaY7GS/5p+pA/IHReXjtc+d7IJYgRD3Y/U2LVXoD7f1SBc3ymYd4g3M/zRzQ==",
+			"dev": true
 		},
 		"rollup-plugin-babel": {
-			"version": "2.7.1",
-			"resolved": "https://registry.npmjs.org/rollup-plugin-babel/-/rollup-plugin-babel-2.7.1.tgz",
-			"integrity": "sha1-FlKBl7D5OKFTb0RoPHqT1XMYL1c=",
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/rollup-plugin-babel/-/rollup-plugin-babel-3.0.2.tgz",
+			"integrity": "sha512-ALGPBFtwJZcYHsNPM6RGJlEncTzAARPvZOGjNPZgDe5hS5t6sJGjiOWibEFVEz5LQN7S7spvCBILaS4N1Cql2w==",
+			"dev": true,
 			"requires": {
-				"babel-core": "6.25.0",
-				"babel-plugin-transform-es2015-classes": "6.24.1",
-				"object-assign": "4.1.1",
 				"rollup-pluginutils": "1.5.2"
 			}
 		},
 		"rollup-plugin-commonjs": {
-			"version": "8.0.2",
-			"resolved": "https://registry.npmjs.org/rollup-plugin-commonjs/-/rollup-plugin-commonjs-8.0.2.tgz",
-			"integrity": "sha1-mLFYm/4ypsD2d5C2DAtJmXKv7Yk=",
+			"version": "8.2.0",
+			"resolved": "https://registry.npmjs.org/rollup-plugin-commonjs/-/rollup-plugin-commonjs-8.2.0.tgz",
+			"integrity": "sha512-EhSkStWuGtfFBI9l89KfUb7yOw3IpcQAtYao/R20FvkiKHDndEF9cyWhuUoSW0igY2/hdH0EeUl/3b9d5xHL3w==",
+			"dev": true,
 			"requires": {
-				"acorn": "4.0.13",
-				"estree-walker": "0.3.1",
-				"magic-string": "0.19.1",
+				"acorn": "5.1.1",
+				"estree-walker": "0.5.0",
+				"magic-string": "0.22.4",
 				"resolve": "1.4.0",
 				"rollup-pluginutils": "2.0.1"
 			},
 			"dependencies": {
-				"acorn": {
-					"version": "4.0.13",
-					"resolved": "https://registry.npmjs.org/acorn/-/acorn-4.0.13.tgz",
-					"integrity": "sha1-EFSVrlNh1pe9GVyCUZLhrX8lN4c="
-				},
 				"estree-walker": {
-					"version": "0.3.1",
-					"resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-0.3.1.tgz",
-					"integrity": "sha1-5rGlHPcpJSTnI3wxLl/mZgwc4ao="
+					"version": "0.5.0",
+					"resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-0.5.0.tgz",
+					"integrity": "sha512-/bEAy+yKAZQrEWUhGmS3H9XpGqSDBtRzX0I2PgMw9kA2n1jN22uV5B5p7MFdZdvWdXCRJztXAfx6ZeRfgkEETg==",
+					"dev": true
 				},
 				"rollup-pluginutils": {
 					"version": "2.0.1",
 					"resolved": "https://registry.npmjs.org/rollup-pluginutils/-/rollup-pluginutils-2.0.1.tgz",
 					"integrity": "sha1-fslbNXP2VDpGpkYb2afFRFJdD8A=",
+					"dev": true,
 					"requires": {
 						"estree-walker": "0.3.1",
 						"micromatch": "2.3.11"
+					},
+					"dependencies": {
+						"estree-walker": {
+							"version": "0.3.1",
+							"resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-0.3.1.tgz",
+							"integrity": "sha1-5rGlHPcpJSTnI3wxLl/mZgwc4ao=",
+							"dev": true
+						}
 					}
 				}
 			}
@@ -4571,6 +4236,7 @@
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/rollup-plugin-node-resolve/-/rollup-plugin-node-resolve-3.0.0.tgz",
 			"integrity": "sha1-i4l8TDAw1QASd7BRSyXSygloPuA=",
+			"dev": true,
 			"requires": {
 				"browser-resolve": "1.11.2",
 				"builtin-modules": "1.1.1",
@@ -4582,6 +4248,7 @@
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/rollup-plugin-replace/-/rollup-plugin-replace-1.1.1.tgz",
 			"integrity": "sha1-OWMV3tBQps5DuVGKiGo/YO+x6jM=",
+			"dev": true,
 			"requires": {
 				"magic-string": "0.15.2",
 				"minimatch": "3.0.4",
@@ -4592,6 +4259,7 @@
 					"version": "0.15.2",
 					"resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.15.2.tgz",
 					"integrity": "sha1-BoHXOIdBu8Ot2qZQYJkmJMbAnpw=",
+					"dev": true,
 					"requires": {
 						"vlq": "0.2.2"
 					}
@@ -4602,6 +4270,7 @@
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/rollup-plugin-uglify/-/rollup-plugin-uglify-2.0.1.tgz",
 			"integrity": "sha1-Z7N60e/a+9g69MNrQMGJ7khmyWk=",
+			"dev": true,
 			"requires": {
 				"uglify-js": "3.0.27"
 			},
@@ -4610,6 +4279,7 @@
 					"version": "3.0.27",
 					"resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.0.27.tgz",
 					"integrity": "sha512-HD8CmxPXUI62v5tweiulMcP/apAtx1DXGcNZkhKQZyC+MTrTsoCBb8yPAwVrbvpgw3EpRU76bRe6axjIiCYcQg==",
+					"dev": true,
 					"requires": {
 						"commander": "2.11.0",
 						"source-map": "0.5.6"
@@ -4621,6 +4291,7 @@
 			"version": "1.5.2",
 			"resolved": "https://registry.npmjs.org/rollup-pluginutils/-/rollup-pluginutils-1.5.2.tgz",
 			"integrity": "sha1-HhVud4+UtyVb+hs9AXi+j1xVJAg=",
+			"dev": true,
 			"requires": {
 				"estree-walker": "0.2.1",
 				"minimatch": "3.0.4"
@@ -4630,6 +4301,7 @@
 			"version": "0.1.0",
 			"resolved": "https://registry.npmjs.org/run-async/-/run-async-0.1.0.tgz",
 			"integrity": "sha1-yK1KXhEGYeQCp9IbUw4AnyX444k=",
+			"dev": true,
 			"requires": {
 				"once": "1.4.0"
 			}
@@ -4637,17 +4309,20 @@
 		"rx-lite": {
 			"version": "3.1.2",
 			"resolved": "https://registry.npmjs.org/rx-lite/-/rx-lite-3.1.2.tgz",
-			"integrity": "sha1-Gc5QLKVyZl87ZHsQk5+X/RYV8QI="
+			"integrity": "sha1-Gc5QLKVyZl87ZHsQk5+X/RYV8QI=",
+			"dev": true
 		},
 		"safe-buffer": {
 			"version": "5.1.1",
 			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
-			"integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg=="
+			"integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg==",
+			"dev": true
 		},
 		"sane": {
 			"version": "1.6.0",
 			"resolved": "https://registry.npmjs.org/sane/-/sane-1.6.0.tgz",
 			"integrity": "sha1-lhDEUjB6E10pwf3+JUcDQYDEZ3U=",
+			"dev": true,
 			"requires": {
 				"anymatch": "1.3.2",
 				"exec-sh": "0.2.0",
@@ -4662,6 +4337,7 @@
 					"version": "1.0.2",
 					"resolved": "https://registry.npmjs.org/bser/-/bser-1.0.2.tgz",
 					"integrity": "sha1-OBEWlwsqbe6lZG3RXdcnhES1YWk=",
+					"dev": true,
 					"requires": {
 						"node-int64": "0.4.0"
 					}
@@ -4670,6 +4346,7 @@
 					"version": "1.9.2",
 					"resolved": "https://registry.npmjs.org/fb-watchman/-/fb-watchman-1.9.2.tgz",
 					"integrity": "sha1-okz0eCf4LTj7Waaa1wt247auc4M=",
+					"dev": true,
 					"requires": {
 						"bser": "1.0.2"
 					}
@@ -4677,60 +4354,71 @@
 				"minimist": {
 					"version": "1.2.0",
 					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
+					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+					"dev": true
 				}
 			}
 		},
 		"sax": {
 			"version": "1.2.4",
 			"resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
-			"integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
+			"integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
+			"dev": true
 		},
 		"semver": {
 			"version": "5.4.1",
 			"resolved": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz",
-			"integrity": "sha512-WfG/X9+oATh81XtllIo/I8gOiY9EXRdv1cQdyykeXK17YcUW3EXUAi2To4pcH6nZtJPr7ZOpM5OMyWJZm+8Rsg=="
+			"integrity": "sha512-WfG/X9+oATh81XtllIo/I8gOiY9EXRdv1cQdyykeXK17YcUW3EXUAi2To4pcH6nZtJPr7ZOpM5OMyWJZm+8Rsg==",
+			"dev": true
 		},
 		"set-blocking": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
-			"integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc="
+			"integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
+			"dev": true
 		},
 		"set-immediate-shim": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz",
 			"integrity": "sha1-SysbJ+uAip+NzEgaWOXlb1mfP2E=",
+			"dev": true,
 			"optional": true
 		},
 		"setimmediate": {
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
-			"integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU="
+			"integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU=",
+			"dev": true
 		},
 		"shelljs": {
 			"version": "0.6.1",
 			"resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.6.1.tgz",
-			"integrity": "sha1-7GIRvtGSBEIIj+D3Cyg3Iy7SyKg="
+			"integrity": "sha1-7GIRvtGSBEIIj+D3Cyg3Iy7SyKg=",
+			"dev": true
 		},
 		"shellwords": {
 			"version": "0.1.0",
 			"resolved": "https://registry.npmjs.org/shellwords/-/shellwords-0.1.0.tgz",
-			"integrity": "sha1-Zq/Ue2oSky2Qccv9mKUueFzQuhQ="
+			"integrity": "sha1-Zq/Ue2oSky2Qccv9mKUueFzQuhQ=",
+			"dev": true
 		},
 		"slash": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz",
-			"integrity": "sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU="
+			"integrity": "sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU=",
+			"dev": true
 		},
 		"slice-ansi": {
 			"version": "0.0.4",
 			"resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-0.0.4.tgz",
-			"integrity": "sha1-7b+JA/ZvfOL46v1s7tZeJkyDGzU="
+			"integrity": "sha1-7b+JA/ZvfOL46v1s7tZeJkyDGzU=",
+			"dev": true
 		},
 		"sntp": {
 			"version": "1.0.9",
 			"resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
 			"integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
+			"dev": true,
 			"requires": {
 				"hoek": "2.16.3"
 			}
@@ -4738,12 +4426,14 @@
 		"source-map": {
 			"version": "0.5.6",
 			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
-			"integrity": "sha1-dc449SvwczxafwwRjYEzSiu19BI="
+			"integrity": "sha1-dc449SvwczxafwwRjYEzSiu19BI=",
+			"dev": true
 		},
 		"source-map-support": {
 			"version": "0.4.15",
 			"resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.15.tgz",
 			"integrity": "sha1-AyAt9lwG0r2MfsI2KhkwVv7407E=",
+			"dev": true,
 			"requires": {
 				"source-map": "0.5.6"
 			}
@@ -4752,6 +4442,7 @@
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
 			"integrity": "sha1-SzBz2TP/UfORLwOsVRlJikFQ20A=",
+			"dev": true,
 			"requires": {
 				"spdx-license-ids": "1.2.2"
 			}
@@ -4759,22 +4450,26 @@
 		"spdx-expression-parse": {
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.4.tgz",
-			"integrity": "sha1-m98vIOH0DtRH++JzJmGR/O1RYmw="
+			"integrity": "sha1-m98vIOH0DtRH++JzJmGR/O1RYmw=",
+			"dev": true
 		},
 		"spdx-license-ids": {
 			"version": "1.2.2",
 			"resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.2.tgz",
-			"integrity": "sha1-yd96NCRZSt5r0RkA1ZZpbcBrrFc="
+			"integrity": "sha1-yd96NCRZSt5r0RkA1ZZpbcBrrFc=",
+			"dev": true
 		},
 		"sprintf-js": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-			"integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
+			"integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
+			"dev": true
 		},
 		"sshpk": {
 			"version": "1.13.1",
 			"resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.13.1.tgz",
 			"integrity": "sha1-US322mKHFEMW3EwY/hzx2UBzm+M=",
+			"dev": true,
 			"requires": {
 				"asn1": "0.2.3",
 				"assert-plus": "1.0.0",
@@ -4789,7 +4484,8 @@
 				"assert-plus": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-					"integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
+					"integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+					"dev": true
 				}
 			}
 		},
@@ -4797,6 +4493,7 @@
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
 			"integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+			"dev": true,
 			"requires": {
 				"safe-buffer": "5.1.1"
 			}
@@ -4805,6 +4502,7 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/string-length/-/string-length-1.0.1.tgz",
 			"integrity": "sha1-VpcPscOFWOnnC3KL894mmsRa36w=",
+			"dev": true,
 			"requires": {
 				"strip-ansi": "3.0.1"
 			}
@@ -4813,6 +4511,7 @@
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
 			"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+			"dev": true,
 			"requires": {
 				"code-point-at": "1.1.0",
 				"is-fullwidth-code-point": "1.0.0",
@@ -4822,12 +4521,14 @@
 		"stringstream": {
 			"version": "0.0.5",
 			"resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
-			"integrity": "sha1-TkhM1N5aC7vuGORjB3EKioFiGHg="
+			"integrity": "sha1-TkhM1N5aC7vuGORjB3EKioFiGHg=",
+			"dev": true
 		},
 		"strip-ansi": {
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
 			"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+			"dev": true,
 			"requires": {
 				"ansi-regex": "2.1.1"
 			}
@@ -4836,6 +4537,7 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
 			"integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
+			"dev": true,
 			"requires": {
 				"is-utf8": "0.2.1"
 			}
@@ -4843,22 +4545,26 @@
 		"strip-json-comments": {
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.4.tgz",
-			"integrity": "sha1-HhX7ysl9Pumb8tc7TGVrCCu6+5E="
+			"integrity": "sha1-HhX7ysl9Pumb8tc7TGVrCCu6+5E=",
+			"dev": true
 		},
 		"supports-color": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-			"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
+			"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+			"dev": true
 		},
 		"symbol-tree": {
 			"version": "3.2.2",
 			"resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.2.tgz",
-			"integrity": "sha1-rifbOPZgp64uHDt9G8KQgZuFGeY="
+			"integrity": "sha1-rifbOPZgp64uHDt9G8KQgZuFGeY=",
+			"dev": true
 		},
 		"table": {
 			"version": "3.8.3",
 			"resolved": "https://registry.npmjs.org/table/-/table-3.8.3.tgz",
 			"integrity": "sha1-K7xULw/amGGnVdOUf+/Ys/UThV8=",
+			"dev": true,
 			"requires": {
 				"ajv": "4.11.8",
 				"ajv-keywords": "1.5.1",
@@ -4871,17 +4577,20 @@
 				"ansi-regex": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
+					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+					"dev": true
 				},
 				"is-fullwidth-code-point": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-					"integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
+					"integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+					"dev": true
 				},
 				"string-width": {
 					"version": "2.1.1",
 					"resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
 					"integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+					"dev": true,
 					"requires": {
 						"is-fullwidth-code-point": "2.0.0",
 						"strip-ansi": "4.0.0"
@@ -4891,6 +4600,7 @@
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
 					"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+					"dev": true,
 					"requires": {
 						"ansi-regex": "3.0.0"
 					}
@@ -4901,6 +4611,7 @@
 			"version": "4.1.1",
 			"resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-4.1.1.tgz",
 			"integrity": "sha512-35+Asrsk3XHJDBgf/VRFexPgh3UyETv8IAn/LRTiZjVy6rjPVqdEk8dJcJYBzl1w0XCJM48lvTy8SfEsCWS4nA==",
+			"dev": true,
 			"requires": {
 				"arrify": "1.0.1",
 				"micromatch": "2.3.11",
@@ -4912,32 +4623,38 @@
 		"text-table": {
 			"version": "0.2.0",
 			"resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
-			"integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ="
+			"integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
+			"dev": true
 		},
 		"throat": {
 			"version": "3.2.0",
 			"resolved": "https://registry.npmjs.org/throat/-/throat-3.2.0.tgz",
-			"integrity": "sha512-/EY8VpvlqJ+sFtLPeOgc8Pl7kQVOWv0woD87KTXVHPIAE842FGT+rokxIhe8xIUP1cfgrkt0as0vDLjDiMtr8w=="
+			"integrity": "sha512-/EY8VpvlqJ+sFtLPeOgc8Pl7kQVOWv0woD87KTXVHPIAE842FGT+rokxIhe8xIUP1cfgrkt0as0vDLjDiMtr8w==",
+			"dev": true
 		},
 		"through": {
 			"version": "2.3.8",
 			"resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
-			"integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
+			"integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
+			"dev": true
 		},
 		"tmpl": {
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.4.tgz",
-			"integrity": "sha1-I2QN17QtAEM5ERQIIOXPRA5SHdE="
+			"integrity": "sha1-I2QN17QtAEM5ERQIIOXPRA5SHdE=",
+			"dev": true
 		},
 		"to-fast-properties": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz",
-			"integrity": "sha1-uDVx+k2MJbguIxsG46MFXeTKGkc="
+			"integrity": "sha1-uDVx+k2MJbguIxsG46MFXeTKGkc=",
+			"dev": true
 		},
 		"tough-cookie": {
 			"version": "2.3.2",
 			"resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.2.tgz",
 			"integrity": "sha1-8IH3bkyFcg5sN6X6ztc3FQ2EByo=",
+			"dev": true,
 			"requires": {
 				"punycode": "1.4.1"
 			}
@@ -4945,22 +4662,26 @@
 		"tr46": {
 			"version": "0.0.3",
 			"resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-			"integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o="
+			"integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o=",
+			"dev": true
 		},
 		"trim-right": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz",
-			"integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM="
+			"integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM=",
+			"dev": true
 		},
 		"tryit": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/tryit/-/tryit-1.0.3.tgz",
-			"integrity": "sha1-OTvnMKlEb9Hq1tpZoBQwjzbCics="
+			"integrity": "sha1-OTvnMKlEb9Hq1tpZoBQwjzbCics=",
+			"dev": true
 		},
 		"tunnel-agent": {
 			"version": "0.6.0",
 			"resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
 			"integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
+			"dev": true,
 			"requires": {
 				"safe-buffer": "5.1.1"
 			}
@@ -4969,12 +4690,14 @@
 			"version": "0.14.5",
 			"resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
 			"integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
+			"dev": true,
 			"optional": true
 		},
 		"type-check": {
 			"version": "0.3.2",
 			"resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
 			"integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
+			"dev": true,
 			"requires": {
 				"prelude-ls": "1.1.2"
 			}
@@ -4982,17 +4705,20 @@
 		"typedarray": {
 			"version": "0.0.6",
 			"resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
-			"integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
+			"integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
+			"dev": true
 		},
 		"ua-parser-js": {
 			"version": "0.7.14",
 			"resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.14.tgz",
-			"integrity": "sha1-EQ1T+kw/MmwSEpK76skE0uAzh8o="
+			"integrity": "sha1-EQ1T+kw/MmwSEpK76skE0uAzh8o=",
+			"dev": true
 		},
 		"uglify-js": {
 			"version": "2.8.29",
 			"resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.29.tgz",
 			"integrity": "sha1-KcVzMUgFe7Th913zW3qcty5qWd0=",
+			"dev": true,
 			"optional": true,
 			"requires": {
 				"source-map": "0.5.6",
@@ -5004,6 +4730,7 @@
 					"version": "3.10.0",
 					"resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
 					"integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"camelcase": "1.2.1",
@@ -5018,27 +4745,32 @@
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
 			"integrity": "sha1-bgkk1r2mta/jSeOabWMoUKD4grc=",
+			"dev": true,
 			"optional": true
 		},
 		"user-home": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/user-home/-/user-home-1.1.1.tgz",
-			"integrity": "sha1-K1viOjK2Onyd640PKNSFcko98ZA="
+			"integrity": "sha1-K1viOjK2Onyd640PKNSFcko98ZA=",
+			"dev": true
 		},
 		"util-deprecate": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-			"integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
+			"integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+			"dev": true
 		},
 		"uuid": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/uuid/-/uuid-3.1.0.tgz",
-			"integrity": "sha512-DIWtzUkw04M4k3bf1IcpS2tngXEL26YUD2M0tMDUpnUrz2hgzUBlD55a4FjdLGPvfHxS6uluGWvaVEqgBcVa+g=="
+			"integrity": "sha512-DIWtzUkw04M4k3bf1IcpS2tngXEL26YUD2M0tMDUpnUrz2hgzUBlD55a4FjdLGPvfHxS6uluGWvaVEqgBcVa+g==",
+			"dev": true
 		},
 		"v8flags": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/v8flags/-/v8flags-2.1.1.tgz",
 			"integrity": "sha1-qrGh+jDUX4jdMhFIh1rALAtV5bQ=",
+			"dev": true,
 			"requires": {
 				"user-home": "1.1.1"
 			}
@@ -5047,6 +4779,7 @@
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz",
 			"integrity": "sha1-KAS6vnEq0zeUWaz74kdGqywwP7w=",
+			"dev": true,
 			"requires": {
 				"spdx-correct": "1.0.2",
 				"spdx-expression-parse": "1.0.4"
@@ -5056,6 +4789,7 @@
 			"version": "1.10.0",
 			"resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
 			"integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
+			"dev": true,
 			"requires": {
 				"assert-plus": "1.0.0",
 				"core-util-is": "1.0.2",
@@ -5065,19 +4799,22 @@
 				"assert-plus": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-					"integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
+					"integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+					"dev": true
 				}
 			}
 		},
 		"vlq": {
 			"version": "0.2.2",
 			"resolved": "https://registry.npmjs.org/vlq/-/vlq-0.2.2.tgz",
-			"integrity": "sha1-4xbVJXtAuGu0PLjV/qXX9U1rDKE="
+			"integrity": "sha1-4xbVJXtAuGu0PLjV/qXX9U1rDKE=",
+			"dev": true
 		},
 		"walker": {
 			"version": "1.0.7",
 			"resolved": "https://registry.npmjs.org/walker/-/walker-1.0.7.tgz",
 			"integrity": "sha1-L3+bj9ENZ3JisYqITijRlhjgKPs=",
+			"dev": true,
 			"requires": {
 				"makeerror": "1.0.11"
 			}
@@ -5085,17 +4822,20 @@
 		"watch": {
 			"version": "0.10.0",
 			"resolved": "https://registry.npmjs.org/watch/-/watch-0.10.0.tgz",
-			"integrity": "sha1-d3mLLaD5kQ1ZXxrOWwwiWFIfIdw="
+			"integrity": "sha1-d3mLLaD5kQ1ZXxrOWwwiWFIfIdw=",
+			"dev": true
 		},
 		"webidl-conversions": {
 			"version": "4.0.1",
 			"resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-4.0.1.tgz",
-			"integrity": "sha1-gBWherg+fhsxFjhIas6B2mziBqA="
+			"integrity": "sha1-gBWherg+fhsxFjhIas6B2mziBqA=",
+			"dev": true
 		},
 		"whatwg-encoding": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-1.0.1.tgz",
 			"integrity": "sha1-PGxFGhmO567FWx7GHQkgxngBpfQ=",
+			"dev": true,
 			"requires": {
 				"iconv-lite": "0.4.13"
 			}
@@ -5103,12 +4843,14 @@
 		"whatwg-fetch": {
 			"version": "2.0.3",
 			"resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-2.0.3.tgz",
-			"integrity": "sha1-nITsLc9oGH/wC8ZOEnS0QhduHIQ="
+			"integrity": "sha1-nITsLc9oGH/wC8ZOEnS0QhduHIQ=",
+			"dev": true
 		},
 		"whatwg-url": {
 			"version": "4.8.0",
 			"resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-4.8.0.tgz",
 			"integrity": "sha1-0pgaqRSMHgCkHFphMRZqtGg7vMA=",
+			"dev": true,
 			"requires": {
 				"tr46": "0.0.3",
 				"webidl-conversions": "3.0.1"
@@ -5117,7 +4859,8 @@
 				"webidl-conversions": {
 					"version": "3.0.1",
 					"resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-					"integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE="
+					"integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE=",
+					"dev": true
 				}
 			}
 		},
@@ -5125,6 +4868,7 @@
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/which/-/which-1.3.0.tgz",
 			"integrity": "sha512-xcJpopdamTuY5duC/KnTTNBraPK54YwpenP4lzxU8H91GudWpFv38u0CKjclE1Wi2EH2EDz5LRcHcKbCIzqGyg==",
+			"dev": true,
 			"requires": {
 				"isexe": "2.0.0"
 			}
@@ -5132,23 +4876,27 @@
 		"which-module": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/which-module/-/which-module-1.0.0.tgz",
-			"integrity": "sha1-u6Y8qGGUiZT/MHc2CJ47lgJsKk8="
+			"integrity": "sha1-u6Y8qGGUiZT/MHc2CJ47lgJsKk8=",
+			"dev": true
 		},
 		"window-size": {
 			"version": "0.1.0",
 			"resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz",
 			"integrity": "sha1-VDjNLqk7IC76Ohn+iIeu58lPnJ0=",
+			"dev": true,
 			"optional": true
 		},
 		"wordwrap": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
-			"integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus="
+			"integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
+			"dev": true
 		},
 		"worker-farm": {
 			"version": "1.4.1",
 			"resolved": "https://registry.npmjs.org/worker-farm/-/worker-farm-1.4.1.tgz",
 			"integrity": "sha512-tgFAtgOYLPutkAyzgpS6VJFL5HY+0ui1Tvua+fITgz8ByaJTMFGtazR6xxQfwfiAcbwE+2fLG/K49wc2TfwCNw==",
+			"dev": true,
 			"requires": {
 				"errno": "0.1.4",
 				"xtend": "4.0.1"
@@ -5158,6 +4906,7 @@
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
 			"integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
+			"dev": true,
 			"requires": {
 				"string-width": "1.0.2",
 				"strip-ansi": "3.0.1"
@@ -5166,12 +4915,14 @@
 		"wrappy": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-			"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+			"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+			"dev": true
 		},
 		"write": {
 			"version": "0.2.1",
 			"resolved": "https://registry.npmjs.org/write/-/write-0.2.1.tgz",
 			"integrity": "sha1-X8A4KOJkzqP+kUVUdvejxWbLB1c=",
+			"dev": true,
 			"requires": {
 				"mkdirp": "0.5.1"
 			}
@@ -5179,22 +4930,26 @@
 		"xml-name-validator": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-2.0.1.tgz",
-			"integrity": "sha1-TYuPHszTQZqjYgYb7O9RXh5VljU="
+			"integrity": "sha1-TYuPHszTQZqjYgYb7O9RXh5VljU=",
+			"dev": true
 		},
 		"xtend": {
 			"version": "4.0.1",
 			"resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
-			"integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68="
+			"integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
+			"dev": true
 		},
 		"y18n": {
 			"version": "3.2.1",
 			"resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
-			"integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE="
+			"integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE=",
+			"dev": true
 		},
 		"yargs": {
 			"version": "7.1.0",
 			"resolved": "https://registry.npmjs.org/yargs/-/yargs-7.1.0.tgz",
 			"integrity": "sha1-a6MY6xaWFyf10oT46gA+jWFU0Mg=",
+			"dev": true,
 			"requires": {
 				"camelcase": "3.0.0",
 				"cliui": "3.2.0",
@@ -5214,12 +4969,14 @@
 				"camelcase": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
-					"integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo="
+					"integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo=",
+					"dev": true
 				},
 				"cliui": {
 					"version": "3.2.0",
 					"resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
 					"integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
+					"dev": true,
 					"requires": {
 						"string-width": "1.0.2",
 						"strip-ansi": "3.0.1",
@@ -5232,6 +4989,7 @@
 			"version": "5.0.0",
 			"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-5.0.0.tgz",
 			"integrity": "sha1-J17PDX/+Bcd+ZOfIbkzZS/DhIoo=",
+			"dev": true,
 			"requires": {
 				"camelcase": "3.0.0"
 			},
@@ -5239,7 +4997,8 @@
 				"camelcase": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
-					"integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo="
+					"integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo=",
+					"dev": true
 				}
 			}
 		}

--- a/packages/react-router-config/package.json
+++ b/packages/react-router-config/package.json
@@ -48,9 +48,9 @@
     "react-addons-test-utils": "^15.4.2",
     "react-dom": "^15.3.0",
     "react-router": "^4.1.1",
-    "rollup": "^0.45.2",
-    "rollup-plugin-babel": "^2.7.1",
-    "rollup-plugin-commonjs": "^8.0.2",
+    "rollup": "^0.48.2",
+    "rollup-plugin-babel": "^3.0.2",
+    "rollup-plugin-commonjs": "^8.2.0",
     "rollup-plugin-node-resolve": "^3.0.0",
     "rollup-plugin-replace": "^1.1.1",
     "rollup-plugin-uglify": "^2.0.1"

--- a/packages/react-router-config/rollup.config.js
+++ b/packages/react-router-config/rollup.config.js
@@ -5,8 +5,8 @@ import commonjs from 'rollup-plugin-commonjs'
 import resolve from 'rollup-plugin-node-resolve'
 
 const config = {
-  entry: 'modules/index.js',
-  moduleName: 'ReactRouterConfig',
+  input: 'modules/index.js',
+  name: 'ReactRouterConfig',
   globals: {
     react: 'React',
     'react-router/Switch': 'ReactRouter.Switch',

--- a/packages/react-router-dom/package-lock.json
+++ b/packages/react-router-dom/package-lock.json
@@ -1,21 +1,26 @@
 {
-	"requires": true,
+	"name": "react-router-dom",
+	"version": "4.1.1",
 	"lockfileVersion": 1,
+	"requires": true,
 	"dependencies": {
 		"abab": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/abab/-/abab-1.0.3.tgz",
-			"integrity": "sha1-uB3l9ydOxOdW15fNg08wNkJyTl0="
+			"integrity": "sha1-uB3l9ydOxOdW15fNg08wNkJyTl0=",
+			"dev": true
 		},
 		"acorn": {
 			"version": "5.1.1",
 			"resolved": "https://registry.npmjs.org/acorn/-/acorn-5.1.1.tgz",
-			"integrity": "sha512-vOk6uEMctu0vQrvuSqFdJyqj1Q0S5VTDL79qtjo+DhRr+1mmaD+tluFSCZqhvi/JUhXSzoZN2BhtstaPEeE8cw=="
+			"integrity": "sha512-vOk6uEMctu0vQrvuSqFdJyqj1Q0S5VTDL79qtjo+DhRr+1mmaD+tluFSCZqhvi/JUhXSzoZN2BhtstaPEeE8cw==",
+			"dev": true
 		},
 		"acorn-globals": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-3.1.0.tgz",
 			"integrity": "sha1-/YJw9x+7SZawBPqIDuXUZXOnMb8=",
+			"dev": true,
 			"requires": {
 				"acorn": "4.0.13"
 			},
@@ -23,7 +28,8 @@
 				"acorn": {
 					"version": "4.0.13",
 					"resolved": "https://registry.npmjs.org/acorn/-/acorn-4.0.13.tgz",
-					"integrity": "sha1-EFSVrlNh1pe9GVyCUZLhrX8lN4c="
+					"integrity": "sha1-EFSVrlNh1pe9GVyCUZLhrX8lN4c=",
+					"dev": true
 				}
 			}
 		},
@@ -31,6 +37,7 @@
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-3.0.1.tgz",
 			"integrity": "sha1-r9+UiPsezvyDSPb7IvRk4ypYs2s=",
+			"dev": true,
 			"requires": {
 				"acorn": "3.3.0"
 			},
@@ -38,7 +45,8 @@
 				"acorn": {
 					"version": "3.3.0",
 					"resolved": "https://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz",
-					"integrity": "sha1-ReN/s56No/JbruP/U2niu18iAXo="
+					"integrity": "sha1-ReN/s56No/JbruP/U2niu18iAXo=",
+					"dev": true
 				}
 			}
 		},
@@ -46,6 +54,7 @@
 			"version": "4.11.8",
 			"resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz",
 			"integrity": "sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY=",
+			"dev": true,
 			"requires": {
 				"co": "4.6.0",
 				"json-stable-stringify": "1.0.1"
@@ -54,12 +63,14 @@
 		"ajv-keywords": {
 			"version": "1.5.1",
 			"resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-1.5.1.tgz",
-			"integrity": "sha1-MU3QpLM2j609/NxU7eYXG4htrzw="
+			"integrity": "sha1-MU3QpLM2j609/NxU7eYXG4htrzw=",
+			"dev": true
 		},
 		"align-text": {
 			"version": "0.1.4",
 			"resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
 			"integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
+			"dev": true,
 			"requires": {
 				"kind-of": "3.2.2",
 				"longest": "1.0.1",
@@ -69,27 +80,32 @@
 		"amdefine": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
-			"integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU="
+			"integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU=",
+			"dev": true
 		},
 		"ansi-escapes": {
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-1.4.0.tgz",
-			"integrity": "sha1-06ioOzGapneTZisT52HHkRQiMG4="
+			"integrity": "sha1-06ioOzGapneTZisT52HHkRQiMG4=",
+			"dev": true
 		},
 		"ansi-regex": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-			"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
+			"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+			"dev": true
 		},
 		"ansi-styles": {
 			"version": "2.2.1",
 			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-			"integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
+			"integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+			"dev": true
 		},
 		"anymatch": {
 			"version": "1.3.2",
 			"resolved": "https://registry.npmjs.org/anymatch/-/anymatch-1.3.2.tgz",
 			"integrity": "sha512-0XNayC8lTHQ2OI8aljNCN3sSx6hsr/1+rlcDAotXJR7C1oZZHCNsfpbKwMjRA3Uqb5tF1Rae2oloTr4xpq+WjA==",
+			"dev": true,
 			"requires": {
 				"micromatch": "2.3.11",
 				"normalize-path": "2.1.1"
@@ -99,6 +115,7 @@
 			"version": "0.4.0",
 			"resolved": "https://registry.npmjs.org/append-transform/-/append-transform-0.4.0.tgz",
 			"integrity": "sha1-126/jKlNJ24keja61EpLdKthGZE=",
+			"dev": true,
 			"requires": {
 				"default-require-extensions": "1.0.0"
 			}
@@ -107,6 +124,7 @@
 			"version": "1.0.9",
 			"resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.9.tgz",
 			"integrity": "sha1-c9g7wmP4bpf4zE9rrhsOkKfSLIY=",
+			"dev": true,
 			"requires": {
 				"sprintf-js": "1.0.3"
 			}
@@ -115,6 +133,7 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
 			"integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
+			"dev": true,
 			"requires": {
 				"arr-flatten": "1.1.0"
 			}
@@ -122,17 +141,20 @@
 		"arr-flatten": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
-			"integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg=="
+			"integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg==",
+			"dev": true
 		},
 		"array-equal": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/array-equal/-/array-equal-1.0.0.tgz",
-			"integrity": "sha1-jCpe8kcv2ep0KwTHenUJO6J1fJM="
+			"integrity": "sha1-jCpe8kcv2ep0KwTHenUJO6J1fJM=",
+			"dev": true
 		},
 		"array-union": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
 			"integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
+			"dev": true,
 			"requires": {
 				"array-uniq": "1.0.3"
 			}
@@ -140,17 +162,20 @@
 		"array-uniq": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.3.tgz",
-			"integrity": "sha1-r2rId6Jcx/dOBYiUdThY39sk/bY="
+			"integrity": "sha1-r2rId6Jcx/dOBYiUdThY39sk/bY=",
+			"dev": true
 		},
 		"array-unique": {
 			"version": "0.2.1",
 			"resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
-			"integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM="
+			"integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM=",
+			"dev": true
 		},
 		"arrify": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
-			"integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0="
+			"integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
+			"dev": true
 		},
 		"asap": {
 			"version": "2.0.6",
@@ -160,17 +185,20 @@
 		"asn1": {
 			"version": "0.2.3",
 			"resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
-			"integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y="
+			"integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y=",
+			"dev": true
 		},
 		"assert-plus": {
 			"version": "0.2.0",
 			"resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
-			"integrity": "sha1-104bh+ev/A24qttwIfP+SBAasjQ="
+			"integrity": "sha1-104bh+ev/A24qttwIfP+SBAasjQ=",
+			"dev": true
 		},
 		"async": {
 			"version": "2.5.0",
 			"resolved": "https://registry.npmjs.org/async/-/async-2.5.0.tgz",
 			"integrity": "sha512-e+lJAJeNWuPCNyxZKOBdaJGyLGHugXVQtrAwtuAe2vhxTYxFTKE73p8JuTmdH0qdQZtDvI4dhJwjZc5zsfIsYw==",
+			"dev": true,
 			"requires": {
 				"lodash": "4.17.4"
 			}
@@ -179,27 +207,32 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/async-each/-/async-each-1.0.1.tgz",
 			"integrity": "sha1-GdOGodntxufByF04iu28xW0zYC0=",
+			"dev": true,
 			"optional": true
 		},
 		"asynckit": {
 			"version": "0.4.0",
 			"resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-			"integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
+			"integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
+			"dev": true
 		},
 		"aws-sign2": {
 			"version": "0.6.0",
 			"resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
-			"integrity": "sha1-FDQt0428yU0OW4fXY81jYSwOeU8="
+			"integrity": "sha1-FDQt0428yU0OW4fXY81jYSwOeU8=",
+			"dev": true
 		},
 		"aws4": {
 			"version": "1.6.0",
 			"resolved": "https://registry.npmjs.org/aws4/-/aws4-1.6.0.tgz",
-			"integrity": "sha1-g+9cqGCysy5KDe7e6MdxudtXRx4="
+			"integrity": "sha1-g+9cqGCysy5KDe7e6MdxudtXRx4=",
+			"dev": true
 		},
 		"babel-cli": {
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-cli/-/babel-cli-6.24.1.tgz",
 			"integrity": "sha1-IHzXBbumFImy6kG1MSNBz2rKIoM=",
+			"dev": true,
 			"requires": {
 				"babel-core": "6.25.0",
 				"babel-polyfill": "6.23.0",
@@ -222,6 +255,7 @@
 			"version": "6.22.0",
 			"resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.22.0.tgz",
 			"integrity": "sha1-AnYgvuVnqIwyVhV05/0IAdMxGOQ=",
+			"dev": true,
 			"requires": {
 				"chalk": "1.1.3",
 				"esutils": "2.0.2",
@@ -232,6 +266,7 @@
 			"version": "6.25.0",
 			"resolved": "https://registry.npmjs.org/babel-core/-/babel-core-6.25.0.tgz",
 			"integrity": "sha1-fdQrBGPHQunVKW3rPsZ6kyLa1yk=",
+			"dev": true,
 			"requires": {
 				"babel-code-frame": "6.22.0",
 				"babel-generator": "6.25.0",
@@ -258,6 +293,7 @@
 			"version": "6.1.2",
 			"resolved": "https://registry.npmjs.org/babel-eslint/-/babel-eslint-6.1.2.tgz",
 			"integrity": "sha1-UpNBn+NnLWZZjTJ9qWlFZ7pqXy8=",
+			"dev": true,
 			"requires": {
 				"babel-traverse": "6.25.0",
 				"babel-types": "6.25.0",
@@ -270,6 +306,7 @@
 			"version": "6.25.0",
 			"resolved": "https://registry.npmjs.org/babel-generator/-/babel-generator-6.25.0.tgz",
 			"integrity": "sha1-M6GvcNXyiQrrRlpKd5PB32qeqfw=",
+			"dev": true,
 			"requires": {
 				"babel-messages": "6.23.0",
 				"babel-runtime": "6.25.0",
@@ -285,6 +322,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-helper-bindify-decorators/-/babel-helper-bindify-decorators-6.24.1.tgz",
 			"integrity": "sha1-FMGeXxQte0fxmlJDHlKxzLxAozA=",
+			"dev": true,
 			"requires": {
 				"babel-runtime": "6.25.0",
 				"babel-traverse": "6.25.0",
@@ -295,6 +333,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-helper-builder-binary-assignment-operator-visitor/-/babel-helper-builder-binary-assignment-operator-visitor-6.24.1.tgz",
 			"integrity": "sha1-zORReto1b0IgvK6KAsKzRvmlZmQ=",
+			"dev": true,
 			"requires": {
 				"babel-helper-explode-assignable-expression": "6.24.1",
 				"babel-runtime": "6.25.0",
@@ -305,6 +344,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-helper-builder-react-jsx/-/babel-helper-builder-react-jsx-6.24.1.tgz",
 			"integrity": "sha1-CteRfjPI11HmRtrKTnfMGTd9LLw=",
+			"dev": true,
 			"requires": {
 				"babel-runtime": "6.25.0",
 				"babel-types": "6.25.0",
@@ -315,6 +355,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-helper-call-delegate/-/babel-helper-call-delegate-6.24.1.tgz",
 			"integrity": "sha1-7Oaqzdx25Bw0YfiL/Fdb0Nqi340=",
+			"dev": true,
 			"requires": {
 				"babel-helper-hoist-variables": "6.24.1",
 				"babel-runtime": "6.25.0",
@@ -326,6 +367,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-helper-define-map/-/babel-helper-define-map-6.24.1.tgz",
 			"integrity": "sha1-epdH8ljYlH0y1RX2qhx70CIEoIA=",
+			"dev": true,
 			"requires": {
 				"babel-helper-function-name": "6.24.1",
 				"babel-runtime": "6.25.0",
@@ -337,6 +379,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-helper-explode-assignable-expression/-/babel-helper-explode-assignable-expression-6.24.1.tgz",
 			"integrity": "sha1-8luCz33BBDPFX3BZLVdGQArCLKo=",
+			"dev": true,
 			"requires": {
 				"babel-runtime": "6.25.0",
 				"babel-traverse": "6.25.0",
@@ -347,6 +390,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-helper-explode-class/-/babel-helper-explode-class-6.24.1.tgz",
 			"integrity": "sha1-fcKjkQ3uAHBW4eMdZAztPVTqqes=",
+			"dev": true,
 			"requires": {
 				"babel-helper-bindify-decorators": "6.24.1",
 				"babel-runtime": "6.25.0",
@@ -358,6 +402,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-helper-function-name/-/babel-helper-function-name-6.24.1.tgz",
 			"integrity": "sha1-00dbjAPtmCQqJbSDUasYOZ01gKk=",
+			"dev": true,
 			"requires": {
 				"babel-helper-get-function-arity": "6.24.1",
 				"babel-runtime": "6.25.0",
@@ -370,6 +415,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-helper-get-function-arity/-/babel-helper-get-function-arity-6.24.1.tgz",
 			"integrity": "sha1-j3eCqpNAfEHTqlCQj4mwMbG2hT0=",
+			"dev": true,
 			"requires": {
 				"babel-runtime": "6.25.0",
 				"babel-types": "6.25.0"
@@ -379,6 +425,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-helper-hoist-variables/-/babel-helper-hoist-variables-6.24.1.tgz",
 			"integrity": "sha1-HssnaJydJVE+rbyZFKc/VAi+enY=",
+			"dev": true,
 			"requires": {
 				"babel-runtime": "6.25.0",
 				"babel-types": "6.25.0"
@@ -388,6 +435,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-helper-optimise-call-expression/-/babel-helper-optimise-call-expression-6.24.1.tgz",
 			"integrity": "sha1-96E0J7qfc/j0+pk8VKl4gtEkQlc=",
+			"dev": true,
 			"requires": {
 				"babel-runtime": "6.25.0",
 				"babel-types": "6.25.0"
@@ -397,6 +445,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-helper-regex/-/babel-helper-regex-6.24.1.tgz",
 			"integrity": "sha1-024i+rEAjXnYhkjjIRaGgShFbOg=",
+			"dev": true,
 			"requires": {
 				"babel-runtime": "6.25.0",
 				"babel-types": "6.25.0",
@@ -407,6 +456,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-helper-remap-async-to-generator/-/babel-helper-remap-async-to-generator-6.24.1.tgz",
 			"integrity": "sha1-XsWBgnrXI/7N04HxySg5BnbkVRs=",
+			"dev": true,
 			"requires": {
 				"babel-helper-function-name": "6.24.1",
 				"babel-runtime": "6.25.0",
@@ -419,6 +469,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-helper-replace-supers/-/babel-helper-replace-supers-6.24.1.tgz",
 			"integrity": "sha1-v22/5Dk40XNpohPKiov3S2qQqxo=",
+			"dev": true,
 			"requires": {
 				"babel-helper-optimise-call-expression": "6.24.1",
 				"babel-messages": "6.23.0",
@@ -432,6 +483,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-helpers/-/babel-helpers-6.24.1.tgz",
 			"integrity": "sha1-NHHenK7DiOXIUOWX5Yom3fN2ArI=",
+			"dev": true,
 			"requires": {
 				"babel-runtime": "6.25.0",
 				"babel-template": "6.25.0"
@@ -441,6 +493,7 @@
 			"version": "20.0.3",
 			"resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-20.0.3.tgz",
 			"integrity": "sha1-5KA7E9wQOJ4UD8ZF0J/8TO0wFnE=",
+			"dev": true,
 			"requires": {
 				"babel-core": "6.25.0",
 				"babel-plugin-istanbul": "4.1.4",
@@ -451,6 +504,7 @@
 			"version": "6.23.0",
 			"resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz",
 			"integrity": "sha1-8830cDhYA1sqKVHG7F7fbGLyYw4=",
+			"dev": true,
 			"requires": {
 				"babel-runtime": "6.25.0"
 			}
@@ -459,6 +513,7 @@
 			"version": "6.22.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-check-es2015-constants/-/babel-plugin-check-es2015-constants-6.22.0.tgz",
 			"integrity": "sha1-NRV7EBQm/S/9PaP3XH0ekYNbv4o=",
+			"dev": true,
 			"requires": {
 				"babel-runtime": "6.25.0"
 			}
@@ -466,12 +521,14 @@
 		"babel-plugin-dev-expression": {
 			"version": "0.2.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-dev-expression/-/babel-plugin-dev-expression-0.2.1.tgz",
-			"integrity": "sha1-1Ke+7++7UOPyc0mQqCokhs+eue4="
+			"integrity": "sha1-1Ke+7++7UOPyc0mQqCokhs+eue4=",
+			"dev": true
 		},
 		"babel-plugin-external-helpers": {
 			"version": "6.22.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-external-helpers/-/babel-plugin-external-helpers-6.22.0.tgz",
 			"integrity": "sha1-IoX0iwK9Xe3oUXXK+MYuhq3M76E=",
+			"dev": true,
 			"requires": {
 				"babel-runtime": "6.25.0"
 			}
@@ -480,6 +537,7 @@
 			"version": "4.1.4",
 			"resolved": "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-4.1.4.tgz",
 			"integrity": "sha1-GN3oS/POMp/d8/QQP66SFFbY5Yc=",
+			"dev": true,
 			"requires": {
 				"find-up": "2.1.0",
 				"istanbul-lib-instrument": "1.7.4",
@@ -490,6 +548,7 @@
 					"version": "2.1.0",
 					"resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
 					"integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+					"dev": true,
 					"requires": {
 						"locate-path": "2.0.0"
 					}
@@ -499,72 +558,86 @@
 		"babel-plugin-jest-hoist": {
 			"version": "20.0.3",
 			"resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-20.0.3.tgz",
-			"integrity": "sha1-r+3IU70/jcNUjqZx++adA8wsF2c="
+			"integrity": "sha1-r+3IU70/jcNUjqZx++adA8wsF2c=",
+			"dev": true
 		},
 		"babel-plugin-syntax-async-functions": {
 			"version": "6.13.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-syntax-async-functions/-/babel-plugin-syntax-async-functions-6.13.0.tgz",
-			"integrity": "sha1-ytnK0RkbWtY0vzCuCHI5HgZHvpU="
+			"integrity": "sha1-ytnK0RkbWtY0vzCuCHI5HgZHvpU=",
+			"dev": true
 		},
 		"babel-plugin-syntax-async-generators": {
 			"version": "6.13.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-syntax-async-generators/-/babel-plugin-syntax-async-generators-6.13.0.tgz",
-			"integrity": "sha1-a8lj67FuzLrmuStZbrfzXDQqi5o="
+			"integrity": "sha1-a8lj67FuzLrmuStZbrfzXDQqi5o=",
+			"dev": true
 		},
 		"babel-plugin-syntax-class-constructor-call": {
 			"version": "6.18.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-syntax-class-constructor-call/-/babel-plugin-syntax-class-constructor-call-6.18.0.tgz",
-			"integrity": "sha1-nLnTn+Q8hgC+yBRkVt3L1OGnZBY="
+			"integrity": "sha1-nLnTn+Q8hgC+yBRkVt3L1OGnZBY=",
+			"dev": true
 		},
 		"babel-plugin-syntax-class-properties": {
 			"version": "6.13.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-syntax-class-properties/-/babel-plugin-syntax-class-properties-6.13.0.tgz",
-			"integrity": "sha1-1+sjt5oxf4VDlixQW4J8fWysJ94="
+			"integrity": "sha1-1+sjt5oxf4VDlixQW4J8fWysJ94=",
+			"dev": true
 		},
 		"babel-plugin-syntax-decorators": {
 			"version": "6.13.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-syntax-decorators/-/babel-plugin-syntax-decorators-6.13.0.tgz",
-			"integrity": "sha1-MSVjtNvePMgGzuPkFszurd0RrAs="
+			"integrity": "sha1-MSVjtNvePMgGzuPkFszurd0RrAs=",
+			"dev": true
 		},
 		"babel-plugin-syntax-dynamic-import": {
 			"version": "6.18.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-syntax-dynamic-import/-/babel-plugin-syntax-dynamic-import-6.18.0.tgz",
-			"integrity": "sha1-jWomIpyDdFqZgqRBBRVyyqF5sdo="
+			"integrity": "sha1-jWomIpyDdFqZgqRBBRVyyqF5sdo=",
+			"dev": true
 		},
 		"babel-plugin-syntax-exponentiation-operator": {
 			"version": "6.13.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-syntax-exponentiation-operator/-/babel-plugin-syntax-exponentiation-operator-6.13.0.tgz",
-			"integrity": "sha1-nufoM3KQ2pUoggGmpX9BcDF4MN4="
+			"integrity": "sha1-nufoM3KQ2pUoggGmpX9BcDF4MN4=",
+			"dev": true
 		},
 		"babel-plugin-syntax-export-extensions": {
 			"version": "6.13.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-syntax-export-extensions/-/babel-plugin-syntax-export-extensions-6.13.0.tgz",
-			"integrity": "sha1-cKFITw+QiaToStRLrDU8lbmxJyE="
+			"integrity": "sha1-cKFITw+QiaToStRLrDU8lbmxJyE=",
+			"dev": true
 		},
 		"babel-plugin-syntax-flow": {
 			"version": "6.18.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-syntax-flow/-/babel-plugin-syntax-flow-6.18.0.tgz",
-			"integrity": "sha1-TDqyCiryaqIM0lmVw5jE63AxDI0="
+			"integrity": "sha1-TDqyCiryaqIM0lmVw5jE63AxDI0=",
+			"dev": true
 		},
 		"babel-plugin-syntax-jsx": {
 			"version": "6.18.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-syntax-jsx/-/babel-plugin-syntax-jsx-6.18.0.tgz",
-			"integrity": "sha1-CvMqmm4Tyno/1QaeYtew9Y0NiUY="
+			"integrity": "sha1-CvMqmm4Tyno/1QaeYtew9Y0NiUY=",
+			"dev": true
 		},
 		"babel-plugin-syntax-object-rest-spread": {
 			"version": "6.13.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-syntax-object-rest-spread/-/babel-plugin-syntax-object-rest-spread-6.13.0.tgz",
-			"integrity": "sha1-/WU28rzhODb/o6VFjEkDpZe7O/U="
+			"integrity": "sha1-/WU28rzhODb/o6VFjEkDpZe7O/U=",
+			"dev": true
 		},
 		"babel-plugin-syntax-trailing-function-commas": {
 			"version": "6.22.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-syntax-trailing-function-commas/-/babel-plugin-syntax-trailing-function-commas-6.22.0.tgz",
-			"integrity": "sha1-ugNgk3+NBuQBgKQ/4NVhb/9TLPM="
+			"integrity": "sha1-ugNgk3+NBuQBgKQ/4NVhb/9TLPM=",
+			"dev": true
 		},
 		"babel-plugin-transform-async-generator-functions": {
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-async-generator-functions/-/babel-plugin-transform-async-generator-functions-6.24.1.tgz",
 			"integrity": "sha1-8FiQAUX9PpkHpt3yjaWfIVJYpds=",
+			"dev": true,
 			"requires": {
 				"babel-helper-remap-async-to-generator": "6.24.1",
 				"babel-plugin-syntax-async-generators": "6.13.0",
@@ -575,6 +648,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-async-to-generator/-/babel-plugin-transform-async-to-generator-6.24.1.tgz",
 			"integrity": "sha1-ZTbjeK/2yx1VF6wOQOs+n8jQh2E=",
+			"dev": true,
 			"requires": {
 				"babel-helper-remap-async-to-generator": "6.24.1",
 				"babel-plugin-syntax-async-functions": "6.13.0",
@@ -585,6 +659,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-class-constructor-call/-/babel-plugin-transform-class-constructor-call-6.24.1.tgz",
 			"integrity": "sha1-gNwoVQWsBn3LjWxl4vbxGrd2Xvk=",
+			"dev": true,
 			"requires": {
 				"babel-plugin-syntax-class-constructor-call": "6.18.0",
 				"babel-runtime": "6.25.0",
@@ -595,6 +670,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-class-properties/-/babel-plugin-transform-class-properties-6.24.1.tgz",
 			"integrity": "sha1-anl2PqYdM9NvN7YRqp3vgagbRqw=",
+			"dev": true,
 			"requires": {
 				"babel-helper-function-name": "6.24.1",
 				"babel-plugin-syntax-class-properties": "6.13.0",
@@ -606,6 +682,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-decorators/-/babel-plugin-transform-decorators-6.24.1.tgz",
 			"integrity": "sha1-eIAT2PjGtSIr33s0Q5Df13Vp4k0=",
+			"dev": true,
 			"requires": {
 				"babel-helper-explode-class": "6.24.1",
 				"babel-plugin-syntax-decorators": "6.13.0",
@@ -618,6 +695,7 @@
 			"version": "6.22.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-arrow-functions/-/babel-plugin-transform-es2015-arrow-functions-6.22.0.tgz",
 			"integrity": "sha1-RSaSy3EdX3ncf4XkQM5BufJE0iE=",
+			"dev": true,
 			"requires": {
 				"babel-runtime": "6.25.0"
 			}
@@ -626,6 +704,7 @@
 			"version": "6.22.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoped-functions/-/babel-plugin-transform-es2015-block-scoped-functions-6.22.0.tgz",
 			"integrity": "sha1-u8UbSflk1wy42OC5ToICRs46YUE=",
+			"dev": true,
 			"requires": {
 				"babel-runtime": "6.25.0"
 			}
@@ -634,6 +713,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoping/-/babel-plugin-transform-es2015-block-scoping-6.24.1.tgz",
 			"integrity": "sha1-dsKV3DpHQbFmWt/TFnIV3P8ypXY=",
+			"dev": true,
 			"requires": {
 				"babel-runtime": "6.25.0",
 				"babel-template": "6.25.0",
@@ -646,6 +726,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-classes/-/babel-plugin-transform-es2015-classes-6.24.1.tgz",
 			"integrity": "sha1-WkxYpQyclGHlZLSyo7+ryXolhNs=",
+			"dev": true,
 			"requires": {
 				"babel-helper-define-map": "6.24.1",
 				"babel-helper-function-name": "6.24.1",
@@ -662,6 +743,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-computed-properties/-/babel-plugin-transform-es2015-computed-properties-6.24.1.tgz",
 			"integrity": "sha1-b+Ko0WiV1WNPTNmZttNICjCBWbM=",
+			"dev": true,
 			"requires": {
 				"babel-runtime": "6.25.0",
 				"babel-template": "6.25.0"
@@ -671,6 +753,7 @@
 			"version": "6.23.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-destructuring/-/babel-plugin-transform-es2015-destructuring-6.23.0.tgz",
 			"integrity": "sha1-mXux8auWf2gtKwh2/jWNYOdlxW0=",
+			"dev": true,
 			"requires": {
 				"babel-runtime": "6.25.0"
 			}
@@ -679,6 +762,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-duplicate-keys/-/babel-plugin-transform-es2015-duplicate-keys-6.24.1.tgz",
 			"integrity": "sha1-c+s9MQypaePvnskcU3QabxV2Qj4=",
+			"dev": true,
 			"requires": {
 				"babel-runtime": "6.25.0",
 				"babel-types": "6.25.0"
@@ -688,6 +772,7 @@
 			"version": "6.23.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-for-of/-/babel-plugin-transform-es2015-for-of-6.23.0.tgz",
 			"integrity": "sha1-9HyVsrYT3x0+zC/bdXNiPHUkhpE=",
+			"dev": true,
 			"requires": {
 				"babel-runtime": "6.25.0"
 			}
@@ -696,6 +781,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-function-name/-/babel-plugin-transform-es2015-function-name-6.24.1.tgz",
 			"integrity": "sha1-g0yJhTvDaxrw86TF26qU/Y6sqos=",
+			"dev": true,
 			"requires": {
 				"babel-helper-function-name": "6.24.1",
 				"babel-runtime": "6.25.0",
@@ -706,6 +792,7 @@
 			"version": "6.22.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-literals/-/babel-plugin-transform-es2015-literals-6.22.0.tgz",
 			"integrity": "sha1-T1SgLWzWbPkVKAAZox0xklN3yi4=",
+			"dev": true,
 			"requires": {
 				"babel-runtime": "6.25.0"
 			}
@@ -714,6 +801,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-amd/-/babel-plugin-transform-es2015-modules-amd-6.24.1.tgz",
 			"integrity": "sha1-Oz5UAXI5hC1tGcMBHEvS8AoA0VQ=",
+			"dev": true,
 			"requires": {
 				"babel-plugin-transform-es2015-modules-commonjs": "6.24.1",
 				"babel-runtime": "6.25.0",
@@ -724,6 +812,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-commonjs/-/babel-plugin-transform-es2015-modules-commonjs-6.24.1.tgz",
 			"integrity": "sha1-0+MQtA72ZKNmIiAAl8bUQCmPK/4=",
+			"dev": true,
 			"requires": {
 				"babel-plugin-transform-strict-mode": "6.24.1",
 				"babel-runtime": "6.25.0",
@@ -735,6 +824,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-systemjs/-/babel-plugin-transform-es2015-modules-systemjs-6.24.1.tgz",
 			"integrity": "sha1-/4mhQrkRmpBhlfXxBuzzBdlAfSM=",
+			"dev": true,
 			"requires": {
 				"babel-helper-hoist-variables": "6.24.1",
 				"babel-runtime": "6.25.0",
@@ -745,6 +835,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-umd/-/babel-plugin-transform-es2015-modules-umd-6.24.1.tgz",
 			"integrity": "sha1-rJl+YoXNGO1hdq22B9YCNErThGg=",
+			"dev": true,
 			"requires": {
 				"babel-plugin-transform-es2015-modules-amd": "6.24.1",
 				"babel-runtime": "6.25.0",
@@ -755,6 +846,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-object-super/-/babel-plugin-transform-es2015-object-super-6.24.1.tgz",
 			"integrity": "sha1-JM72muIcuDp/hgPa0CH1cusnj40=",
+			"dev": true,
 			"requires": {
 				"babel-helper-replace-supers": "6.24.1",
 				"babel-runtime": "6.25.0"
@@ -764,6 +856,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-parameters/-/babel-plugin-transform-es2015-parameters-6.24.1.tgz",
 			"integrity": "sha1-V6w1GrScrxSpfNE7CfZv3wpiXys=",
+			"dev": true,
 			"requires": {
 				"babel-helper-call-delegate": "6.24.1",
 				"babel-helper-get-function-arity": "6.24.1",
@@ -777,6 +870,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-shorthand-properties/-/babel-plugin-transform-es2015-shorthand-properties-6.24.1.tgz",
 			"integrity": "sha1-JPh11nIch2YbvZmkYi5R8U3jiqA=",
+			"dev": true,
 			"requires": {
 				"babel-runtime": "6.25.0",
 				"babel-types": "6.25.0"
@@ -786,6 +880,7 @@
 			"version": "6.22.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-spread/-/babel-plugin-transform-es2015-spread-6.22.0.tgz",
 			"integrity": "sha1-1taKmfia7cRTbIGlQujdnxdG+NE=",
+			"dev": true,
 			"requires": {
 				"babel-runtime": "6.25.0"
 			}
@@ -794,6 +889,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-sticky-regex/-/babel-plugin-transform-es2015-sticky-regex-6.24.1.tgz",
 			"integrity": "sha1-AMHNsaynERLN8M9hJsLta0V8zbw=",
+			"dev": true,
 			"requires": {
 				"babel-helper-regex": "6.24.1",
 				"babel-runtime": "6.25.0",
@@ -804,6 +900,7 @@
 			"version": "6.22.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-template-literals/-/babel-plugin-transform-es2015-template-literals-6.22.0.tgz",
 			"integrity": "sha1-qEs0UPfp+PH2g51taH2oS7EjbY0=",
+			"dev": true,
 			"requires": {
 				"babel-runtime": "6.25.0"
 			}
@@ -812,6 +909,7 @@
 			"version": "6.23.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-typeof-symbol/-/babel-plugin-transform-es2015-typeof-symbol-6.23.0.tgz",
 			"integrity": "sha1-3sCfHN3/lLUqxz1QXITfWdzOs3I=",
+			"dev": true,
 			"requires": {
 				"babel-runtime": "6.25.0"
 			}
@@ -820,6 +918,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-unicode-regex/-/babel-plugin-transform-es2015-unicode-regex-6.24.1.tgz",
 			"integrity": "sha1-04sS9C6nMj9yk4fxinxa4frrNek=",
+			"dev": true,
 			"requires": {
 				"babel-helper-regex": "6.24.1",
 				"babel-runtime": "6.25.0",
@@ -830,6 +929,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-exponentiation-operator/-/babel-plugin-transform-exponentiation-operator-6.24.1.tgz",
 			"integrity": "sha1-KrDJx/MJj6SJB3cruBP+QejeOg4=",
+			"dev": true,
 			"requires": {
 				"babel-helper-builder-binary-assignment-operator-visitor": "6.24.1",
 				"babel-plugin-syntax-exponentiation-operator": "6.13.0",
@@ -840,6 +940,7 @@
 			"version": "6.22.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-export-extensions/-/babel-plugin-transform-export-extensions-6.22.0.tgz",
 			"integrity": "sha1-U3OLR+deghhYnuqUbLvTkQm75lM=",
+			"dev": true,
 			"requires": {
 				"babel-plugin-syntax-export-extensions": "6.13.0",
 				"babel-runtime": "6.25.0"
@@ -849,6 +950,7 @@
 			"version": "6.22.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-flow-strip-types/-/babel-plugin-transform-flow-strip-types-6.22.0.tgz",
 			"integrity": "sha1-hMtnKTXUNxT9wyvOhFaNh0Qc988=",
+			"dev": true,
 			"requires": {
 				"babel-plugin-syntax-flow": "6.18.0",
 				"babel-runtime": "6.25.0"
@@ -858,6 +960,7 @@
 			"version": "1.4.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-imports/-/babel-plugin-transform-imports-1.4.1.tgz",
 			"integrity": "sha512-o7EqCZFj0pKUUDwYDZLTRSg1wNMN69p31l3Sf1+ujTFjWUq+/plAUJ04kO1kn5oLVaHbwLi2F4jQbIHFTN2t+A==",
+			"dev": true,
 			"requires": {
 				"babel-types": "6.25.0",
 				"lodash.camelcase": "4.3.0",
@@ -869,6 +972,7 @@
 			"version": "6.23.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-object-rest-spread/-/babel-plugin-transform-object-rest-spread-6.23.0.tgz",
 			"integrity": "sha1-h11ryb52HFiirj/u5dxIldjH+SE=",
+			"dev": true,
 			"requires": {
 				"babel-plugin-syntax-object-rest-spread": "6.13.0",
 				"babel-runtime": "6.25.0"
@@ -878,6 +982,7 @@
 			"version": "6.25.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-react-display-name/-/babel-plugin-transform-react-display-name-6.25.0.tgz",
 			"integrity": "sha1-Z+K/Hx6ck6sI25Z5LgU5K/LMKNE=",
+			"dev": true,
 			"requires": {
 				"babel-runtime": "6.25.0"
 			}
@@ -886,6 +991,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-react-jsx/-/babel-plugin-transform-react-jsx-6.24.1.tgz",
 			"integrity": "sha1-hAoCjn30YN/DotKfDA2R9jduZqM=",
+			"dev": true,
 			"requires": {
 				"babel-helper-builder-react-jsx": "6.24.1",
 				"babel-plugin-syntax-jsx": "6.18.0",
@@ -896,6 +1002,7 @@
 			"version": "6.22.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-react-jsx-self/-/babel-plugin-transform-react-jsx-self-6.22.0.tgz",
 			"integrity": "sha1-322AqdomEqEh5t3XVYvL7PBuY24=",
+			"dev": true,
 			"requires": {
 				"babel-plugin-syntax-jsx": "6.18.0",
 				"babel-runtime": "6.25.0"
@@ -905,6 +1012,7 @@
 			"version": "6.22.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-react-jsx-source/-/babel-plugin-transform-react-jsx-source-6.22.0.tgz",
 			"integrity": "sha1-ZqwSFT9c0tF7PBkmj0vwGX9E7NY=",
+			"dev": true,
 			"requires": {
 				"babel-plugin-syntax-jsx": "6.18.0",
 				"babel-runtime": "6.25.0"
@@ -913,12 +1021,14 @@
 		"babel-plugin-transform-react-remove-prop-types": {
 			"version": "0.2.12",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-react-remove-prop-types/-/babel-plugin-transform-react-remove-prop-types-0.2.12.tgz",
-			"integrity": "sha1-NAZpbfC4tFYIn51ybSfn4SPS+Sk="
+			"integrity": "sha1-NAZpbfC4tFYIn51ybSfn4SPS+Sk=",
+			"dev": true
 		},
 		"babel-plugin-transform-regenerator": {
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-regenerator/-/babel-plugin-transform-regenerator-6.24.1.tgz",
 			"integrity": "sha1-uNowWtQ8PJm0hI5P5AN7dw0jxBg=",
+			"dev": true,
 			"requires": {
 				"regenerator-transform": "0.9.11"
 			}
@@ -927,6 +1037,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-strict-mode/-/babel-plugin-transform-strict-mode-6.24.1.tgz",
 			"integrity": "sha1-1fr3qleKZbvlkc9e2uBKDGcCB1g=",
+			"dev": true,
 			"requires": {
 				"babel-runtime": "6.25.0",
 				"babel-types": "6.25.0"
@@ -936,6 +1047,7 @@
 			"version": "6.23.0",
 			"resolved": "https://registry.npmjs.org/babel-polyfill/-/babel-polyfill-6.23.0.tgz",
 			"integrity": "sha1-g2TKYt+Or7gwSZ9pkXdGbDsDSZ0=",
+			"dev": true,
 			"requires": {
 				"babel-runtime": "6.25.0",
 				"core-js": "2.4.1",
@@ -946,6 +1058,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-preset-es2015/-/babel-preset-es2015-6.24.1.tgz",
 			"integrity": "sha1-1EBQ1rwsn+6nAqrzjXJ6AhBTiTk=",
+			"dev": true,
 			"requires": {
 				"babel-plugin-check-es2015-constants": "6.22.0",
 				"babel-plugin-transform-es2015-arrow-functions": "6.22.0",
@@ -977,6 +1090,7 @@
 			"version": "6.23.0",
 			"resolved": "https://registry.npmjs.org/babel-preset-flow/-/babel-preset-flow-6.23.0.tgz",
 			"integrity": "sha1-5xIYiHCFrpoktb5Baa/7WZgWxJ0=",
+			"dev": true,
 			"requires": {
 				"babel-plugin-transform-flow-strip-types": "6.22.0"
 			}
@@ -985,6 +1099,7 @@
 			"version": "20.0.3",
 			"resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-20.0.3.tgz",
 			"integrity": "sha1-y6yq3stdaJyh4d4TYOv8ZoYsF4o=",
+			"dev": true,
 			"requires": {
 				"babel-plugin-jest-hoist": "20.0.3"
 			}
@@ -993,6 +1108,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-preset-react/-/babel-preset-react-6.24.1.tgz",
 			"integrity": "sha1-umnfrqRfw+xjm2pOzqbhdwLJE4A=",
+			"dev": true,
 			"requires": {
 				"babel-plugin-syntax-jsx": "6.18.0",
 				"babel-plugin-transform-react-display-name": "6.25.0",
@@ -1006,6 +1122,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-preset-stage-1/-/babel-preset-stage-1-6.24.1.tgz",
 			"integrity": "sha1-dpLNfc1oSZB+auSgqFWJz7niv7A=",
+			"dev": true,
 			"requires": {
 				"babel-plugin-transform-class-constructor-call": "6.24.1",
 				"babel-plugin-transform-export-extensions": "6.22.0",
@@ -1016,6 +1133,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-preset-stage-2/-/babel-preset-stage-2-6.24.1.tgz",
 			"integrity": "sha1-2eKWD7PXEYfw5k7sYrwHdnIZvcE=",
+			"dev": true,
 			"requires": {
 				"babel-plugin-syntax-dynamic-import": "6.18.0",
 				"babel-plugin-transform-class-properties": "6.24.1",
@@ -1027,6 +1145,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-preset-stage-3/-/babel-preset-stage-3-6.24.1.tgz",
 			"integrity": "sha1-g2raCp56f6N8sTj7kyb4eTSkg5U=",
+			"dev": true,
 			"requires": {
 				"babel-plugin-syntax-trailing-function-commas": "6.22.0",
 				"babel-plugin-transform-async-generator-functions": "6.24.1",
@@ -1039,6 +1158,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-register/-/babel-register-6.24.1.tgz",
 			"integrity": "sha1-fhDhOi9xBlvfrVoXh7pFvKbe118=",
+			"dev": true,
 			"requires": {
 				"babel-core": "6.25.0",
 				"babel-runtime": "6.25.0",
@@ -1053,6 +1173,7 @@
 			"version": "6.25.0",
 			"resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.25.0.tgz",
 			"integrity": "sha1-M7mOql1IK7AajRqmtDetKwGuxBw=",
+			"dev": true,
 			"requires": {
 				"core-js": "2.4.1",
 				"regenerator-runtime": "0.10.5"
@@ -1062,6 +1183,7 @@
 			"version": "6.25.0",
 			"resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.25.0.tgz",
 			"integrity": "sha1-ZlJBFmt8KqTGGdceGSlpVSsQwHE=",
+			"dev": true,
 			"requires": {
 				"babel-runtime": "6.25.0",
 				"babel-traverse": "6.25.0",
@@ -1074,6 +1196,7 @@
 			"version": "6.25.0",
 			"resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.25.0.tgz",
 			"integrity": "sha1-IldJfi/NGbie3BPEyROB+VEklvE=",
+			"dev": true,
 			"requires": {
 				"babel-code-frame": "6.22.0",
 				"babel-messages": "6.23.0",
@@ -1090,6 +1213,7 @@
 			"version": "6.25.0",
 			"resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.25.0.tgz",
 			"integrity": "sha1-cK+ySNVmDl0Y+BHZHIMDtUE0oY4=",
+			"dev": true,
 			"requires": {
 				"babel-runtime": "6.25.0",
 				"esutils": "2.0.2",
@@ -1100,17 +1224,20 @@
 		"babylon": {
 			"version": "6.17.4",
 			"resolved": "https://registry.npmjs.org/babylon/-/babylon-6.17.4.tgz",
-			"integrity": "sha512-kChlV+0SXkjE0vUn9OZ7pBMWRFd8uq3mZe8x1K6jhuNcAFAtEnjchFAqB+dYEXKyd+JpT6eppRR78QAr5gTsUw=="
+			"integrity": "sha512-kChlV+0SXkjE0vUn9OZ7pBMWRFd8uq3mZe8x1K6jhuNcAFAtEnjchFAqB+dYEXKyd+JpT6eppRR78QAr5gTsUw==",
+			"dev": true
 		},
 		"balanced-match": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-			"integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
+			"integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+			"dev": true
 		},
 		"bcrypt-pbkdf": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
 			"integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
+			"dev": true,
 			"optional": true,
 			"requires": {
 				"tweetnacl": "0.14.5"
@@ -1120,12 +1247,14 @@
 			"version": "1.9.0",
 			"resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.9.0.tgz",
 			"integrity": "sha1-ZlBsFs5vTWkopbPNajPKQelB43s=",
+			"dev": true,
 			"optional": true
 		},
 		"boom": {
 			"version": "2.10.1",
 			"resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
 			"integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
+			"dev": true,
 			"requires": {
 				"hoek": "2.16.3"
 			}
@@ -1134,6 +1263,7 @@
 			"version": "1.1.8",
 			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
 			"integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
+			"dev": true,
 			"requires": {
 				"balanced-match": "1.0.0",
 				"concat-map": "0.0.1"
@@ -1143,6 +1273,7 @@
 			"version": "1.8.5",
 			"resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
 			"integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
+			"dev": true,
 			"requires": {
 				"expand-range": "1.8.2",
 				"preserve": "0.2.0",
@@ -1153,6 +1284,7 @@
 			"version": "1.11.2",
 			"resolved": "https://registry.npmjs.org/browser-resolve/-/browser-resolve-1.11.2.tgz",
 			"integrity": "sha1-j/CbCixCFxihBRwmCzLkj0QpOM4=",
+			"dev": true,
 			"requires": {
 				"resolve": "1.1.7"
 			},
@@ -1160,7 +1292,8 @@
 				"resolve": {
 					"version": "1.1.7",
 					"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
-					"integrity": "sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs="
+					"integrity": "sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs=",
+					"dev": true
 				}
 			}
 		},
@@ -1168,6 +1301,7 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/bser/-/bser-2.0.0.tgz",
 			"integrity": "sha1-mseNPtXZFYBP2HrLFYvHlxR6Fxk=",
+			"dev": true,
 			"requires": {
 				"node-int64": "0.4.0"
 			}
@@ -1175,12 +1309,14 @@
 		"builtin-modules": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
-			"integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8="
+			"integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=",
+			"dev": true
 		},
 		"caller-path": {
 			"version": "0.1.0",
 			"resolved": "https://registry.npmjs.org/caller-path/-/caller-path-0.1.0.tgz",
 			"integrity": "sha1-lAhe9jWB7NPaqSREqP6U6CV3dR8=",
+			"dev": true,
 			"requires": {
 				"callsites": "0.2.0"
 			}
@@ -1188,23 +1324,27 @@
 		"callsites": {
 			"version": "0.2.0",
 			"resolved": "https://registry.npmjs.org/callsites/-/callsites-0.2.0.tgz",
-			"integrity": "sha1-r6uWJikQp/M8GaV3WCXGnzTjUMo="
+			"integrity": "sha1-r6uWJikQp/M8GaV3WCXGnzTjUMo=",
+			"dev": true
 		},
 		"camelcase": {
 			"version": "1.2.1",
 			"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
 			"integrity": "sha1-m7UwTS4LVmmLLHWLCKPqqdqlijk=",
+			"dev": true,
 			"optional": true
 		},
 		"caseless": {
 			"version": "0.12.0",
 			"resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
-			"integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
+			"integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
+			"dev": true
 		},
 		"center-align": {
 			"version": "0.1.3",
 			"resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
 			"integrity": "sha1-qg0yYptu6XIgBBHL1EYckHvCt60=",
+			"dev": true,
 			"optional": true,
 			"requires": {
 				"align-text": "0.1.4",
@@ -1215,6 +1355,7 @@
 			"version": "1.1.3",
 			"resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
 			"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+			"dev": true,
 			"requires": {
 				"ansi-styles": "2.2.1",
 				"escape-string-regexp": "1.0.5",
@@ -1227,11 +1368,11 @@
 			"version": "1.7.0",
 			"resolved": "https://registry.npmjs.org/chokidar/-/chokidar-1.7.0.tgz",
 			"integrity": "sha1-eY5ol3gVHIB2tLNg5e3SjNortGg=",
+			"dev": true,
 			"optional": true,
 			"requires": {
 				"anymatch": "1.3.2",
 				"async-each": "1.0.1",
-				"fsevents": "1.1.2",
 				"glob-parent": "2.0.0",
 				"inherits": "2.0.3",
 				"is-binary-path": "1.0.1",
@@ -1243,17 +1384,20 @@
 		"ci-info": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/ci-info/-/ci-info-1.0.0.tgz",
-			"integrity": "sha1-3FKF8rTiUYIWg2gcOBwziPRuxTQ="
+			"integrity": "sha1-3FKF8rTiUYIWg2gcOBwziPRuxTQ=",
+			"dev": true
 		},
 		"circular-json": {
 			"version": "0.3.3",
 			"resolved": "https://registry.npmjs.org/circular-json/-/circular-json-0.3.3.tgz",
-			"integrity": "sha512-UZK3NBx2Mca+b5LsG7bY183pHWt5Y1xts4P3Pz7ENTwGVnJOUWbRb3ocjvX7hx9tq/yTAdclXm9sZ38gNuem4A=="
+			"integrity": "sha512-UZK3NBx2Mca+b5LsG7bY183pHWt5Y1xts4P3Pz7ENTwGVnJOUWbRb3ocjvX7hx9tq/yTAdclXm9sZ38gNuem4A==",
+			"dev": true
 		},
 		"cli-cursor": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-1.0.2.tgz",
 			"integrity": "sha1-ZNo/fValRBLll5S9Ytw1KV6PKYc=",
+			"dev": true,
 			"requires": {
 				"restore-cursor": "1.0.1"
 			}
@@ -1261,12 +1405,14 @@
 		"cli-width": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.1.0.tgz",
-			"integrity": "sha1-sjTKIJsp72b8UY2bmNWEewDt8Ao="
+			"integrity": "sha1-sjTKIJsp72b8UY2bmNWEewDt8Ao=",
+			"dev": true
 		},
 		"cliui": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
 			"integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
+			"dev": true,
 			"optional": true,
 			"requires": {
 				"center-align": "0.1.3",
@@ -1278,6 +1424,7 @@
 					"version": "0.0.2",
 					"resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
 					"integrity": "sha1-t5Zpu0LstAn4PVg8rVLKF+qhZD8=",
+					"dev": true,
 					"optional": true
 				}
 			}
@@ -1285,17 +1432,20 @@
 		"co": {
 			"version": "4.6.0",
 			"resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
-			"integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ="
+			"integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
+			"dev": true
 		},
 		"code-point-at": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
-			"integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
+			"integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
+			"dev": true
 		},
 		"color-convert": {
 			"version": "1.9.0",
 			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.0.tgz",
 			"integrity": "sha1-Gsz5fdc5uYO/mU1W/sj5WFNkG3o=",
+			"dev": true,
 			"requires": {
 				"color-name": "1.1.3"
 			}
@@ -1303,12 +1453,14 @@
 		"color-name": {
 			"version": "1.1.3",
 			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-			"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
+			"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+			"dev": true
 		},
 		"combined-stream": {
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
 			"integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
+			"dev": true,
 			"requires": {
 				"delayed-stream": "1.0.0"
 			}
@@ -1316,17 +1468,20 @@
 		"commander": {
 			"version": "2.11.0",
 			"resolved": "https://registry.npmjs.org/commander/-/commander-2.11.0.tgz",
-			"integrity": "sha512-b0553uYA5YAEGgyYIGYROzKQ7X5RAqedkfjiZxwi0kL1g3bOaBNNZfYkzt/CL0umgD5wc9Jec2FbB98CjkMRvQ=="
+			"integrity": "sha512-b0553uYA5YAEGgyYIGYROzKQ7X5RAqedkfjiZxwi0kL1g3bOaBNNZfYkzt/CL0umgD5wc9Jec2FbB98CjkMRvQ==",
+			"dev": true
 		},
 		"concat-map": {
 			"version": "0.0.1",
 			"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-			"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+			"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+			"dev": true
 		},
 		"concat-stream": {
 			"version": "1.6.0",
 			"resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.0.tgz",
 			"integrity": "sha1-CqxmL9Ur54lk1VMvaUeE5wEQrPc=",
+			"dev": true,
 			"requires": {
 				"inherits": "2.0.3",
 				"readable-stream": "2.3.3",
@@ -1336,32 +1491,38 @@
 		"contains-path": {
 			"version": "0.1.0",
 			"resolved": "https://registry.npmjs.org/contains-path/-/contains-path-0.1.0.tgz",
-			"integrity": "sha1-/ozxhP9mcLa67wGp1IYaXL7EEgo="
+			"integrity": "sha1-/ozxhP9mcLa67wGp1IYaXL7EEgo=",
+			"dev": true
 		},
 		"content-type-parser": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/content-type-parser/-/content-type-parser-1.0.1.tgz",
-			"integrity": "sha1-w+VpiMU8ZRJ/tG1AMqOpACRv3JQ="
+			"integrity": "sha1-w+VpiMU8ZRJ/tG1AMqOpACRv3JQ=",
+			"dev": true
 		},
 		"convert-source-map": {
 			"version": "1.5.0",
 			"resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.5.0.tgz",
-			"integrity": "sha1-ms1whRxtXf3ZPZKC5e35SgP/RrU="
+			"integrity": "sha1-ms1whRxtXf3ZPZKC5e35SgP/RrU=",
+			"dev": true
 		},
 		"core-js": {
 			"version": "2.4.1",
 			"resolved": "https://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz",
-			"integrity": "sha1-TekR5mew6ukSTjQlS1OupvxhjT4="
+			"integrity": "sha1-TekR5mew6ukSTjQlS1OupvxhjT4=",
+			"dev": true
 		},
 		"core-util-is": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-			"integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+			"integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+			"dev": true
 		},
 		"create-react-class": {
 			"version": "15.6.0",
 			"resolved": "https://registry.npmjs.org/create-react-class/-/create-react-class-15.6.0.tgz",
 			"integrity": "sha1-q0SEl8JlZuHilBPogyB9V8/nvtQ=",
+			"dev": true,
 			"requires": {
 				"fbjs": "0.8.14",
 				"loose-envify": "1.3.1",
@@ -1372,6 +1533,7 @@
 			"version": "2.0.5",
 			"resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
 			"integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
+			"dev": true,
 			"requires": {
 				"boom": "2.10.1"
 			}
@@ -1379,12 +1541,14 @@
 		"cssom": {
 			"version": "0.3.2",
 			"resolved": "https://registry.npmjs.org/cssom/-/cssom-0.3.2.tgz",
-			"integrity": "sha1-uANhcMefB6kP8vFuIihAJ6JDhIs="
+			"integrity": "sha1-uANhcMefB6kP8vFuIihAJ6JDhIs=",
+			"dev": true
 		},
 		"cssstyle": {
 			"version": "0.2.37",
 			"resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-0.2.37.tgz",
 			"integrity": "sha1-VBCXI0yyUTyDzu06zdwn/yeYfVQ=",
+			"dev": true,
 			"requires": {
 				"cssom": "0.3.2"
 			}
@@ -1393,6 +1557,7 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/d/-/d-1.0.0.tgz",
 			"integrity": "sha1-dUu1v+VUUdpppYuU1F9MWwRi1Y8=",
+			"dev": true,
 			"requires": {
 				"es5-ext": "0.10.26"
 			}
@@ -1401,6 +1566,7 @@
 			"version": "1.14.1",
 			"resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
 			"integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
+			"dev": true,
 			"requires": {
 				"assert-plus": "1.0.0"
 			},
@@ -1408,7 +1574,8 @@
 				"assert-plus": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-					"integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
+					"integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+					"dev": true
 				}
 			}
 		},
@@ -1416,6 +1583,7 @@
 			"version": "2.6.8",
 			"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
 			"integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw=",
+			"dev": true,
 			"requires": {
 				"ms": "2.0.0"
 			}
@@ -1423,17 +1591,20 @@
 		"decamelize": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
-			"integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA="
+			"integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
+			"dev": true
 		},
 		"deep-is": {
 			"version": "0.1.3",
 			"resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
-			"integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ="
+			"integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
+			"dev": true
 		},
 		"default-require-extensions": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/default-require-extensions/-/default-require-extensions-1.0.0.tgz",
 			"integrity": "sha1-836hXT4T/9m0N9M+GnW1+5eHTLg=",
+			"dev": true,
 			"requires": {
 				"strip-bom": "2.0.0"
 			}
@@ -1442,6 +1613,7 @@
 			"version": "2.2.2",
 			"resolved": "https://registry.npmjs.org/del/-/del-2.2.2.tgz",
 			"integrity": "sha1-wSyYHQZ4RshLyvhiz/kw2Qf/0ag=",
+			"dev": true,
 			"requires": {
 				"globby": "5.0.0",
 				"is-path-cwd": "1.0.0",
@@ -1455,12 +1627,14 @@
 		"delayed-stream": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-			"integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
+			"integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
+			"dev": true
 		},
 		"detect-indent": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-4.0.0.tgz",
 			"integrity": "sha1-920GQ1LN9Docts5hnE7jqUdd4gg=",
+			"dev": true,
 			"requires": {
 				"repeating": "2.0.1"
 			}
@@ -1468,12 +1642,14 @@
 		"diff": {
 			"version": "3.3.0",
 			"resolved": "https://registry.npmjs.org/diff/-/diff-3.3.0.tgz",
-			"integrity": "sha512-w0XZubFWn0Adlsapj9EAWX0FqWdO4tz8kc3RiYdWLh4k/V8PTb6i0SMgXt0vRM3zyKnT8tKO7mUlieRQHIjMNg=="
+			"integrity": "sha512-w0XZubFWn0Adlsapj9EAWX0FqWdO4tz8kc3RiYdWLh4k/V8PTb6i0SMgXt0vRM3zyKnT8tKO7mUlieRQHIjMNg==",
+			"dev": true
 		},
 		"doctrine": {
 			"version": "1.5.0",
 			"resolved": "https://registry.npmjs.org/doctrine/-/doctrine-1.5.0.tgz",
 			"integrity": "sha1-N53Ocw9hZvds76TmcHoVmwLFpvo=",
+			"dev": true,
 			"requires": {
 				"esutils": "2.0.2",
 				"isarray": "1.0.0"
@@ -1482,12 +1658,14 @@
 		"duplexer": {
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz",
-			"integrity": "sha1-rOb/gIwc5mtX0ev5eXessCM0z8E="
+			"integrity": "sha1-rOb/gIwc5mtX0ev5eXessCM0z8E=",
+			"dev": true
 		},
 		"ecc-jsbn": {
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
 			"integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
+			"dev": true,
 			"optional": true,
 			"requires": {
 				"jsbn": "0.1.1"
@@ -1505,6 +1683,7 @@
 			"version": "0.1.4",
 			"resolved": "https://registry.npmjs.org/errno/-/errno-0.1.4.tgz",
 			"integrity": "sha1-uJbiOp5ei6M4cfyZar02NfyaHH0=",
+			"dev": true,
 			"requires": {
 				"prr": "0.0.0"
 			}
@@ -1513,6 +1692,7 @@
 			"version": "1.3.1",
 			"resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.1.tgz",
 			"integrity": "sha1-+FWobOYa3E6GIcPNoh56dhLDqNw=",
+			"dev": true,
 			"requires": {
 				"is-arrayish": "0.2.1"
 			}
@@ -1521,6 +1701,7 @@
 			"version": "0.10.26",
 			"resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.26.tgz",
 			"integrity": "sha1-UbISilMbcMT2dkCTpzy+u4IYY3I=",
+			"dev": true,
 			"requires": {
 				"es6-iterator": "2.0.1",
 				"es6-symbol": "3.1.1"
@@ -1530,6 +1711,7 @@
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.1.tgz",
 			"integrity": "sha1-jjGcnwRTv1ddN0lAplWSDlnKVRI=",
+			"dev": true,
 			"requires": {
 				"d": "1.0.0",
 				"es5-ext": "0.10.26",
@@ -1540,6 +1722,7 @@
 			"version": "0.1.5",
 			"resolved": "https://registry.npmjs.org/es6-map/-/es6-map-0.1.5.tgz",
 			"integrity": "sha1-kTbgUD3MBqMBaQ8LsU/042TpSfA=",
+			"dev": true,
 			"requires": {
 				"d": "1.0.0",
 				"es5-ext": "0.10.26",
@@ -1553,6 +1736,7 @@
 			"version": "0.1.5",
 			"resolved": "https://registry.npmjs.org/es6-set/-/es6-set-0.1.5.tgz",
 			"integrity": "sha1-0rPsXU2ADO2BjbU40ol02wpzzLE=",
+			"dev": true,
 			"requires": {
 				"d": "1.0.0",
 				"es5-ext": "0.10.26",
@@ -1565,6 +1749,7 @@
 			"version": "3.1.1",
 			"resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.1.tgz",
 			"integrity": "sha1-vwDvT9q2uhtG7Le2KbTH7VcVzHc=",
+			"dev": true,
 			"requires": {
 				"d": "1.0.0",
 				"es5-ext": "0.10.26"
@@ -1574,6 +1759,7 @@
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-2.0.2.tgz",
 			"integrity": "sha1-XjqzIlH/0VOKH45f+hNXdy+S2W8=",
+			"dev": true,
 			"requires": {
 				"d": "1.0.0",
 				"es5-ext": "0.10.26",
@@ -1584,12 +1770,14 @@
 		"escape-string-regexp": {
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-			"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
+			"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+			"dev": true
 		},
 		"escodegen": {
 			"version": "1.8.1",
 			"resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.8.1.tgz",
 			"integrity": "sha1-WltTr0aTEQvrsIZ6o0MN07cKEBg=",
+			"dev": true,
 			"requires": {
 				"esprima": "2.7.3",
 				"estraverse": "1.9.3",
@@ -1601,17 +1789,20 @@
 				"esprima": {
 					"version": "2.7.3",
 					"resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.3.tgz",
-					"integrity": "sha1-luO3DVd59q1JzQMmc9HDEnZ7pYE="
+					"integrity": "sha1-luO3DVd59q1JzQMmc9HDEnZ7pYE=",
+					"dev": true
 				},
 				"estraverse": {
 					"version": "1.9.3",
 					"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-1.9.3.tgz",
-					"integrity": "sha1-r2fy3JIlgkFZUJJgkaQAXSnJu0Q="
+					"integrity": "sha1-r2fy3JIlgkFZUJJgkaQAXSnJu0Q=",
+					"dev": true
 				},
 				"source-map": {
 					"version": "0.2.0",
 					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.2.0.tgz",
 					"integrity": "sha1-2rc/vPwrqBm03gO9b26qSBZLP50=",
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"amdefine": "1.0.1"
@@ -1623,6 +1814,7 @@
 			"version": "3.6.0",
 			"resolved": "https://registry.npmjs.org/escope/-/escope-3.6.0.tgz",
 			"integrity": "sha1-4Bl16BJ4GhY6ba392AOY3GTIicM=",
+			"dev": true,
 			"requires": {
 				"es6-map": "0.1.5",
 				"es6-weak-map": "2.0.2",
@@ -1634,6 +1826,7 @@
 			"version": "2.13.1",
 			"resolved": "https://registry.npmjs.org/eslint/-/eslint-2.13.1.tgz",
 			"integrity": "sha1-5MyPoPAJ+4KaquI4VaKTYL4fbBE=",
+			"dev": true,
 			"requires": {
 				"chalk": "1.1.3",
 				"concat-stream": "1.6.0",
@@ -1674,6 +1867,7 @@
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/user-home/-/user-home-2.0.0.tgz",
 					"integrity": "sha1-nHC/2Babwdy/SGBODwS4tJzenp8=",
+					"dev": true,
 					"requires": {
 						"os-homedir": "1.0.2"
 					}
@@ -1684,6 +1878,7 @@
 			"version": "0.2.3",
 			"resolved": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.2.3.tgz",
 			"integrity": "sha1-Wt2BBujJKNssuiMrzZ76hG49oWw=",
+			"dev": true,
 			"requires": {
 				"debug": "2.6.8",
 				"object-assign": "4.1.1",
@@ -1694,6 +1889,7 @@
 			"version": "1.16.0",
 			"resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-1.16.0.tgz",
 			"integrity": "sha1-svoH68xTUE0PKkR3WC7Iv/GHG58=",
+			"dev": true,
 			"requires": {
 				"builtin-modules": "1.1.1",
 				"contains-path": "0.1.0",
@@ -1717,6 +1913,7 @@
 					"version": "1.3.0",
 					"resolved": "https://registry.npmjs.org/doctrine/-/doctrine-1.3.0.tgz",
 					"integrity": "sha1-E+dWgrVVGEJCdvfBc3g0Vu+RPSY=",
+					"dev": true,
 					"requires": {
 						"esutils": "2.0.2",
 						"isarray": "1.0.0"
@@ -1728,6 +1925,7 @@
 			"version": "5.2.2",
 			"resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-5.2.2.tgz",
 			"integrity": "sha1-fbBo4fVIf2hx5N7vNqOBwwPqwWE=",
+			"dev": true,
 			"requires": {
 				"doctrine": "1.5.0",
 				"jsx-ast-utils": "1.4.1"
@@ -1737,6 +1935,7 @@
 			"version": "3.4.3",
 			"resolved": "https://registry.npmjs.org/espree/-/espree-3.4.3.tgz",
 			"integrity": "sha1-KRC1zNSc6JPC//+qtP2LOjG4I3Q=",
+			"dev": true,
 			"requires": {
 				"acorn": "5.1.1",
 				"acorn-jsx": "3.0.1"
@@ -1745,12 +1944,14 @@
 		"esprima": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.0.tgz",
-			"integrity": "sha512-oftTcaMu/EGrEIu904mWteKIv8vMuOgGYo7EhVJJN00R/EED9DCua/xxHRdYnKtcECzVg7xOWhflvJMnqcFZjw=="
+			"integrity": "sha512-oftTcaMu/EGrEIu904mWteKIv8vMuOgGYo7EhVJJN00R/EED9DCua/xxHRdYnKtcECzVg7xOWhflvJMnqcFZjw==",
+			"dev": true
 		},
 		"esrecurse": {
 			"version": "4.2.0",
 			"resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.2.0.tgz",
 			"integrity": "sha1-+pVo2Y04I/mkHZHpAtyrnqblsWM=",
+			"dev": true,
 			"requires": {
 				"estraverse": "4.2.0",
 				"object-assign": "4.1.1"
@@ -1759,22 +1960,26 @@
 		"estraverse": {
 			"version": "4.2.0",
 			"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.2.0.tgz",
-			"integrity": "sha1-De4/7TH81GlhjOc0IJn8GvoL2xM="
+			"integrity": "sha1-De4/7TH81GlhjOc0IJn8GvoL2xM=",
+			"dev": true
 		},
 		"estree-walker": {
 			"version": "0.2.1",
 			"resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-0.2.1.tgz",
-			"integrity": "sha1-va/oCVOD2EFNXcLs9MkXO225QS4="
+			"integrity": "sha1-va/oCVOD2EFNXcLs9MkXO225QS4=",
+			"dev": true
 		},
 		"esutils": {
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
-			"integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs="
+			"integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
+			"dev": true
 		},
 		"event-emitter": {
 			"version": "0.3.5",
 			"resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.5.tgz",
 			"integrity": "sha1-34xp7vFkeSPHFXuc6DhAYQsCzDk=",
+			"dev": true,
 			"requires": {
 				"d": "1.0.0",
 				"es5-ext": "0.10.26"
@@ -1784,6 +1989,7 @@
 			"version": "0.2.0",
 			"resolved": "https://registry.npmjs.org/exec-sh/-/exec-sh-0.2.0.tgz",
 			"integrity": "sha1-FPdd4/INKG75MwmbLOUKkDWc7xA=",
+			"dev": true,
 			"requires": {
 				"merge": "1.2.0"
 			}
@@ -1791,12 +1997,14 @@
 		"exit-hook": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/exit-hook/-/exit-hook-1.1.1.tgz",
-			"integrity": "sha1-8FyiM7SMBdVP/wd2XfhQfpXAL/g="
+			"integrity": "sha1-8FyiM7SMBdVP/wd2XfhQfpXAL/g=",
+			"dev": true
 		},
 		"expand-brackets": {
 			"version": "0.1.5",
 			"resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
 			"integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
+			"dev": true,
 			"requires": {
 				"is-posix-bracket": "0.1.1"
 			}
@@ -1805,6 +2013,7 @@
 			"version": "1.8.2",
 			"resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
 			"integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
+			"dev": true,
 			"requires": {
 				"fill-range": "2.2.3"
 			}
@@ -1812,12 +2021,14 @@
 		"extend": {
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
-			"integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ="
+			"integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ=",
+			"dev": true
 		},
 		"extglob": {
 			"version": "0.3.2",
 			"resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
 			"integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
+			"dev": true,
 			"requires": {
 				"is-extglob": "1.0.0"
 			}
@@ -1825,17 +2036,20 @@
 		"extsprintf": {
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
-			"integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU="
+			"integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
+			"dev": true
 		},
 		"fast-levenshtein": {
 			"version": "2.0.6",
 			"resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
-			"integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc="
+			"integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
+			"dev": true
 		},
 		"fb-watchman": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/fb-watchman/-/fb-watchman-2.0.0.tgz",
 			"integrity": "sha1-VOmr99+i8mzZsWNsWIwa/AXeXVg=",
+			"dev": true,
 			"requires": {
 				"bser": "2.0.0"
 			}
@@ -1865,6 +2079,7 @@
 			"version": "1.7.0",
 			"resolved": "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
 			"integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
+			"dev": true,
 			"requires": {
 				"escape-string-regexp": "1.0.5",
 				"object-assign": "4.1.1"
@@ -1874,6 +2089,7 @@
 			"version": "1.3.1",
 			"resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-1.3.1.tgz",
 			"integrity": "sha1-RMYepgeuS+nBQC9B9EJwy/4zT/g=",
+			"dev": true,
 			"requires": {
 				"flat-cache": "1.2.2",
 				"object-assign": "4.1.1"
@@ -1882,12 +2098,14 @@
 		"filename-regex": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.1.tgz",
-			"integrity": "sha1-wcS5vuPglyXdsQa3XB4wH+LxiyY="
+			"integrity": "sha1-wcS5vuPglyXdsQa3XB4wH+LxiyY=",
+			"dev": true
 		},
 		"fileset": {
 			"version": "2.0.3",
 			"resolved": "https://registry.npmjs.org/fileset/-/fileset-2.0.3.tgz",
 			"integrity": "sha1-jnVIqW08wjJ+5eZ0FocjozO7oqA=",
+			"dev": true,
 			"requires": {
 				"glob": "7.1.2",
 				"minimatch": "3.0.4"
@@ -1897,6 +2115,7 @@
 			"version": "2.2.3",
 			"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.3.tgz",
 			"integrity": "sha1-ULd9/X5Gm8dJJHCWNpn+eoSFpyM=",
+			"dev": true,
 			"requires": {
 				"is-number": "2.1.0",
 				"isobject": "2.1.0",
@@ -1909,6 +2128,7 @@
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
 			"integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
+			"dev": true,
 			"requires": {
 				"path-exists": "2.1.0",
 				"pinkie-promise": "2.0.1"
@@ -1918,6 +2138,7 @@
 			"version": "1.2.2",
 			"resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-1.2.2.tgz",
 			"integrity": "sha1-+oZxTnLCHbiGAXYezy9VXRq8a5Y=",
+			"dev": true,
 			"requires": {
 				"circular-json": "0.3.3",
 				"del": "2.2.2",
@@ -1928,12 +2149,14 @@
 		"for-in": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
-			"integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA="
+			"integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA=",
+			"dev": true
 		},
 		"for-own": {
 			"version": "0.1.5",
 			"resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
 			"integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
+			"dev": true,
 			"requires": {
 				"for-in": "1.0.2"
 			}
@@ -1941,12 +2164,14 @@
 		"forever-agent": {
 			"version": "0.6.1",
 			"resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
-			"integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE="
+			"integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
+			"dev": true
 		},
 		"form-data": {
 			"version": "2.1.4",
 			"resolved": "https://registry.npmjs.org/form-data/-/form-data-2.1.4.tgz",
 			"integrity": "sha1-M8GDrPGTJ27KqYFDpp6Uv+4XUNE=",
+			"dev": true,
 			"requires": {
 				"asynckit": "0.4.0",
 				"combined-stream": "1.0.5",
@@ -1956,812 +2181,32 @@
 		"fs-readdir-recursive": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/fs-readdir-recursive/-/fs-readdir-recursive-1.0.0.tgz",
-			"integrity": "sha1-jNF0XItPiinIyuw5JHaSG6GV9WA="
+			"integrity": "sha1-jNF0XItPiinIyuw5JHaSG6GV9WA=",
+			"dev": true
 		},
 		"fs.realpath": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-			"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
-		},
-		"fsevents": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.1.2.tgz",
-			"integrity": "sha512-Sn44E5wQW4bTHXvQmvSHwqbuiXtduD6Rrjm2ZtUEGbyrig+nUH3t/QD4M4/ZXViY556TBpRgZkHLDx3JxPwxiw==",
-			"optional": true,
-			"requires": {
-				"nan": "2.6.2",
-				"node-pre-gyp": "0.6.36"
-			},
-			"dependencies": {
-				"abbrev": {
-					"version": "1.1.0",
-					"bundled": true,
-					"optional": true
-				},
-				"ajv": {
-					"version": "4.11.8",
-					"bundled": true,
-					"optional": true,
-					"requires": {
-						"co": "4.6.0",
-						"json-stable-stringify": "1.0.1"
-					}
-				},
-				"ansi-regex": {
-					"version": "2.1.1",
-					"bundled": true
-				},
-				"aproba": {
-					"version": "1.1.1",
-					"bundled": true,
-					"optional": true
-				},
-				"are-we-there-yet": {
-					"version": "1.1.4",
-					"bundled": true,
-					"optional": true,
-					"requires": {
-						"delegates": "1.0.0",
-						"readable-stream": "2.2.9"
-					}
-				},
-				"asn1": {
-					"version": "0.2.3",
-					"bundled": true,
-					"optional": true
-				},
-				"assert-plus": {
-					"version": "0.2.0",
-					"bundled": true,
-					"optional": true
-				},
-				"asynckit": {
-					"version": "0.4.0",
-					"bundled": true,
-					"optional": true
-				},
-				"aws-sign2": {
-					"version": "0.6.0",
-					"bundled": true,
-					"optional": true
-				},
-				"aws4": {
-					"version": "1.6.0",
-					"bundled": true,
-					"optional": true
-				},
-				"balanced-match": {
-					"version": "0.4.2",
-					"bundled": true
-				},
-				"bcrypt-pbkdf": {
-					"version": "1.0.1",
-					"bundled": true,
-					"optional": true,
-					"requires": {
-						"tweetnacl": "0.14.5"
-					}
-				},
-				"block-stream": {
-					"version": "0.0.9",
-					"bundled": true,
-					"requires": {
-						"inherits": "2.0.3"
-					}
-				},
-				"boom": {
-					"version": "2.10.1",
-					"bundled": true,
-					"requires": {
-						"hoek": "2.16.3"
-					}
-				},
-				"brace-expansion": {
-					"version": "1.1.7",
-					"bundled": true,
-					"requires": {
-						"balanced-match": "0.4.2",
-						"concat-map": "0.0.1"
-					}
-				},
-				"buffer-shims": {
-					"version": "1.0.0",
-					"bundled": true
-				},
-				"caseless": {
-					"version": "0.12.0",
-					"bundled": true,
-					"optional": true
-				},
-				"co": {
-					"version": "4.6.0",
-					"bundled": true,
-					"optional": true
-				},
-				"code-point-at": {
-					"version": "1.1.0",
-					"bundled": true
-				},
-				"combined-stream": {
-					"version": "1.0.5",
-					"bundled": true,
-					"requires": {
-						"delayed-stream": "1.0.0"
-					}
-				},
-				"concat-map": {
-					"version": "0.0.1",
-					"bundled": true
-				},
-				"console-control-strings": {
-					"version": "1.1.0",
-					"bundled": true
-				},
-				"core-util-is": {
-					"version": "1.0.2",
-					"bundled": true
-				},
-				"cryptiles": {
-					"version": "2.0.5",
-					"bundled": true,
-					"optional": true,
-					"requires": {
-						"boom": "2.10.1"
-					}
-				},
-				"dashdash": {
-					"version": "1.14.1",
-					"bundled": true,
-					"optional": true,
-					"requires": {
-						"assert-plus": "1.0.0"
-					},
-					"dependencies": {
-						"assert-plus": {
-							"version": "1.0.0",
-							"bundled": true,
-							"optional": true
-						}
-					}
-				},
-				"debug": {
-					"version": "2.6.8",
-					"bundled": true,
-					"optional": true,
-					"requires": {
-						"ms": "2.0.0"
-					}
-				},
-				"deep-extend": {
-					"version": "0.4.2",
-					"bundled": true,
-					"optional": true
-				},
-				"delayed-stream": {
-					"version": "1.0.0",
-					"bundled": true
-				},
-				"delegates": {
-					"version": "1.0.0",
-					"bundled": true,
-					"optional": true
-				},
-				"ecc-jsbn": {
-					"version": "0.1.1",
-					"bundled": true,
-					"optional": true,
-					"requires": {
-						"jsbn": "0.1.1"
-					}
-				},
-				"extend": {
-					"version": "3.0.1",
-					"bundled": true,
-					"optional": true
-				},
-				"extsprintf": {
-					"version": "1.0.2",
-					"bundled": true
-				},
-				"forever-agent": {
-					"version": "0.6.1",
-					"bundled": true,
-					"optional": true
-				},
-				"form-data": {
-					"version": "2.1.4",
-					"bundled": true,
-					"optional": true,
-					"requires": {
-						"asynckit": "0.4.0",
-						"combined-stream": "1.0.5",
-						"mime-types": "2.1.15"
-					}
-				},
-				"fs.realpath": {
-					"version": "1.0.0",
-					"bundled": true
-				},
-				"fstream": {
-					"version": "1.0.11",
-					"bundled": true,
-					"requires": {
-						"graceful-fs": "4.1.11",
-						"inherits": "2.0.3",
-						"mkdirp": "0.5.1",
-						"rimraf": "2.6.1"
-					}
-				},
-				"fstream-ignore": {
-					"version": "1.0.5",
-					"bundled": true,
-					"optional": true,
-					"requires": {
-						"fstream": "1.0.11",
-						"inherits": "2.0.3",
-						"minimatch": "3.0.4"
-					}
-				},
-				"gauge": {
-					"version": "2.7.4",
-					"bundled": true,
-					"optional": true,
-					"requires": {
-						"aproba": "1.1.1",
-						"console-control-strings": "1.1.0",
-						"has-unicode": "2.0.1",
-						"object-assign": "4.1.1",
-						"signal-exit": "3.0.2",
-						"string-width": "1.0.2",
-						"strip-ansi": "3.0.1",
-						"wide-align": "1.1.2"
-					}
-				},
-				"getpass": {
-					"version": "0.1.7",
-					"bundled": true,
-					"optional": true,
-					"requires": {
-						"assert-plus": "1.0.0"
-					},
-					"dependencies": {
-						"assert-plus": {
-							"version": "1.0.0",
-							"bundled": true,
-							"optional": true
-						}
-					}
-				},
-				"glob": {
-					"version": "7.1.2",
-					"bundled": true,
-					"requires": {
-						"fs.realpath": "1.0.0",
-						"inflight": "1.0.6",
-						"inherits": "2.0.3",
-						"minimatch": "3.0.4",
-						"once": "1.4.0",
-						"path-is-absolute": "1.0.1"
-					}
-				},
-				"graceful-fs": {
-					"version": "4.1.11",
-					"bundled": true
-				},
-				"har-schema": {
-					"version": "1.0.5",
-					"bundled": true,
-					"optional": true
-				},
-				"har-validator": {
-					"version": "4.2.1",
-					"bundled": true,
-					"optional": true,
-					"requires": {
-						"ajv": "4.11.8",
-						"har-schema": "1.0.5"
-					}
-				},
-				"has-unicode": {
-					"version": "2.0.1",
-					"bundled": true,
-					"optional": true
-				},
-				"hawk": {
-					"version": "3.1.3",
-					"bundled": true,
-					"optional": true,
-					"requires": {
-						"boom": "2.10.1",
-						"cryptiles": "2.0.5",
-						"hoek": "2.16.3",
-						"sntp": "1.0.9"
-					}
-				},
-				"hoek": {
-					"version": "2.16.3",
-					"bundled": true
-				},
-				"http-signature": {
-					"version": "1.1.1",
-					"bundled": true,
-					"optional": true,
-					"requires": {
-						"assert-plus": "0.2.0",
-						"jsprim": "1.4.0",
-						"sshpk": "1.13.0"
-					}
-				},
-				"inflight": {
-					"version": "1.0.6",
-					"bundled": true,
-					"requires": {
-						"once": "1.4.0",
-						"wrappy": "1.0.2"
-					}
-				},
-				"inherits": {
-					"version": "2.0.3",
-					"bundled": true
-				},
-				"ini": {
-					"version": "1.3.4",
-					"bundled": true,
-					"optional": true
-				},
-				"is-fullwidth-code-point": {
-					"version": "1.0.0",
-					"bundled": true,
-					"requires": {
-						"number-is-nan": "1.0.1"
-					}
-				},
-				"is-typedarray": {
-					"version": "1.0.0",
-					"bundled": true,
-					"optional": true
-				},
-				"isarray": {
-					"version": "1.0.0",
-					"bundled": true
-				},
-				"isstream": {
-					"version": "0.1.2",
-					"bundled": true,
-					"optional": true
-				},
-				"jodid25519": {
-					"version": "1.0.2",
-					"bundled": true,
-					"optional": true,
-					"requires": {
-						"jsbn": "0.1.1"
-					}
-				},
-				"jsbn": {
-					"version": "0.1.1",
-					"bundled": true,
-					"optional": true
-				},
-				"json-schema": {
-					"version": "0.2.3",
-					"bundled": true,
-					"optional": true
-				},
-				"json-stable-stringify": {
-					"version": "1.0.1",
-					"bundled": true,
-					"optional": true,
-					"requires": {
-						"jsonify": "0.0.0"
-					}
-				},
-				"json-stringify-safe": {
-					"version": "5.0.1",
-					"bundled": true,
-					"optional": true
-				},
-				"jsonify": {
-					"version": "0.0.0",
-					"bundled": true,
-					"optional": true
-				},
-				"jsprim": {
-					"version": "1.4.0",
-					"bundled": true,
-					"optional": true,
-					"requires": {
-						"assert-plus": "1.0.0",
-						"extsprintf": "1.0.2",
-						"json-schema": "0.2.3",
-						"verror": "1.3.6"
-					},
-					"dependencies": {
-						"assert-plus": {
-							"version": "1.0.0",
-							"bundled": true,
-							"optional": true
-						}
-					}
-				},
-				"mime-db": {
-					"version": "1.27.0",
-					"bundled": true
-				},
-				"mime-types": {
-					"version": "2.1.15",
-					"bundled": true,
-					"requires": {
-						"mime-db": "1.27.0"
-					}
-				},
-				"minimatch": {
-					"version": "3.0.4",
-					"bundled": true,
-					"requires": {
-						"brace-expansion": "1.1.7"
-					}
-				},
-				"minimist": {
-					"version": "0.0.8",
-					"bundled": true
-				},
-				"mkdirp": {
-					"version": "0.5.1",
-					"bundled": true,
-					"requires": {
-						"minimist": "0.0.8"
-					}
-				},
-				"ms": {
-					"version": "2.0.0",
-					"bundled": true,
-					"optional": true
-				},
-				"node-pre-gyp": {
-					"version": "0.6.36",
-					"bundled": true,
-					"optional": true,
-					"requires": {
-						"mkdirp": "0.5.1",
-						"nopt": "4.0.1",
-						"npmlog": "4.1.0",
-						"rc": "1.2.1",
-						"request": "2.81.0",
-						"rimraf": "2.6.1",
-						"semver": "5.3.0",
-						"tar": "2.2.1",
-						"tar-pack": "3.4.0"
-					}
-				},
-				"nopt": {
-					"version": "4.0.1",
-					"bundled": true,
-					"optional": true,
-					"requires": {
-						"abbrev": "1.1.0",
-						"osenv": "0.1.4"
-					}
-				},
-				"npmlog": {
-					"version": "4.1.0",
-					"bundled": true,
-					"optional": true,
-					"requires": {
-						"are-we-there-yet": "1.1.4",
-						"console-control-strings": "1.1.0",
-						"gauge": "2.7.4",
-						"set-blocking": "2.0.0"
-					}
-				},
-				"number-is-nan": {
-					"version": "1.0.1",
-					"bundled": true
-				},
-				"oauth-sign": {
-					"version": "0.8.2",
-					"bundled": true,
-					"optional": true
-				},
-				"object-assign": {
-					"version": "4.1.1",
-					"bundled": true,
-					"optional": true
-				},
-				"once": {
-					"version": "1.4.0",
-					"bundled": true,
-					"requires": {
-						"wrappy": "1.0.2"
-					}
-				},
-				"os-homedir": {
-					"version": "1.0.2",
-					"bundled": true,
-					"optional": true
-				},
-				"os-tmpdir": {
-					"version": "1.0.2",
-					"bundled": true,
-					"optional": true
-				},
-				"osenv": {
-					"version": "0.1.4",
-					"bundled": true,
-					"optional": true,
-					"requires": {
-						"os-homedir": "1.0.2",
-						"os-tmpdir": "1.0.2"
-					}
-				},
-				"path-is-absolute": {
-					"version": "1.0.1",
-					"bundled": true
-				},
-				"performance-now": {
-					"version": "0.2.0",
-					"bundled": true,
-					"optional": true
-				},
-				"process-nextick-args": {
-					"version": "1.0.7",
-					"bundled": true
-				},
-				"punycode": {
-					"version": "1.4.1",
-					"bundled": true,
-					"optional": true
-				},
-				"qs": {
-					"version": "6.4.0",
-					"bundled": true,
-					"optional": true
-				},
-				"rc": {
-					"version": "1.2.1",
-					"bundled": true,
-					"optional": true,
-					"requires": {
-						"deep-extend": "0.4.2",
-						"ini": "1.3.4",
-						"minimist": "1.2.0",
-						"strip-json-comments": "2.0.1"
-					},
-					"dependencies": {
-						"minimist": {
-							"version": "1.2.0",
-							"bundled": true,
-							"optional": true
-						}
-					}
-				},
-				"readable-stream": {
-					"version": "2.2.9",
-					"bundled": true,
-					"requires": {
-						"buffer-shims": "1.0.0",
-						"core-util-is": "1.0.2",
-						"inherits": "2.0.3",
-						"isarray": "1.0.0",
-						"process-nextick-args": "1.0.7",
-						"string_decoder": "1.0.1",
-						"util-deprecate": "1.0.2"
-					}
-				},
-				"request": {
-					"version": "2.81.0",
-					"bundled": true,
-					"optional": true,
-					"requires": {
-						"aws-sign2": "0.6.0",
-						"aws4": "1.6.0",
-						"caseless": "0.12.0",
-						"combined-stream": "1.0.5",
-						"extend": "3.0.1",
-						"forever-agent": "0.6.1",
-						"form-data": "2.1.4",
-						"har-validator": "4.2.1",
-						"hawk": "3.1.3",
-						"http-signature": "1.1.1",
-						"is-typedarray": "1.0.0",
-						"isstream": "0.1.2",
-						"json-stringify-safe": "5.0.1",
-						"mime-types": "2.1.15",
-						"oauth-sign": "0.8.2",
-						"performance-now": "0.2.0",
-						"qs": "6.4.0",
-						"safe-buffer": "5.0.1",
-						"stringstream": "0.0.5",
-						"tough-cookie": "2.3.2",
-						"tunnel-agent": "0.6.0",
-						"uuid": "3.0.1"
-					}
-				},
-				"rimraf": {
-					"version": "2.6.1",
-					"bundled": true,
-					"requires": {
-						"glob": "7.1.2"
-					}
-				},
-				"safe-buffer": {
-					"version": "5.0.1",
-					"bundled": true
-				},
-				"semver": {
-					"version": "5.3.0",
-					"bundled": true,
-					"optional": true
-				},
-				"set-blocking": {
-					"version": "2.0.0",
-					"bundled": true,
-					"optional": true
-				},
-				"signal-exit": {
-					"version": "3.0.2",
-					"bundled": true,
-					"optional": true
-				},
-				"sntp": {
-					"version": "1.0.9",
-					"bundled": true,
-					"optional": true,
-					"requires": {
-						"hoek": "2.16.3"
-					}
-				},
-				"sshpk": {
-					"version": "1.13.0",
-					"bundled": true,
-					"optional": true,
-					"requires": {
-						"asn1": "0.2.3",
-						"assert-plus": "1.0.0",
-						"bcrypt-pbkdf": "1.0.1",
-						"dashdash": "1.14.1",
-						"ecc-jsbn": "0.1.1",
-						"getpass": "0.1.7",
-						"jodid25519": "1.0.2",
-						"jsbn": "0.1.1",
-						"tweetnacl": "0.14.5"
-					},
-					"dependencies": {
-						"assert-plus": {
-							"version": "1.0.0",
-							"bundled": true,
-							"optional": true
-						}
-					}
-				},
-				"string_decoder": {
-					"version": "1.0.1",
-					"bundled": true,
-					"requires": {
-						"safe-buffer": "5.0.1"
-					}
-				},
-				"string-width": {
-					"version": "1.0.2",
-					"bundled": true,
-					"requires": {
-						"code-point-at": "1.1.0",
-						"is-fullwidth-code-point": "1.0.0",
-						"strip-ansi": "3.0.1"
-					}
-				},
-				"stringstream": {
-					"version": "0.0.5",
-					"bundled": true,
-					"optional": true
-				},
-				"strip-ansi": {
-					"version": "3.0.1",
-					"bundled": true,
-					"requires": {
-						"ansi-regex": "2.1.1"
-					}
-				},
-				"strip-json-comments": {
-					"version": "2.0.1",
-					"bundled": true,
-					"optional": true
-				},
-				"tar": {
-					"version": "2.2.1",
-					"bundled": true,
-					"requires": {
-						"block-stream": "0.0.9",
-						"fstream": "1.0.11",
-						"inherits": "2.0.3"
-					}
-				},
-				"tar-pack": {
-					"version": "3.4.0",
-					"bundled": true,
-					"optional": true,
-					"requires": {
-						"debug": "2.6.8",
-						"fstream": "1.0.11",
-						"fstream-ignore": "1.0.5",
-						"once": "1.4.0",
-						"readable-stream": "2.2.9",
-						"rimraf": "2.6.1",
-						"tar": "2.2.1",
-						"uid-number": "0.0.6"
-					}
-				},
-				"tough-cookie": {
-					"version": "2.3.2",
-					"bundled": true,
-					"optional": true,
-					"requires": {
-						"punycode": "1.4.1"
-					}
-				},
-				"tunnel-agent": {
-					"version": "0.6.0",
-					"bundled": true,
-					"optional": true,
-					"requires": {
-						"safe-buffer": "5.0.1"
-					}
-				},
-				"tweetnacl": {
-					"version": "0.14.5",
-					"bundled": true,
-					"optional": true
-				},
-				"uid-number": {
-					"version": "0.0.6",
-					"bundled": true,
-					"optional": true
-				},
-				"util-deprecate": {
-					"version": "1.0.2",
-					"bundled": true
-				},
-				"uuid": {
-					"version": "3.0.1",
-					"bundled": true,
-					"optional": true
-				},
-				"verror": {
-					"version": "1.3.6",
-					"bundled": true,
-					"optional": true,
-					"requires": {
-						"extsprintf": "1.0.2"
-					}
-				},
-				"wide-align": {
-					"version": "1.1.2",
-					"bundled": true,
-					"optional": true,
-					"requires": {
-						"string-width": "1.0.2"
-					}
-				},
-				"wrappy": {
-					"version": "1.0.2",
-					"bundled": true
-				}
-			}
+			"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+			"dev": true
 		},
 		"function-bind": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.0.tgz",
-			"integrity": "sha1-FhdnFMgBeY5Ojyz391KUZ7tKV3E="
+			"integrity": "sha1-FhdnFMgBeY5Ojyz391KUZ7tKV3E=",
+			"dev": true
 		},
 		"generate-function": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz",
-			"integrity": "sha1-aFj+fAlpt9TpCTM3ZHrHn2DfvnQ="
+			"integrity": "sha1-aFj+fAlpt9TpCTM3ZHrHn2DfvnQ=",
+			"dev": true
 		},
 		"generate-object-property": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
 			"integrity": "sha1-nA4cQDCM6AT0eDYYuTf6iPmdUNA=",
+			"dev": true,
 			"requires": {
 				"is-property": "1.0.2"
 			}
@@ -2769,12 +2214,14 @@
 		"get-caller-file": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.2.tgz",
-			"integrity": "sha1-9wLmMSfn4jHBYKgMFVSstw1QR+U="
+			"integrity": "sha1-9wLmMSfn4jHBYKgMFVSstw1QR+U=",
+			"dev": true
 		},
 		"getpass": {
 			"version": "0.1.7",
 			"resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
 			"integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
+			"dev": true,
 			"requires": {
 				"assert-plus": "1.0.0"
 			},
@@ -2782,7 +2229,8 @@
 				"assert-plus": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-					"integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
+					"integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+					"dev": true
 				}
 			}
 		},
@@ -2790,6 +2238,7 @@
 			"version": "7.1.2",
 			"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
 			"integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+			"dev": true,
 			"requires": {
 				"fs.realpath": "1.0.0",
 				"inflight": "1.0.6",
@@ -2803,6 +2252,7 @@
 			"version": "0.3.0",
 			"resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz",
 			"integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
+			"dev": true,
 			"requires": {
 				"glob-parent": "2.0.0",
 				"is-glob": "2.0.1"
@@ -2812,6 +2262,7 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
 			"integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
+			"dev": true,
 			"requires": {
 				"is-glob": "2.0.1"
 			}
@@ -2819,12 +2270,14 @@
 		"globals": {
 			"version": "9.18.0",
 			"resolved": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz",
-			"integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ=="
+			"integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ==",
+			"dev": true
 		},
 		"globby": {
 			"version": "5.0.0",
 			"resolved": "https://registry.npmjs.org/globby/-/globby-5.0.0.tgz",
 			"integrity": "sha1-69hGZ8oNuzMLmbz8aOrCvFQ3Dg0=",
+			"dev": true,
 			"requires": {
 				"array-union": "1.0.2",
 				"arrify": "1.0.1",
@@ -2837,17 +2290,20 @@
 		"graceful-fs": {
 			"version": "4.1.11",
 			"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
-			"integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg="
+			"integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
+			"dev": true
 		},
 		"growly": {
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/growly/-/growly-1.3.0.tgz",
-			"integrity": "sha1-8QdIy+dq+WS3yWyTxrzCivEgwIE="
+			"integrity": "sha1-8QdIy+dq+WS3yWyTxrzCivEgwIE=",
+			"dev": true
 		},
 		"gzip-size": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/gzip-size/-/gzip-size-3.0.0.tgz",
 			"integrity": "sha1-VGGI6b3DN/Zzdy+BZgRks4nc5SA=",
+			"dev": true,
 			"requires": {
 				"duplexer": "0.1.1"
 			}
@@ -2856,6 +2312,7 @@
 			"version": "4.0.10",
 			"resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.10.tgz",
 			"integrity": "sha1-PTDHGLCaPZbyPqTMH0A8TTup/08=",
+			"dev": true,
 			"requires": {
 				"async": "1.5.2",
 				"optimist": "0.6.1",
@@ -2866,12 +2323,14 @@
 				"async": {
 					"version": "1.5.2",
 					"resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
-					"integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo="
+					"integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
+					"dev": true
 				},
 				"source-map": {
 					"version": "0.4.4",
 					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
 					"integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
+					"dev": true,
 					"requires": {
 						"amdefine": "1.0.1"
 					}
@@ -2881,12 +2340,14 @@
 		"har-schema": {
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/har-schema/-/har-schema-1.0.5.tgz",
-			"integrity": "sha1-0mMTX0MwfALGAq/I/pWXDAFRNp4="
+			"integrity": "sha1-0mMTX0MwfALGAq/I/pWXDAFRNp4=",
+			"dev": true
 		},
 		"har-validator": {
 			"version": "4.2.1",
 			"resolved": "https://registry.npmjs.org/har-validator/-/har-validator-4.2.1.tgz",
 			"integrity": "sha1-M0gdDxu/9gDdID11gSpqX7oALio=",
+			"dev": true,
 			"requires": {
 				"ajv": "4.11.8",
 				"har-schema": "1.0.5"
@@ -2896,6 +2357,7 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/has/-/has-1.0.1.tgz",
 			"integrity": "sha1-hGFzP1OLCDfJNh45qauelwTcLyg=",
+			"dev": true,
 			"requires": {
 				"function-bind": "1.1.0"
 			}
@@ -2904,6 +2366,7 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
 			"integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+			"dev": true,
 			"requires": {
 				"ansi-regex": "2.1.1"
 			}
@@ -2911,12 +2374,14 @@
 		"has-flag": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
-			"integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo="
+			"integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
+			"dev": true
 		},
 		"hawk": {
 			"version": "3.1.3",
 			"resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
 			"integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
+			"dev": true,
 			"requires": {
 				"boom": "2.10.1",
 				"cryptiles": "2.0.5",
@@ -2939,12 +2404,19 @@
 		"hoek": {
 			"version": "2.16.3",
 			"resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
-			"integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0="
+			"integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0=",
+			"dev": true
+		},
+		"hoist-non-react-statics": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-1.2.0.tgz",
+			"integrity": "sha1-qkSM8JhtVcxAdzsXF0t90GbLfPs="
 		},
 		"home-or-tmp": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-2.0.0.tgz",
 			"integrity": "sha1-42w/LSyufXRqhX440Y1fMqeILbg=",
+			"dev": true,
 			"requires": {
 				"os-homedir": "1.0.2",
 				"os-tmpdir": "1.0.2"
@@ -2953,12 +2425,14 @@
 		"hosted-git-info": {
 			"version": "2.5.0",
 			"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.5.0.tgz",
-			"integrity": "sha512-pNgbURSuab90KbTqvRPsseaTxOJCZBD0a7t+haSN33piP9cCM4l0CqdzAif2hUqm716UovKB2ROmiabGAKVXyg=="
+			"integrity": "sha512-pNgbURSuab90KbTqvRPsseaTxOJCZBD0a7t+haSN33piP9cCM4l0CqdzAif2hUqm716UovKB2ROmiabGAKVXyg==",
+			"dev": true
 		},
 		"html-encoding-sniffer": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-1.0.1.tgz",
 			"integrity": "sha1-eb96eF6klf5mFl5zQVPzY/9UN9o=",
+			"dev": true,
 			"requires": {
 				"whatwg-encoding": "1.0.1"
 			}
@@ -2967,6 +2441,7 @@
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
 			"integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
+			"dev": true,
 			"requires": {
 				"assert-plus": "0.2.0",
 				"jsprim": "1.4.1",
@@ -2981,17 +2456,20 @@
 		"ignore": {
 			"version": "3.3.3",
 			"resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.3.tgz",
-			"integrity": "sha1-QyNS5XrM2HqzEQ6C0/6g5HgSFW0="
+			"integrity": "sha1-QyNS5XrM2HqzEQ6C0/6g5HgSFW0=",
+			"dev": true
 		},
 		"imurmurhash": {
 			"version": "0.1.4",
 			"resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
-			"integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o="
+			"integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
+			"dev": true
 		},
 		"inflight": {
 			"version": "1.0.6",
 			"resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
 			"integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+			"dev": true,
 			"requires": {
 				"once": "1.4.0",
 				"wrappy": "1.0.2"
@@ -3000,12 +2478,14 @@
 		"inherits": {
 			"version": "2.0.3",
 			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-			"integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+			"integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+			"dev": true
 		},
 		"inquirer": {
 			"version": "0.12.0",
 			"resolved": "https://registry.npmjs.org/inquirer/-/inquirer-0.12.0.tgz",
 			"integrity": "sha1-HvK/1jUE3wvHV4X/+MLEHfEvB34=",
+			"dev": true,
 			"requires": {
 				"ansi-escapes": "1.4.0",
 				"ansi-regex": "2.1.1",
@@ -3033,17 +2513,20 @@
 		"invert-kv": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
-			"integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY="
+			"integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY=",
+			"dev": true
 		},
 		"is-arrayish": {
 			"version": "0.2.1",
 			"resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
-			"integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0="
+			"integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
+			"dev": true
 		},
 		"is-binary-path": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
 			"integrity": "sha1-dfFmQrSA8YenEcgUFh/TpKdlWJg=",
+			"dev": true,
 			"optional": true,
 			"requires": {
 				"binary-extensions": "1.9.0"
@@ -3052,12 +2535,14 @@
 		"is-buffer": {
 			"version": "1.1.5",
 			"resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.5.tgz",
-			"integrity": "sha1-Hzsm72E7IUuIy8ojzGwB2Hlh7sw="
+			"integrity": "sha1-Hzsm72E7IUuIy8ojzGwB2Hlh7sw=",
+			"dev": true
 		},
 		"is-builtin-module": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
 			"integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
+			"dev": true,
 			"requires": {
 				"builtin-modules": "1.1.1"
 			}
@@ -3066,6 +2551,7 @@
 			"version": "1.0.10",
 			"resolved": "https://registry.npmjs.org/is-ci/-/is-ci-1.0.10.tgz",
 			"integrity": "sha1-9zkzayYyNlBhqdSCcM1WrjNpMY4=",
+			"dev": true,
 			"requires": {
 				"ci-info": "1.0.0"
 			}
@@ -3073,12 +2559,14 @@
 		"is-dotfile": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.3.tgz",
-			"integrity": "sha1-pqLzL/0t+wT1yiXs0Pa4PPeYoeE="
+			"integrity": "sha1-pqLzL/0t+wT1yiXs0Pa4PPeYoeE=",
+			"dev": true
 		},
 		"is-equal-shallow": {
 			"version": "0.1.3",
 			"resolved": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
 			"integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
+			"dev": true,
 			"requires": {
 				"is-primitive": "2.0.0"
 			}
@@ -3086,17 +2574,20 @@
 		"is-extendable": {
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
-			"integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik="
+			"integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik=",
+			"dev": true
 		},
 		"is-extglob": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-			"integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA="
+			"integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
+			"dev": true
 		},
 		"is-finite": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
 			"integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
+			"dev": true,
 			"requires": {
 				"number-is-nan": "1.0.1"
 			}
@@ -3105,6 +2596,7 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
 			"integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+			"dev": true,
 			"requires": {
 				"number-is-nan": "1.0.1"
 			}
@@ -3113,6 +2605,7 @@
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
 			"integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
+			"dev": true,
 			"requires": {
 				"is-extglob": "1.0.0"
 			}
@@ -3120,12 +2613,14 @@
 		"is-module": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/is-module/-/is-module-1.0.0.tgz",
-			"integrity": "sha1-Mlj7afeMFNW4FdZkM2tM/7ZEFZE="
+			"integrity": "sha1-Mlj7afeMFNW4FdZkM2tM/7ZEFZE=",
+			"dev": true
 		},
 		"is-my-json-valid": {
 			"version": "2.16.0",
 			"resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.16.0.tgz",
 			"integrity": "sha1-8Hndm/2uZe4gOKrorLyGqxCeNpM=",
+			"dev": true,
 			"requires": {
 				"generate-function": "2.0.0",
 				"generate-object-property": "1.2.0",
@@ -3137,6 +2632,7 @@
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
 			"integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
+			"dev": true,
 			"requires": {
 				"kind-of": "3.2.2"
 			}
@@ -3144,12 +2640,14 @@
 		"is-path-cwd": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/is-path-cwd/-/is-path-cwd-1.0.0.tgz",
-			"integrity": "sha1-0iXsIxMuie3Tj9p2dHLmLmXxEG0="
+			"integrity": "sha1-0iXsIxMuie3Tj9p2dHLmLmXxEG0=",
+			"dev": true
 		},
 		"is-path-in-cwd": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/is-path-in-cwd/-/is-path-in-cwd-1.0.0.tgz",
 			"integrity": "sha1-ZHdYK4IU1gI0YJRWcAO+ip6sBNw=",
+			"dev": true,
 			"requires": {
 				"is-path-inside": "1.0.0"
 			}
@@ -3158,6 +2656,7 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.0.tgz",
 			"integrity": "sha1-/AbloWg/vaE95mev9xe7wQpI838=",
+			"dev": true,
 			"requires": {
 				"path-is-inside": "1.0.2"
 			}
@@ -3165,22 +2664,26 @@
 		"is-posix-bracket": {
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz",
-			"integrity": "sha1-MzTceXdDaOkvAW5vvAqI9c1ua8Q="
+			"integrity": "sha1-MzTceXdDaOkvAW5vvAqI9c1ua8Q=",
+			"dev": true
 		},
 		"is-primitive": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz",
-			"integrity": "sha1-IHurkWOEmcB7Kt8kCkGochADRXU="
+			"integrity": "sha1-IHurkWOEmcB7Kt8kCkGochADRXU=",
+			"dev": true
 		},
 		"is-property": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
-			"integrity": "sha1-V/4cTkhHTt1lsJkR8msc1Ald2oQ="
+			"integrity": "sha1-V/4cTkhHTt1lsJkR8msc1Ald2oQ=",
+			"dev": true
 		},
 		"is-resolvable": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/is-resolvable/-/is-resolvable-1.0.0.tgz",
 			"integrity": "sha1-jfV8YeouPFAUCNEA+wE8+NbgzGI=",
+			"dev": true,
 			"requires": {
 				"tryit": "1.0.3"
 			}
@@ -3193,27 +2696,32 @@
 		"is-typedarray": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-			"integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
+			"integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
+			"dev": true
 		},
 		"is-utf8": {
 			"version": "0.2.1",
 			"resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
-			"integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI="
+			"integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI=",
+			"dev": true
 		},
 		"isarray": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-			"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+			"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+			"dev": true
 		},
 		"isexe": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-			"integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
+			"integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
+			"dev": true
 		},
 		"isobject": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
 			"integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
+			"dev": true,
 			"requires": {
 				"isarray": "1.0.0"
 			}
@@ -3230,12 +2738,14 @@
 		"isstream": {
 			"version": "0.1.2",
 			"resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
-			"integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
+			"integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
+			"dev": true
 		},
 		"istanbul-api": {
 			"version": "1.1.11",
 			"resolved": "https://registry.npmjs.org/istanbul-api/-/istanbul-api-1.1.11.tgz",
 			"integrity": "sha1-/MC0YeKzvaceMFFVE4I4doJX2d4=",
+			"dev": true,
 			"requires": {
 				"async": "2.5.0",
 				"fileset": "2.0.3",
@@ -3253,12 +2763,14 @@
 		"istanbul-lib-coverage": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-1.1.1.tgz",
-			"integrity": "sha512-0+1vDkmzxqJIn5rcoEqapSB4DmPxE31EtI2dF2aCkV5esN9EWHxZ0dwgDClivMXJqE7zaYQxq30hj5L0nlTN5Q=="
+			"integrity": "sha512-0+1vDkmzxqJIn5rcoEqapSB4DmPxE31EtI2dF2aCkV5esN9EWHxZ0dwgDClivMXJqE7zaYQxq30hj5L0nlTN5Q==",
+			"dev": true
 		},
 		"istanbul-lib-hook": {
 			"version": "1.0.7",
 			"resolved": "https://registry.npmjs.org/istanbul-lib-hook/-/istanbul-lib-hook-1.0.7.tgz",
 			"integrity": "sha512-3U2HB9y1ZV9UmFlE12Fx+nPtFqIymzrqCksrXujm3NVbAZIJg/RfYgO1XiIa0mbmxTjWpVEVlkIZJ25xVIAfkQ==",
+			"dev": true,
 			"requires": {
 				"append-transform": "0.4.0"
 			}
@@ -3267,6 +2779,7 @@
 			"version": "1.7.4",
 			"resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-1.7.4.tgz",
 			"integrity": "sha1-6f2SDkdn89Ge3HZeLWs/XMvQ7qg=",
+			"dev": true,
 			"requires": {
 				"babel-generator": "6.25.0",
 				"babel-template": "6.25.0",
@@ -3281,6 +2794,7 @@
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-1.1.1.tgz",
 			"integrity": "sha512-tvF+YmCmH4thnez6JFX06ujIA19WPa9YUiwjc1uALF2cv5dmE3It8b5I8Ob7FHJ70H9Y5yF+TDkVa/mcADuw1Q==",
+			"dev": true,
 			"requires": {
 				"istanbul-lib-coverage": "1.1.1",
 				"mkdirp": "0.5.1",
@@ -3292,6 +2806,7 @@
 					"version": "3.2.3",
 					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
 					"integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
+					"dev": true,
 					"requires": {
 						"has-flag": "1.0.0"
 					}
@@ -3302,6 +2817,7 @@
 			"version": "1.2.1",
 			"resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-1.2.1.tgz",
 			"integrity": "sha512-mukVvSXCn9JQvdJl8wP/iPhqig0MRtuWuD4ZNKo6vB2Ik//AmhAKe3QnPN02dmkRe3lTudFk3rzoHhwU4hb94w==",
+			"dev": true,
 			"requires": {
 				"debug": "2.6.8",
 				"istanbul-lib-coverage": "1.1.1",
@@ -3314,6 +2830,7 @@
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-1.1.1.tgz",
 			"integrity": "sha512-P8G873A0kW24XRlxHVGhMJBhQ8gWAec+dae7ZxOBzxT4w+a9ATSPvRVK3LB1RAJ9S8bg2tOyWHAGW40Zd2dKfw==",
+			"dev": true,
 			"requires": {
 				"handlebars": "4.0.10"
 			}
@@ -3322,6 +2839,7 @@
 			"version": "20.0.4",
 			"resolved": "https://registry.npmjs.org/jest/-/jest-20.0.4.tgz",
 			"integrity": "sha1-PdJgwpidba1nix6cxNkZRPbWAqw=",
+			"dev": true,
 			"requires": {
 				"jest-cli": "20.0.4"
 			},
@@ -3329,12 +2847,14 @@
 				"callsites": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/callsites/-/callsites-2.0.0.tgz",
-					"integrity": "sha1-BuuE8A7qQT2oav/vrL/7Ngk7PFA="
+					"integrity": "sha1-BuuE8A7qQT2oav/vrL/7Ngk7PFA=",
+					"dev": true
 				},
 				"jest-cli": {
 					"version": "20.0.4",
 					"resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-20.0.4.tgz",
 					"integrity": "sha1-5TKxnYiuW8bEF+iwWTpv6VSx3JM=",
+					"dev": true,
 					"requires": {
 						"ansi-escapes": "1.4.0",
 						"callsites": "2.0.0",
@@ -3373,12 +2893,14 @@
 		"jest-changed-files": {
 			"version": "20.0.3",
 			"resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-20.0.3.tgz",
-			"integrity": "sha1-k5TVzGXEOEBhSb7xv01Sto4D4/g="
+			"integrity": "sha1-k5TVzGXEOEBhSb7xv01Sto4D4/g=",
+			"dev": true
 		},
 		"jest-config": {
 			"version": "20.0.4",
 			"resolved": "https://registry.npmjs.org/jest-config/-/jest-config-20.0.4.tgz",
 			"integrity": "sha1-43kwqyIXyRNgXv8T5712PsSPruo=",
+			"dev": true,
 			"requires": {
 				"chalk": "1.1.3",
 				"glob": "7.1.2",
@@ -3396,6 +2918,7 @@
 			"version": "20.0.3",
 			"resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-20.0.3.tgz",
 			"integrity": "sha1-gfKI/Z5nXw+yPHXxwrGURf5YZhc=",
+			"dev": true,
 			"requires": {
 				"chalk": "1.1.3",
 				"diff": "3.3.0",
@@ -3406,12 +2929,14 @@
 		"jest-docblock": {
 			"version": "20.0.3",
 			"resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-20.0.3.tgz",
-			"integrity": "sha1-F76phDQswz2DxQ++FUXqDvqkRxI="
+			"integrity": "sha1-F76phDQswz2DxQ++FUXqDvqkRxI=",
+			"dev": true
 		},
 		"jest-environment-jsdom": {
 			"version": "20.0.3",
 			"resolved": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-20.0.3.tgz",
 			"integrity": "sha1-BIqKwS7iJfcZBBdxODS7mZeH3pk=",
+			"dev": true,
 			"requires": {
 				"jest-mock": "20.0.3",
 				"jest-util": "20.0.3",
@@ -3422,6 +2947,7 @@
 			"version": "20.0.3",
 			"resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-20.0.3.tgz",
 			"integrity": "sha1-1Ii8RhKvLCRumG6K52caCZFj1AM=",
+			"dev": true,
 			"requires": {
 				"jest-mock": "20.0.3",
 				"jest-util": "20.0.3"
@@ -3431,6 +2957,7 @@
 			"version": "20.0.4",
 			"resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-20.0.4.tgz",
 			"integrity": "sha1-ZT61XIic48Ah97lGk/IKQVm63wM=",
+			"dev": true,
 			"requires": {
 				"fb-watchman": "2.0.0",
 				"graceful-fs": "4.1.11",
@@ -3444,6 +2971,7 @@
 			"version": "20.0.4",
 			"resolved": "https://registry.npmjs.org/jest-jasmine2/-/jest-jasmine2-20.0.4.tgz",
 			"integrity": "sha1-/MWxQReA2RHQQpAu8YWehS5g1eE=",
+			"dev": true,
 			"requires": {
 				"chalk": "1.1.3",
 				"graceful-fs": "4.1.11",
@@ -3460,6 +2988,7 @@
 			"version": "20.0.3",
 			"resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-20.0.3.tgz",
 			"integrity": "sha1-s6a443yld4A7CDKpixZPRLeBVhI=",
+			"dev": true,
 			"requires": {
 				"chalk": "1.1.3",
 				"pretty-format": "20.0.3"
@@ -3469,6 +2998,7 @@
 			"version": "20.0.3",
 			"resolved": "https://registry.npmjs.org/jest-matchers/-/jest-matchers-20.0.3.tgz",
 			"integrity": "sha1-ymnbHDLbWm9wf6XgQBq7VXAN/WA=",
+			"dev": true,
 			"requires": {
 				"jest-diff": "20.0.3",
 				"jest-matcher-utils": "20.0.3",
@@ -3480,6 +3010,7 @@
 			"version": "20.0.3",
 			"resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-20.0.3.tgz",
 			"integrity": "sha1-auwoRDBvyw5udNV5bBAG2W/dgxw=",
+			"dev": true,
 			"requires": {
 				"chalk": "1.1.3",
 				"micromatch": "2.3.11",
@@ -3489,17 +3020,20 @@
 		"jest-mock": {
 			"version": "20.0.3",
 			"resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-20.0.3.tgz",
-			"integrity": "sha1-i8Bw6QQUqhVcEajWTIaaDVxx2lk="
+			"integrity": "sha1-i8Bw6QQUqhVcEajWTIaaDVxx2lk=",
+			"dev": true
 		},
 		"jest-regex-util": {
 			"version": "20.0.3",
 			"resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-20.0.3.tgz",
-			"integrity": "sha1-hburXRM+RGJbGfr4xqpRItCF12I="
+			"integrity": "sha1-hburXRM+RGJbGfr4xqpRItCF12I=",
+			"dev": true
 		},
 		"jest-resolve": {
 			"version": "20.0.4",
 			"resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-20.0.4.tgz",
 			"integrity": "sha1-lEiz6La6/BVHlETGSZBFt//ll6U=",
+			"dev": true,
 			"requires": {
 				"browser-resolve": "1.11.2",
 				"is-builtin-module": "1.0.0",
@@ -3510,6 +3044,7 @@
 			"version": "20.0.3",
 			"resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-20.0.3.tgz",
 			"integrity": "sha1-bhSntxevDyyzZnxUneQK8Bexcjo=",
+			"dev": true,
 			"requires": {
 				"jest-regex-util": "20.0.3"
 			}
@@ -3518,6 +3053,7 @@
 			"version": "20.0.4",
 			"resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-20.0.4.tgz",
 			"integrity": "sha1-osgCIZxCA/dU3xQE5JAYYWnRJNg=",
+			"dev": true,
 			"requires": {
 				"babel-core": "6.25.0",
 				"babel-jest": "20.0.3",
@@ -3539,7 +3075,8 @@
 				"strip-bom": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
-					"integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM="
+					"integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
+					"dev": true
 				}
 			}
 		},
@@ -3547,6 +3084,7 @@
 			"version": "20.0.3",
 			"resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-20.0.3.tgz",
 			"integrity": "sha1-W4R+GtsaTZCFKn+fElCG4YfHZWY=",
+			"dev": true,
 			"requires": {
 				"chalk": "1.1.3",
 				"jest-diff": "20.0.3",
@@ -3560,6 +3098,7 @@
 			"version": "20.0.3",
 			"resolved": "https://registry.npmjs.org/jest-util/-/jest-util-20.0.3.tgz",
 			"integrity": "sha1-DAf32A2C9OWmfG+LnD/n9lz9Mq0=",
+			"dev": true,
 			"requires": {
 				"chalk": "1.1.3",
 				"graceful-fs": "4.1.11",
@@ -3574,6 +3113,7 @@
 			"version": "20.0.3",
 			"resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-20.0.3.tgz",
 			"integrity": "sha1-0M/R3k9XnymEhJJcKA+PHZTsPKs=",
+			"dev": true,
 			"requires": {
 				"chalk": "1.1.3",
 				"jest-matcher-utils": "20.0.3",
@@ -3590,6 +3130,7 @@
 			"version": "3.9.1",
 			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.9.1.tgz",
 			"integrity": "sha512-CbcG379L1e+mWBnLvHWWeLs8GyV/EMw862uLI3c+GxVyDHWZcjZinwuBd3iW2pgxgIlksW/1vNJa4to+RvDOww==",
+			"dev": true,
 			"requires": {
 				"argparse": "1.0.9",
 				"esprima": "4.0.0"
@@ -3599,12 +3140,14 @@
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
 			"integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
+			"dev": true,
 			"optional": true
 		},
 		"jsdom": {
 			"version": "9.12.0",
 			"resolved": "https://registry.npmjs.org/jsdom/-/jsdom-9.12.0.tgz",
 			"integrity": "sha1-6MVG//ywbADUgzyoRBD+1/igl9Q=",
+			"dev": true,
 			"requires": {
 				"abab": "1.0.3",
 				"acorn": "4.0.13",
@@ -3630,24 +3173,28 @@
 				"acorn": {
 					"version": "4.0.13",
 					"resolved": "https://registry.npmjs.org/acorn/-/acorn-4.0.13.tgz",
-					"integrity": "sha1-EFSVrlNh1pe9GVyCUZLhrX8lN4c="
+					"integrity": "sha1-EFSVrlNh1pe9GVyCUZLhrX8lN4c=",
+					"dev": true
 				}
 			}
 		},
 		"jsesc": {
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/jsesc/-/jsesc-1.3.0.tgz",
-			"integrity": "sha1-RsP+yMGJKxKwgz25vHYiF226s0s="
+			"integrity": "sha1-RsP+yMGJKxKwgz25vHYiF226s0s=",
+			"dev": true
 		},
 		"json-schema": {
 			"version": "0.2.3",
 			"resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
-			"integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM="
+			"integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
+			"dev": true
 		},
 		"json-stable-stringify": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
 			"integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
+			"dev": true,
 			"requires": {
 				"jsonify": "0.0.0"
 			}
@@ -3655,27 +3202,32 @@
 		"json-stringify-safe": {
 			"version": "5.0.1",
 			"resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-			"integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
+			"integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
+			"dev": true
 		},
 		"json5": {
 			"version": "0.5.1",
 			"resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
-			"integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE="
+			"integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE=",
+			"dev": true
 		},
 		"jsonify": {
 			"version": "0.0.0",
 			"resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
-			"integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM="
+			"integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=",
+			"dev": true
 		},
 		"jsonpointer": {
 			"version": "4.0.1",
 			"resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-4.0.1.tgz",
-			"integrity": "sha1-T9kss04OnbPInIYi7PUfm5eMbLk="
+			"integrity": "sha1-T9kss04OnbPInIYi7PUfm5eMbLk=",
+			"dev": true
 		},
 		"jsprim": {
 			"version": "1.4.1",
 			"resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
 			"integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
+			"dev": true,
 			"requires": {
 				"assert-plus": "1.0.0",
 				"extsprintf": "1.3.0",
@@ -3686,19 +3238,22 @@
 				"assert-plus": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-					"integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
+					"integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+					"dev": true
 				}
 			}
 		},
 		"jsx-ast-utils": {
 			"version": "1.4.1",
 			"resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-1.4.1.tgz",
-			"integrity": "sha1-OGchPo3Xm/Ho8jAMDPwe+xgsDfE="
+			"integrity": "sha1-OGchPo3Xm/Ho8jAMDPwe+xgsDfE=",
+			"dev": true
 		},
 		"kind-of": {
 			"version": "3.2.2",
 			"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
 			"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+			"dev": true,
 			"requires": {
 				"is-buffer": "1.1.5"
 			}
@@ -3707,12 +3262,14 @@
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz",
 			"integrity": "sha1-odePw6UEdMuAhF07O24dpJpEbo4=",
+			"dev": true,
 			"optional": true
 		},
 		"lcid": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
 			"integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
+			"dev": true,
 			"requires": {
 				"invert-kv": "1.0.0"
 			}
@@ -3720,12 +3277,14 @@
 		"leven": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/leven/-/leven-2.1.0.tgz",
-			"integrity": "sha1-wuep93IJTe6dNCAq6KzORoeHVYA="
+			"integrity": "sha1-wuep93IJTe6dNCAq6KzORoeHVYA=",
+			"dev": true
 		},
 		"levn": {
 			"version": "0.3.0",
 			"resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
 			"integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
+			"dev": true,
 			"requires": {
 				"prelude-ls": "1.1.2",
 				"type-check": "0.3.2"
@@ -3735,6 +3294,7 @@
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
 			"integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
+			"dev": true,
 			"requires": {
 				"graceful-fs": "4.1.11",
 				"parse-json": "2.2.0",
@@ -3747,6 +3307,7 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
 			"integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
+			"dev": true,
 			"requires": {
 				"p-locate": "2.0.0",
 				"path-exists": "3.0.0"
@@ -3755,64 +3316,76 @@
 				"path-exists": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
-					"integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU="
+					"integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
+					"dev": true
 				}
 			}
 		},
 		"lodash": {
 			"version": "4.17.4",
 			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
-			"integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4="
+			"integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4=",
+			"dev": true
 		},
 		"lodash.assign": {
 			"version": "4.2.0",
 			"resolved": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-4.2.0.tgz",
-			"integrity": "sha1-DZnzzNem0mHRm9rrkkUAXShYCOc="
+			"integrity": "sha1-DZnzzNem0mHRm9rrkkUAXShYCOc=",
+			"dev": true
 		},
 		"lodash.camelcase": {
 			"version": "4.3.0",
 			"resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
-			"integrity": "sha1-soqmKIorn8ZRA1x3EfZathkDMaY="
+			"integrity": "sha1-soqmKIorn8ZRA1x3EfZathkDMaY=",
+			"dev": true
 		},
 		"lodash.cond": {
 			"version": "4.5.2",
 			"resolved": "https://registry.npmjs.org/lodash.cond/-/lodash.cond-4.5.2.tgz",
-			"integrity": "sha1-9HGh2khr5g9quVXRcRVSPdHSVdU="
+			"integrity": "sha1-9HGh2khr5g9quVXRcRVSPdHSVdU=",
+			"dev": true
 		},
 		"lodash.endswith": {
 			"version": "4.2.1",
 			"resolved": "https://registry.npmjs.org/lodash.endswith/-/lodash.endswith-4.2.1.tgz",
-			"integrity": "sha1-/tWawXOO0+I27dcGTsRWRIs3vAk="
+			"integrity": "sha1-/tWawXOO0+I27dcGTsRWRIs3vAk=",
+			"dev": true
 		},
 		"lodash.find": {
 			"version": "4.6.0",
 			"resolved": "https://registry.npmjs.org/lodash.find/-/lodash.find-4.6.0.tgz",
-			"integrity": "sha1-ywcE1Hq3F4n/oN6Ll92Sb7iLE7E="
+			"integrity": "sha1-ywcE1Hq3F4n/oN6Ll92Sb7iLE7E=",
+			"dev": true
 		},
 		"lodash.findindex": {
 			"version": "4.6.0",
 			"resolved": "https://registry.npmjs.org/lodash.findindex/-/lodash.findindex-4.6.0.tgz",
-			"integrity": "sha1-oyRd7mH7m24GJLU1ElYku2nBEQY="
+			"integrity": "sha1-oyRd7mH7m24GJLU1ElYku2nBEQY=",
+			"dev": true
 		},
 		"lodash.kebabcase": {
 			"version": "4.1.1",
 			"resolved": "https://registry.npmjs.org/lodash.kebabcase/-/lodash.kebabcase-4.1.1.tgz",
-			"integrity": "sha1-hImxyw0p/4gZXM7KRI/21swpXDY="
+			"integrity": "sha1-hImxyw0p/4gZXM7KRI/21swpXDY=",
+			"dev": true
 		},
 		"lodash.pickby": {
 			"version": "4.6.0",
 			"resolved": "https://registry.npmjs.org/lodash.pickby/-/lodash.pickby-4.6.0.tgz",
-			"integrity": "sha1-feoh2MGNdwOifHBMFdO4SmfjOv8="
+			"integrity": "sha1-feoh2MGNdwOifHBMFdO4SmfjOv8=",
+			"dev": true
 		},
 		"lodash.snakecase": {
 			"version": "4.1.1",
 			"resolved": "https://registry.npmjs.org/lodash.snakecase/-/lodash.snakecase-4.1.1.tgz",
-			"integrity": "sha1-OdcUo1NXFHg3rv1ktdy7Fr7Nj40="
+			"integrity": "sha1-OdcUo1NXFHg3rv1ktdy7Fr7Nj40=",
+			"dev": true
 		},
 		"longest": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
-			"integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc="
+			"integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc=",
+			"dev": true
 		},
 		"loose-envify": {
 			"version": "1.3.1",
@@ -3823,9 +3396,10 @@
 			}
 		},
 		"magic-string": {
-			"version": "0.19.1",
-			"resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.19.1.tgz",
-			"integrity": "sha1-FNdoATyvLsj96hakmvgvw3fnUgE=",
+			"version": "0.22.4",
+			"resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.22.4.tgz",
+			"integrity": "sha512-kxBL06p6iO2qPBHsqGK2b3cRwiRGpnmSuVWNhwHcMX7qJOUr1HvricYP1LZOCdkQBUp0jiWg2d6WJwR3vYgByw==",
+			"dev": true,
 			"requires": {
 				"vlq": "0.2.2"
 			}
@@ -3834,6 +3408,7 @@
 			"version": "1.0.11",
 			"resolved": "https://registry.npmjs.org/makeerror/-/makeerror-1.0.11.tgz",
 			"integrity": "sha1-4BpckQnyr3lmDk6LlYd5AYT1qWw=",
+			"dev": true,
 			"requires": {
 				"tmpl": "1.0.4"
 			}
@@ -3841,12 +3416,14 @@
 		"merge": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/merge/-/merge-1.2.0.tgz",
-			"integrity": "sha1-dTHjnUlJwoGma4xabgJl6LBYlNo="
+			"integrity": "sha1-dTHjnUlJwoGma4xabgJl6LBYlNo=",
+			"dev": true
 		},
 		"micromatch": {
 			"version": "2.3.11",
 			"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
 			"integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
+			"dev": true,
 			"requires": {
 				"arr-diff": "2.0.0",
 				"array-unique": "0.2.1",
@@ -3866,12 +3443,14 @@
 		"mime-db": {
 			"version": "1.29.0",
 			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.29.0.tgz",
-			"integrity": "sha1-SNJtI1WJZRcErFkWygYAGRQmaHg="
+			"integrity": "sha1-SNJtI1WJZRcErFkWygYAGRQmaHg=",
+			"dev": true
 		},
 		"mime-types": {
 			"version": "2.1.16",
 			"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.16.tgz",
 			"integrity": "sha1-K4WKUuXs1RbbiXrCvodIeDBpjiM=",
+			"dev": true,
 			"requires": {
 				"mime-db": "1.29.0"
 			}
@@ -3880,6 +3459,7 @@
 			"version": "3.0.4",
 			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
 			"integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+			"dev": true,
 			"requires": {
 				"brace-expansion": "1.1.8"
 			}
@@ -3887,12 +3467,14 @@
 		"minimist": {
 			"version": "0.0.8",
 			"resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-			"integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
+			"integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+			"dev": true
 		},
 		"mkdirp": {
 			"version": "0.5.1",
 			"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
 			"integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+			"dev": true,
 			"requires": {
 				"minimist": "0.0.8"
 			}
@@ -3900,23 +3482,20 @@
 		"ms": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-			"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+			"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+			"dev": true
 		},
 		"mute-stream": {
 			"version": "0.0.5",
 			"resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.5.tgz",
-			"integrity": "sha1-j7+rsKmKJT0xhDMfno3rc3L6xsA="
-		},
-		"nan": {
-			"version": "2.6.2",
-			"resolved": "https://registry.npmjs.org/nan/-/nan-2.6.2.tgz",
-			"integrity": "sha1-5P805slf37WuzAjeZZb0NgWn20U=",
-			"optional": true
+			"integrity": "sha1-j7+rsKmKJT0xhDMfno3rc3L6xsA=",
+			"dev": true
 		},
 		"natural-compare": {
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
-			"integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc="
+			"integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
+			"dev": true
 		},
 		"node-fetch": {
 			"version": "1.7.1",
@@ -3930,12 +3509,14 @@
 		"node-int64": {
 			"version": "0.4.0",
 			"resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
-			"integrity": "sha1-h6kGXNs1XTGC2PlM4RGIuCXGijs="
+			"integrity": "sha1-h6kGXNs1XTGC2PlM4RGIuCXGijs=",
+			"dev": true
 		},
 		"node-notifier": {
 			"version": "5.1.2",
 			"resolved": "https://registry.npmjs.org/node-notifier/-/node-notifier-5.1.2.tgz",
 			"integrity": "sha1-L6nhJgX6EACdRFSdb82KY93g5P8=",
+			"dev": true,
 			"requires": {
 				"growly": "1.3.0",
 				"semver": "5.4.1",
@@ -3947,6 +3528,7 @@
 			"version": "2.4.0",
 			"resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
 			"integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
+			"dev": true,
 			"requires": {
 				"hosted-git-info": "2.5.0",
 				"is-builtin-module": "1.0.0",
@@ -3958,6 +3540,7 @@
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
 			"integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
+			"dev": true,
 			"requires": {
 				"remove-trailing-separator": "1.0.2"
 			}
@@ -3965,17 +3548,20 @@
 		"number-is-nan": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-			"integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
+			"integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
+			"dev": true
 		},
 		"nwmatcher": {
 			"version": "1.4.1",
 			"resolved": "https://registry.npmjs.org/nwmatcher/-/nwmatcher-1.4.1.tgz",
-			"integrity": "sha1-eumwew6oBNt+JfBctf5Al9TklJ8="
+			"integrity": "sha1-eumwew6oBNt+JfBctf5Al9TklJ8=",
+			"dev": true
 		},
 		"oauth-sign": {
 			"version": "0.8.2",
 			"resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
-			"integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM="
+			"integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM=",
+			"dev": true
 		},
 		"object-assign": {
 			"version": "4.1.1",
@@ -3986,6 +3572,7 @@
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
 			"integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
+			"dev": true,
 			"requires": {
 				"for-own": "0.1.5",
 				"is-extendable": "0.1.1"
@@ -3995,6 +3582,7 @@
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
 			"integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+			"dev": true,
 			"requires": {
 				"wrappy": "1.0.2"
 			}
@@ -4002,12 +3590,14 @@
 		"onetime": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
-			"integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k="
+			"integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k=",
+			"dev": true
 		},
 		"optimist": {
 			"version": "0.6.1",
 			"resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
 			"integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
+			"dev": true,
 			"requires": {
 				"minimist": "0.0.8",
 				"wordwrap": "0.0.3"
@@ -4016,7 +3606,8 @@
 				"wordwrap": {
 					"version": "0.0.3",
 					"resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
-					"integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc="
+					"integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc=",
+					"dev": true
 				}
 			}
 		},
@@ -4024,6 +3615,7 @@
 			"version": "0.8.2",
 			"resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
 			"integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
+			"dev": true,
 			"requires": {
 				"deep-is": "0.1.3",
 				"fast-levenshtein": "2.0.6",
@@ -4036,12 +3628,14 @@
 		"os-homedir": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
-			"integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M="
+			"integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
+			"dev": true
 		},
 		"os-locale": {
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
 			"integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
+			"dev": true,
 			"requires": {
 				"lcid": "1.0.0"
 			}
@@ -4049,12 +3643,14 @@
 		"os-tmpdir": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
-			"integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ="
+			"integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
+			"dev": true
 		},
 		"output-file-sync": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/output-file-sync/-/output-file-sync-1.1.2.tgz",
 			"integrity": "sha1-0KM+7+YaIF+suQCS6CZZjVJFznY=",
+			"dev": true,
 			"requires": {
 				"graceful-fs": "4.1.11",
 				"mkdirp": "0.5.1",
@@ -4064,12 +3660,14 @@
 		"p-limit": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.1.0.tgz",
-			"integrity": "sha1-sH/y2aXYi+yAYDWJWiurZqJ5iLw="
+			"integrity": "sha1-sH/y2aXYi+yAYDWJWiurZqJ5iLw=",
+			"dev": true
 		},
 		"p-locate": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
 			"integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
+			"dev": true,
 			"requires": {
 				"p-limit": "1.1.0"
 			}
@@ -4077,12 +3675,14 @@
 		"p-map": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/p-map/-/p-map-1.1.1.tgz",
-			"integrity": "sha1-BfXkrpegaDcbwqXMhr+9vBnErno="
+			"integrity": "sha1-BfXkrpegaDcbwqXMhr+9vBnErno=",
+			"dev": true
 		},
 		"parse-glob": {
 			"version": "3.0.4",
 			"resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
 			"integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
+			"dev": true,
 			"requires": {
 				"glob-base": "0.3.0",
 				"is-dotfile": "1.0.3",
@@ -4094,6 +3694,7 @@
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
 			"integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
+			"dev": true,
 			"requires": {
 				"error-ex": "1.3.1"
 			}
@@ -4101,12 +3702,14 @@
 		"parse5": {
 			"version": "1.5.1",
 			"resolved": "https://registry.npmjs.org/parse5/-/parse5-1.5.1.tgz",
-			"integrity": "sha1-m387DeMr543CQBsXVzzK8Pb1nZQ="
+			"integrity": "sha1-m387DeMr543CQBsXVzzK8Pb1nZQ=",
+			"dev": true
 		},
 		"path-exists": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
 			"integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
+			"dev": true,
 			"requires": {
 				"pinkie-promise": "2.0.1"
 			}
@@ -4114,22 +3717,41 @@
 		"path-is-absolute": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-			"integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
+			"integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+			"dev": true
 		},
 		"path-is-inside": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.2.tgz",
-			"integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM="
+			"integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM=",
+			"dev": true
 		},
 		"path-parse": {
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.5.tgz",
-			"integrity": "sha1-PBrfhx6pzWyUMbbqK9dKD/BVxME="
+			"integrity": "sha1-PBrfhx6pzWyUMbbqK9dKD/BVxME=",
+			"dev": true
+		},
+		"path-to-regexp": {
+			"version": "1.7.0",
+			"resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.7.0.tgz",
+			"integrity": "sha1-Wf3g9DW62suhA6hOnTvGTpa5k30=",
+			"requires": {
+				"isarray": "0.0.1"
+			},
+			"dependencies": {
+				"isarray": {
+					"version": "0.0.1",
+					"resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+					"integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+				}
+			}
 		},
 		"path-type": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
 			"integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
+			"dev": true,
 			"requires": {
 				"graceful-fs": "4.1.11",
 				"pify": "2.3.0",
@@ -4139,22 +3761,26 @@
 		"performance-now": {
 			"version": "0.2.0",
 			"resolved": "https://registry.npmjs.org/performance-now/-/performance-now-0.2.0.tgz",
-			"integrity": "sha1-M+8wxcd9TqIcWlOGnZG1bY8lVeU="
+			"integrity": "sha1-M+8wxcd9TqIcWlOGnZG1bY8lVeU=",
+			"dev": true
 		},
 		"pify": {
 			"version": "2.3.0",
 			"resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-			"integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
+			"integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+			"dev": true
 		},
 		"pinkie": {
 			"version": "2.0.4",
 			"resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
-			"integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA="
+			"integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
+			"dev": true
 		},
 		"pinkie-promise": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
 			"integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
+			"dev": true,
 			"requires": {
 				"pinkie": "2.0.4"
 			}
@@ -4163,6 +3789,7 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-1.0.0.tgz",
 			"integrity": "sha1-ektQio1bstYp1EcFb/TpyTFM89Q=",
+			"dev": true,
 			"requires": {
 				"find-up": "1.1.2"
 			}
@@ -4171,6 +3798,7 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/pkg-up/-/pkg-up-1.0.0.tgz",
 			"integrity": "sha1-Pgj7RhUlxEIWJKM7n35tCvWwWiY=",
+			"dev": true,
 			"requires": {
 				"find-up": "1.1.2"
 			}
@@ -4178,22 +3806,26 @@
 		"pluralize": {
 			"version": "1.2.1",
 			"resolved": "https://registry.npmjs.org/pluralize/-/pluralize-1.2.1.tgz",
-			"integrity": "sha1-0aIUg/0iu0HlihL6NCGCMUCJfEU="
+			"integrity": "sha1-0aIUg/0iu0HlihL6NCGCMUCJfEU=",
+			"dev": true
 		},
 		"prelude-ls": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
-			"integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ="
+			"integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
+			"dev": true
 		},
 		"preserve": {
 			"version": "0.2.0",
 			"resolved": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz",
-			"integrity": "sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks="
+			"integrity": "sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks=",
+			"dev": true
 		},
 		"pretty-bytes": {
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-3.0.1.tgz",
 			"integrity": "sha1-J9AAjXeAY6C0gRuzXHnxvV1fvM8=",
+			"dev": true,
 			"requires": {
 				"number-is-nan": "1.0.1"
 			}
@@ -4202,6 +3834,7 @@
 			"version": "20.0.3",
 			"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-20.0.3.tgz",
 			"integrity": "sha1-Ag41ClYKH+GpjcO+tsz/s4beixQ=",
+			"dev": true,
 			"requires": {
 				"ansi-regex": "2.1.1",
 				"ansi-styles": "3.2.0"
@@ -4211,6 +3844,7 @@
 					"version": "3.2.0",
 					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
 					"integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+					"dev": true,
 					"requires": {
 						"color-convert": "1.9.0"
 					}
@@ -4220,17 +3854,20 @@
 		"private": {
 			"version": "0.1.7",
 			"resolved": "https://registry.npmjs.org/private/-/private-0.1.7.tgz",
-			"integrity": "sha1-aM5eih7woju1cMwoU3tTMqumPvE="
+			"integrity": "sha1-aM5eih7woju1cMwoU3tTMqumPvE=",
+			"dev": true
 		},
 		"process-nextick-args": {
 			"version": "1.0.7",
 			"resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
-			"integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M="
+			"integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M=",
+			"dev": true
 		},
 		"progress": {
 			"version": "1.1.8",
 			"resolved": "https://registry.npmjs.org/progress/-/progress-1.1.8.tgz",
-			"integrity": "sha1-4mDHj2Fhzdmw5WzD4Khd4Xx6V74="
+			"integrity": "sha1-4mDHj2Fhzdmw5WzD4Khd4Xx6V74=",
+			"dev": true
 		},
 		"promise": {
 			"version": "7.3.1",
@@ -4252,22 +3889,26 @@
 		"prr": {
 			"version": "0.0.0",
 			"resolved": "https://registry.npmjs.org/prr/-/prr-0.0.0.tgz",
-			"integrity": "sha1-GoS4WQgyVQFBGFPQCB7j+obikmo="
+			"integrity": "sha1-GoS4WQgyVQFBGFPQCB7j+obikmo=",
+			"dev": true
 		},
 		"punycode": {
 			"version": "1.4.1",
 			"resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
-			"integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
+			"integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
+			"dev": true
 		},
 		"qs": {
 			"version": "6.4.0",
 			"resolved": "https://registry.npmjs.org/qs/-/qs-6.4.0.tgz",
-			"integrity": "sha1-E+JtKK1rD/qpExLNO/cI7TUecjM="
+			"integrity": "sha1-E+JtKK1rD/qpExLNO/cI7TUecjM=",
+			"dev": true
 		},
 		"randomatic": {
 			"version": "1.1.7",
 			"resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.7.tgz",
 			"integrity": "sha512-D5JUjPyJbaJDkuAazpVnSfVkLlpeO3wDlPROTMLGKG1zMFNFRgrciKo1ltz/AzNTkqE0HzDx655QOL51N06how==",
+			"dev": true,
 			"requires": {
 				"is-number": "3.0.0",
 				"kind-of": "4.0.0"
@@ -4277,6 +3918,7 @@
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
 					"integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+					"dev": true,
 					"requires": {
 						"kind-of": "3.2.2"
 					},
@@ -4285,6 +3927,7 @@
 							"version": "3.2.2",
 							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
 							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+							"dev": true,
 							"requires": {
 								"is-buffer": "1.1.5"
 							}
@@ -4295,6 +3938,7 @@
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
 					"integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
+					"dev": true,
 					"requires": {
 						"is-buffer": "1.1.5"
 					}
@@ -4305,6 +3949,7 @@
 			"version": "15.6.1",
 			"resolved": "https://registry.npmjs.org/react/-/react-15.6.1.tgz",
 			"integrity": "sha1-uqhDTsZ4C96ZfNw4C3nNM7ljk98=",
+			"dev": true,
 			"requires": {
 				"create-react-class": "15.6.0",
 				"fbjs": "0.8.14",
@@ -4316,12 +3961,14 @@
 		"react-addons-test-utils": {
 			"version": "15.6.0",
 			"resolved": "https://registry.npmjs.org/react-addons-test-utils/-/react-addons-test-utils-15.6.0.tgz",
-			"integrity": "sha1-Bi02EX/o0Y87peBuszODsLhepbk="
+			"integrity": "sha1-Bi02EX/o0Y87peBuszODsLhepbk=",
+			"dev": true
 		},
 		"react-dom": {
 			"version": "15.6.1",
 			"resolved": "https://registry.npmjs.org/react-dom/-/react-dom-15.6.1.tgz",
 			"integrity": "sha1-LLDtQZEDjlPCCes6eaI+Kkz5lHA=",
+			"dev": true,
 			"requires": {
 				"fbjs": "0.8.14",
 				"loose-envify": "1.3.1",
@@ -4329,10 +3976,25 @@
 				"prop-types": "15.5.10"
 			}
 		},
+		"react-router": {
+			"version": "4.1.2",
+			"resolved": "https://registry.npmjs.org/react-router/-/react-router-4.1.2.tgz",
+			"integrity": "sha512-VyM87OP+GkijVkkOXJw39A9fKtFelLoZYYDxtELhpZefjYatxI2SUxZcImo/9Tv52rR9UnNJBPSBpVRQMdvi8A==",
+			"requires": {
+				"history": "4.6.3",
+				"hoist-non-react-statics": "1.2.0",
+				"invariant": "2.2.2",
+				"loose-envify": "1.3.1",
+				"path-to-regexp": "1.7.0",
+				"prop-types": "15.5.10",
+				"warning": "3.0.0"
+			}
+		},
 		"read-pkg": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
 			"integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
+			"dev": true,
 			"requires": {
 				"load-json-file": "1.1.0",
 				"normalize-package-data": "2.4.0",
@@ -4343,6 +4005,7 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
 			"integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
+			"dev": true,
 			"requires": {
 				"find-up": "1.1.2",
 				"read-pkg": "1.1.0"
@@ -4352,6 +4015,7 @@
 			"version": "2.3.3",
 			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
 			"integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
+			"dev": true,
 			"requires": {
 				"core-util-is": "1.0.2",
 				"inherits": "2.0.3",
@@ -4366,6 +4030,7 @@
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/readdirp/-/readdirp-2.1.0.tgz",
 			"integrity": "sha1-TtCtBg3zBzMAxIRANz9y0cxkLXg=",
+			"dev": true,
 			"optional": true,
 			"requires": {
 				"graceful-fs": "4.1.11",
@@ -4378,6 +4043,7 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/readline2/-/readline2-1.0.1.tgz",
 			"integrity": "sha1-QQWWCP/BVHV7cV2ZidGZ/783LjU=",
+			"dev": true,
 			"requires": {
 				"code-point-at": "1.1.0",
 				"is-fullwidth-code-point": "1.0.0",
@@ -4387,17 +4053,20 @@
 		"regenerate": {
 			"version": "1.3.2",
 			"resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.3.2.tgz",
-			"integrity": "sha1-0ZQcZ7rUN+G+dkM63Vs4X5WxkmA="
+			"integrity": "sha1-0ZQcZ7rUN+G+dkM63Vs4X5WxkmA=",
+			"dev": true
 		},
 		"regenerator-runtime": {
 			"version": "0.10.5",
 			"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz",
-			"integrity": "sha1-M2w+/BIgrc7dosn6tntaeVWjNlg="
+			"integrity": "sha1-M2w+/BIgrc7dosn6tntaeVWjNlg=",
+			"dev": true
 		},
 		"regenerator-transform": {
 			"version": "0.9.11",
 			"resolved": "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.9.11.tgz",
 			"integrity": "sha1-On0GdSDLe3F2dp61/4aGkb7+EoM=",
+			"dev": true,
 			"requires": {
 				"babel-runtime": "6.25.0",
 				"babel-types": "6.25.0",
@@ -4408,6 +4077,7 @@
 			"version": "0.4.3",
 			"resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.3.tgz",
 			"integrity": "sha1-mxpsNdTQ3871cRrmUejp09cRQUU=",
+			"dev": true,
 			"requires": {
 				"is-equal-shallow": "0.1.3",
 				"is-primitive": "2.0.0"
@@ -4417,6 +4087,7 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-2.0.0.tgz",
 			"integrity": "sha1-SdA4g3uNz4v6W5pCE5k45uoq4kA=",
+			"dev": true,
 			"requires": {
 				"regenerate": "1.3.2",
 				"regjsgen": "0.2.0",
@@ -4426,12 +4097,14 @@
 		"regjsgen": {
 			"version": "0.2.0",
 			"resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.2.0.tgz",
-			"integrity": "sha1-bAFq3qxVT3WCP+N6wFuS1aTtsfc="
+			"integrity": "sha1-bAFq3qxVT3WCP+N6wFuS1aTtsfc=",
+			"dev": true
 		},
 		"regjsparser": {
 			"version": "0.1.5",
 			"resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.1.5.tgz",
 			"integrity": "sha1-fuj4Tcb6eS0/0K4ijSS9lJ6tIFw=",
+			"dev": true,
 			"requires": {
 				"jsesc": "0.5.0"
 			},
@@ -4439,29 +4112,34 @@
 				"jsesc": {
 					"version": "0.5.0",
 					"resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
-					"integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0="
+					"integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0=",
+					"dev": true
 				}
 			}
 		},
 		"remove-trailing-separator": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.0.2.tgz",
-			"integrity": "sha1-abBi2XhyetFNxrVrpKt3L9jXBRE="
+			"integrity": "sha1-abBi2XhyetFNxrVrpKt3L9jXBRE=",
+			"dev": true
 		},
 		"repeat-element": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz",
-			"integrity": "sha1-7wiaF40Ug7quTZPrmLT55OEdmQo="
+			"integrity": "sha1-7wiaF40Ug7quTZPrmLT55OEdmQo=",
+			"dev": true
 		},
 		"repeat-string": {
 			"version": "1.6.1",
 			"resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
-			"integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc="
+			"integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
+			"dev": true
 		},
 		"repeating": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
 			"integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
+			"dev": true,
 			"requires": {
 				"is-finite": "1.0.2"
 			}
@@ -4470,6 +4148,7 @@
 			"version": "2.81.0",
 			"resolved": "https://registry.npmjs.org/request/-/request-2.81.0.tgz",
 			"integrity": "sha1-xpKJRqDgbF+Nb4qTM0af/aRimKA=",
+			"dev": true,
 			"requires": {
 				"aws-sign2": "0.6.0",
 				"aws4": "1.6.0",
@@ -4498,17 +4177,20 @@
 		"require-directory": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
-			"integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I="
+			"integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
+			"dev": true
 		},
 		"require-main-filename": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
-			"integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE="
+			"integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE=",
+			"dev": true
 		},
 		"require-uncached": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/require-uncached/-/require-uncached-1.0.3.tgz",
 			"integrity": "sha1-Tg1W1slmL9MeQwEcS5WqSZVUIdM=",
+			"dev": true,
 			"requires": {
 				"caller-path": "0.1.0",
 				"resolve-from": "1.0.1"
@@ -4518,6 +4200,7 @@
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.4.0.tgz",
 			"integrity": "sha512-aW7sVKPufyHqOmyyLzg/J+8606v5nevBgaliIlV7nUpVMsDnoBGV/cbSLNjZAg9q0Cfd/+easKVKQ8vOu8fn1Q==",
+			"dev": true,
 			"requires": {
 				"path-parse": "1.0.5"
 			}
@@ -4525,7 +4208,8 @@
 		"resolve-from": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-1.0.1.tgz",
-			"integrity": "sha1-Jsv+k10a7uq7Kbw/5a6wHpPUQiY="
+			"integrity": "sha1-Jsv+k10a7uq7Kbw/5a6wHpPUQiY=",
+			"dev": true
 		},
 		"resolve-pathname": {
 			"version": "2.1.0",
@@ -4536,6 +4220,7 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-1.0.1.tgz",
 			"integrity": "sha1-NGYfRohjJ/7SmRR5FSJS35LapUE=",
+			"dev": true,
 			"requires": {
 				"exit-hook": "1.1.1",
 				"onetime": "1.1.0"
@@ -4545,6 +4230,7 @@
 			"version": "0.1.3",
 			"resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
 			"integrity": "sha1-YTObci/mo1FWiSENJOFMlhSGE+8=",
+			"dev": true,
 			"optional": true,
 			"requires": {
 				"align-text": "0.1.4"
@@ -4554,58 +4240,61 @@
 			"version": "2.6.1",
 			"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.1.tgz",
 			"integrity": "sha1-wjOOxkPfeht/5cVPqG9XQopV8z0=",
+			"dev": true,
 			"requires": {
 				"glob": "7.1.2"
 			}
 		},
 		"rollup": {
-			"version": "0.45.2",
-			"resolved": "https://registry.npmjs.org/rollup/-/rollup-0.45.2.tgz",
-			"integrity": "sha512-2+bq5GQSrocdhr+M92mOQRmF1evtLRzv9NdmEC2wo7BILvTG8irHCtD0q+zg8ikNu63iJicdN5IzyxAXRTFKOQ==",
-			"requires": {
-				"source-map-support": "0.4.15"
-			}
+			"version": "0.48.2",
+			"resolved": "https://registry.npmjs.org/rollup/-/rollup-0.48.2.tgz",
+			"integrity": "sha512-5IOVEA87/OWQlojaAPN0WStLAhlaY7GS/5p+pA/IHReXjtc+d7IJYgRD3Y/U2LVXoD7f1SBc3ymYd4g3M/zRzQ==",
+			"dev": true
 		},
 		"rollup-plugin-babel": {
-			"version": "2.7.1",
-			"resolved": "https://registry.npmjs.org/rollup-plugin-babel/-/rollup-plugin-babel-2.7.1.tgz",
-			"integrity": "sha1-FlKBl7D5OKFTb0RoPHqT1XMYL1c=",
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/rollup-plugin-babel/-/rollup-plugin-babel-3.0.2.tgz",
+			"integrity": "sha512-ALGPBFtwJZcYHsNPM6RGJlEncTzAARPvZOGjNPZgDe5hS5t6sJGjiOWibEFVEz5LQN7S7spvCBILaS4N1Cql2w==",
+			"dev": true,
 			"requires": {
-				"babel-core": "6.25.0",
-				"babel-plugin-transform-es2015-classes": "6.24.1",
-				"object-assign": "4.1.1",
 				"rollup-pluginutils": "1.5.2"
 			}
 		},
 		"rollup-plugin-commonjs": {
-			"version": "8.0.2",
-			"resolved": "https://registry.npmjs.org/rollup-plugin-commonjs/-/rollup-plugin-commonjs-8.0.2.tgz",
-			"integrity": "sha1-mLFYm/4ypsD2d5C2DAtJmXKv7Yk=",
+			"version": "8.2.0",
+			"resolved": "https://registry.npmjs.org/rollup-plugin-commonjs/-/rollup-plugin-commonjs-8.2.0.tgz",
+			"integrity": "sha512-EhSkStWuGtfFBI9l89KfUb7yOw3IpcQAtYao/R20FvkiKHDndEF9cyWhuUoSW0igY2/hdH0EeUl/3b9d5xHL3w==",
+			"dev": true,
 			"requires": {
-				"acorn": "4.0.13",
-				"estree-walker": "0.3.1",
-				"magic-string": "0.19.1",
+				"acorn": "5.1.1",
+				"estree-walker": "0.5.0",
+				"magic-string": "0.22.4",
 				"resolve": "1.4.0",
 				"rollup-pluginutils": "2.0.1"
 			},
 			"dependencies": {
-				"acorn": {
-					"version": "4.0.13",
-					"resolved": "https://registry.npmjs.org/acorn/-/acorn-4.0.13.tgz",
-					"integrity": "sha1-EFSVrlNh1pe9GVyCUZLhrX8lN4c="
-				},
 				"estree-walker": {
-					"version": "0.3.1",
-					"resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-0.3.1.tgz",
-					"integrity": "sha1-5rGlHPcpJSTnI3wxLl/mZgwc4ao="
+					"version": "0.5.0",
+					"resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-0.5.0.tgz",
+					"integrity": "sha512-/bEAy+yKAZQrEWUhGmS3H9XpGqSDBtRzX0I2PgMw9kA2n1jN22uV5B5p7MFdZdvWdXCRJztXAfx6ZeRfgkEETg==",
+					"dev": true
 				},
 				"rollup-pluginutils": {
 					"version": "2.0.1",
 					"resolved": "https://registry.npmjs.org/rollup-pluginutils/-/rollup-pluginutils-2.0.1.tgz",
 					"integrity": "sha1-fslbNXP2VDpGpkYb2afFRFJdD8A=",
+					"dev": true,
 					"requires": {
 						"estree-walker": "0.3.1",
 						"micromatch": "2.3.11"
+					},
+					"dependencies": {
+						"estree-walker": {
+							"version": "0.3.1",
+							"resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-0.3.1.tgz",
+							"integrity": "sha1-5rGlHPcpJSTnI3wxLl/mZgwc4ao=",
+							"dev": true
+						}
 					}
 				}
 			}
@@ -4614,6 +4303,7 @@
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/rollup-plugin-node-resolve/-/rollup-plugin-node-resolve-3.0.0.tgz",
 			"integrity": "sha1-i4l8TDAw1QASd7BRSyXSygloPuA=",
+			"dev": true,
 			"requires": {
 				"browser-resolve": "1.11.2",
 				"builtin-modules": "1.1.1",
@@ -4625,6 +4315,7 @@
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/rollup-plugin-replace/-/rollup-plugin-replace-1.1.1.tgz",
 			"integrity": "sha1-OWMV3tBQps5DuVGKiGo/YO+x6jM=",
+			"dev": true,
 			"requires": {
 				"magic-string": "0.15.2",
 				"minimatch": "3.0.4",
@@ -4635,6 +4326,7 @@
 					"version": "0.15.2",
 					"resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.15.2.tgz",
 					"integrity": "sha1-BoHXOIdBu8Ot2qZQYJkmJMbAnpw=",
+					"dev": true,
 					"requires": {
 						"vlq": "0.2.2"
 					}
@@ -4645,6 +4337,7 @@
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/rollup-plugin-uglify/-/rollup-plugin-uglify-2.0.1.tgz",
 			"integrity": "sha1-Z7N60e/a+9g69MNrQMGJ7khmyWk=",
+			"dev": true,
 			"requires": {
 				"uglify-js": "3.0.27"
 			},
@@ -4653,6 +4346,7 @@
 					"version": "3.0.27",
 					"resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.0.27.tgz",
 					"integrity": "sha512-HD8CmxPXUI62v5tweiulMcP/apAtx1DXGcNZkhKQZyC+MTrTsoCBb8yPAwVrbvpgw3EpRU76bRe6axjIiCYcQg==",
+					"dev": true,
 					"requires": {
 						"commander": "2.11.0",
 						"source-map": "0.5.6"
@@ -4664,6 +4358,7 @@
 			"version": "1.5.2",
 			"resolved": "https://registry.npmjs.org/rollup-pluginutils/-/rollup-pluginutils-1.5.2.tgz",
 			"integrity": "sha1-HhVud4+UtyVb+hs9AXi+j1xVJAg=",
+			"dev": true,
 			"requires": {
 				"estree-walker": "0.2.1",
 				"minimatch": "3.0.4"
@@ -4673,6 +4368,7 @@
 			"version": "0.1.0",
 			"resolved": "https://registry.npmjs.org/run-async/-/run-async-0.1.0.tgz",
 			"integrity": "sha1-yK1KXhEGYeQCp9IbUw4AnyX444k=",
+			"dev": true,
 			"requires": {
 				"once": "1.4.0"
 			}
@@ -4680,17 +4376,20 @@
 		"rx-lite": {
 			"version": "3.1.2",
 			"resolved": "https://registry.npmjs.org/rx-lite/-/rx-lite-3.1.2.tgz",
-			"integrity": "sha1-Gc5QLKVyZl87ZHsQk5+X/RYV8QI="
+			"integrity": "sha1-Gc5QLKVyZl87ZHsQk5+X/RYV8QI=",
+			"dev": true
 		},
 		"safe-buffer": {
 			"version": "5.1.1",
 			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
-			"integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg=="
+			"integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg==",
+			"dev": true
 		},
 		"sane": {
 			"version": "1.6.0",
 			"resolved": "https://registry.npmjs.org/sane/-/sane-1.6.0.tgz",
 			"integrity": "sha1-lhDEUjB6E10pwf3+JUcDQYDEZ3U=",
+			"dev": true,
 			"requires": {
 				"anymatch": "1.3.2",
 				"exec-sh": "0.2.0",
@@ -4705,6 +4404,7 @@
 					"version": "1.0.2",
 					"resolved": "https://registry.npmjs.org/bser/-/bser-1.0.2.tgz",
 					"integrity": "sha1-OBEWlwsqbe6lZG3RXdcnhES1YWk=",
+					"dev": true,
 					"requires": {
 						"node-int64": "0.4.0"
 					}
@@ -4713,6 +4413,7 @@
 					"version": "1.9.2",
 					"resolved": "https://registry.npmjs.org/fb-watchman/-/fb-watchman-1.9.2.tgz",
 					"integrity": "sha1-okz0eCf4LTj7Waaa1wt247auc4M=",
+					"dev": true,
 					"requires": {
 						"bser": "1.0.2"
 					}
@@ -4720,29 +4421,34 @@
 				"minimist": {
 					"version": "1.2.0",
 					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
+					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+					"dev": true
 				}
 			}
 		},
 		"sax": {
 			"version": "1.2.4",
 			"resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
-			"integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
+			"integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
+			"dev": true
 		},
 		"semver": {
 			"version": "5.4.1",
 			"resolved": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz",
-			"integrity": "sha512-WfG/X9+oATh81XtllIo/I8gOiY9EXRdv1cQdyykeXK17YcUW3EXUAi2To4pcH6nZtJPr7ZOpM5OMyWJZm+8Rsg=="
+			"integrity": "sha512-WfG/X9+oATh81XtllIo/I8gOiY9EXRdv1cQdyykeXK17YcUW3EXUAi2To4pcH6nZtJPr7ZOpM5OMyWJZm+8Rsg==",
+			"dev": true
 		},
 		"set-blocking": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
-			"integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc="
+			"integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
+			"dev": true
 		},
 		"set-immediate-shim": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz",
 			"integrity": "sha1-SysbJ+uAip+NzEgaWOXlb1mfP2E=",
+			"dev": true,
 			"optional": true
 		},
 		"setimmediate": {
@@ -4753,27 +4459,32 @@
 		"shelljs": {
 			"version": "0.6.1",
 			"resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.6.1.tgz",
-			"integrity": "sha1-7GIRvtGSBEIIj+D3Cyg3Iy7SyKg="
+			"integrity": "sha1-7GIRvtGSBEIIj+D3Cyg3Iy7SyKg=",
+			"dev": true
 		},
 		"shellwords": {
 			"version": "0.1.0",
 			"resolved": "https://registry.npmjs.org/shellwords/-/shellwords-0.1.0.tgz",
-			"integrity": "sha1-Zq/Ue2oSky2Qccv9mKUueFzQuhQ="
+			"integrity": "sha1-Zq/Ue2oSky2Qccv9mKUueFzQuhQ=",
+			"dev": true
 		},
 		"slash": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz",
-			"integrity": "sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU="
+			"integrity": "sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU=",
+			"dev": true
 		},
 		"slice-ansi": {
 			"version": "0.0.4",
 			"resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-0.0.4.tgz",
-			"integrity": "sha1-7b+JA/ZvfOL46v1s7tZeJkyDGzU="
+			"integrity": "sha1-7b+JA/ZvfOL46v1s7tZeJkyDGzU=",
+			"dev": true
 		},
 		"sntp": {
 			"version": "1.0.9",
 			"resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
 			"integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
+			"dev": true,
 			"requires": {
 				"hoek": "2.16.3"
 			}
@@ -4781,12 +4492,14 @@
 		"source-map": {
 			"version": "0.5.6",
 			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
-			"integrity": "sha1-dc449SvwczxafwwRjYEzSiu19BI="
+			"integrity": "sha1-dc449SvwczxafwwRjYEzSiu19BI=",
+			"dev": true
 		},
 		"source-map-support": {
 			"version": "0.4.15",
 			"resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.15.tgz",
 			"integrity": "sha1-AyAt9lwG0r2MfsI2KhkwVv7407E=",
+			"dev": true,
 			"requires": {
 				"source-map": "0.5.6"
 			}
@@ -4795,6 +4508,7 @@
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
 			"integrity": "sha1-SzBz2TP/UfORLwOsVRlJikFQ20A=",
+			"dev": true,
 			"requires": {
 				"spdx-license-ids": "1.2.2"
 			}
@@ -4802,22 +4516,26 @@
 		"spdx-expression-parse": {
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.4.tgz",
-			"integrity": "sha1-m98vIOH0DtRH++JzJmGR/O1RYmw="
+			"integrity": "sha1-m98vIOH0DtRH++JzJmGR/O1RYmw=",
+			"dev": true
 		},
 		"spdx-license-ids": {
 			"version": "1.2.2",
 			"resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.2.tgz",
-			"integrity": "sha1-yd96NCRZSt5r0RkA1ZZpbcBrrFc="
+			"integrity": "sha1-yd96NCRZSt5r0RkA1ZZpbcBrrFc=",
+			"dev": true
 		},
 		"sprintf-js": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-			"integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
+			"integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
+			"dev": true
 		},
 		"sshpk": {
 			"version": "1.13.1",
 			"resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.13.1.tgz",
 			"integrity": "sha1-US322mKHFEMW3EwY/hzx2UBzm+M=",
+			"dev": true,
 			"requires": {
 				"asn1": "0.2.3",
 				"assert-plus": "1.0.0",
@@ -4832,7 +4550,8 @@
 				"assert-plus": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-					"integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
+					"integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+					"dev": true
 				}
 			}
 		},
@@ -4840,6 +4559,7 @@
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
 			"integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+			"dev": true,
 			"requires": {
 				"safe-buffer": "5.1.1"
 			}
@@ -4848,6 +4568,7 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/string-length/-/string-length-1.0.1.tgz",
 			"integrity": "sha1-VpcPscOFWOnnC3KL894mmsRa36w=",
+			"dev": true,
 			"requires": {
 				"strip-ansi": "3.0.1"
 			}
@@ -4856,6 +4577,7 @@
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
 			"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+			"dev": true,
 			"requires": {
 				"code-point-at": "1.1.0",
 				"is-fullwidth-code-point": "1.0.0",
@@ -4865,12 +4587,14 @@
 		"stringstream": {
 			"version": "0.0.5",
 			"resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
-			"integrity": "sha1-TkhM1N5aC7vuGORjB3EKioFiGHg="
+			"integrity": "sha1-TkhM1N5aC7vuGORjB3EKioFiGHg=",
+			"dev": true
 		},
 		"strip-ansi": {
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
 			"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+			"dev": true,
 			"requires": {
 				"ansi-regex": "2.1.1"
 			}
@@ -4879,6 +4603,7 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
 			"integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
+			"dev": true,
 			"requires": {
 				"is-utf8": "0.2.1"
 			}
@@ -4886,22 +4611,26 @@
 		"strip-json-comments": {
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.4.tgz",
-			"integrity": "sha1-HhX7ysl9Pumb8tc7TGVrCCu6+5E="
+			"integrity": "sha1-HhX7ysl9Pumb8tc7TGVrCCu6+5E=",
+			"dev": true
 		},
 		"supports-color": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-			"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
+			"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+			"dev": true
 		},
 		"symbol-tree": {
 			"version": "3.2.2",
 			"resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.2.tgz",
-			"integrity": "sha1-rifbOPZgp64uHDt9G8KQgZuFGeY="
+			"integrity": "sha1-rifbOPZgp64uHDt9G8KQgZuFGeY=",
+			"dev": true
 		},
 		"table": {
 			"version": "3.8.3",
 			"resolved": "https://registry.npmjs.org/table/-/table-3.8.3.tgz",
 			"integrity": "sha1-K7xULw/amGGnVdOUf+/Ys/UThV8=",
+			"dev": true,
 			"requires": {
 				"ajv": "4.11.8",
 				"ajv-keywords": "1.5.1",
@@ -4914,17 +4643,20 @@
 				"ansi-regex": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
+					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+					"dev": true
 				},
 				"is-fullwidth-code-point": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-					"integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
+					"integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+					"dev": true
 				},
 				"string-width": {
 					"version": "2.1.1",
 					"resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
 					"integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+					"dev": true,
 					"requires": {
 						"is-fullwidth-code-point": "2.0.0",
 						"strip-ansi": "4.0.0"
@@ -4934,6 +4666,7 @@
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
 					"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+					"dev": true,
 					"requires": {
 						"ansi-regex": "3.0.0"
 					}
@@ -4944,6 +4677,7 @@
 			"version": "4.1.1",
 			"resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-4.1.1.tgz",
 			"integrity": "sha512-35+Asrsk3XHJDBgf/VRFexPgh3UyETv8IAn/LRTiZjVy6rjPVqdEk8dJcJYBzl1w0XCJM48lvTy8SfEsCWS4nA==",
+			"dev": true,
 			"requires": {
 				"arrify": "1.0.1",
 				"micromatch": "2.3.11",
@@ -4955,32 +4689,38 @@
 		"text-table": {
 			"version": "0.2.0",
 			"resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
-			"integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ="
+			"integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
+			"dev": true
 		},
 		"throat": {
 			"version": "3.2.0",
 			"resolved": "https://registry.npmjs.org/throat/-/throat-3.2.0.tgz",
-			"integrity": "sha512-/EY8VpvlqJ+sFtLPeOgc8Pl7kQVOWv0woD87KTXVHPIAE842FGT+rokxIhe8xIUP1cfgrkt0as0vDLjDiMtr8w=="
+			"integrity": "sha512-/EY8VpvlqJ+sFtLPeOgc8Pl7kQVOWv0woD87KTXVHPIAE842FGT+rokxIhe8xIUP1cfgrkt0as0vDLjDiMtr8w==",
+			"dev": true
 		},
 		"through": {
 			"version": "2.3.8",
 			"resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
-			"integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
+			"integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
+			"dev": true
 		},
 		"tmpl": {
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.4.tgz",
-			"integrity": "sha1-I2QN17QtAEM5ERQIIOXPRA5SHdE="
+			"integrity": "sha1-I2QN17QtAEM5ERQIIOXPRA5SHdE=",
+			"dev": true
 		},
 		"to-fast-properties": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz",
-			"integrity": "sha1-uDVx+k2MJbguIxsG46MFXeTKGkc="
+			"integrity": "sha1-uDVx+k2MJbguIxsG46MFXeTKGkc=",
+			"dev": true
 		},
 		"tough-cookie": {
 			"version": "2.3.2",
 			"resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.2.tgz",
 			"integrity": "sha1-8IH3bkyFcg5sN6X6ztc3FQ2EByo=",
+			"dev": true,
 			"requires": {
 				"punycode": "1.4.1"
 			}
@@ -4988,22 +4728,26 @@
 		"tr46": {
 			"version": "0.0.3",
 			"resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-			"integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o="
+			"integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o=",
+			"dev": true
 		},
 		"trim-right": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz",
-			"integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM="
+			"integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM=",
+			"dev": true
 		},
 		"tryit": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/tryit/-/tryit-1.0.3.tgz",
-			"integrity": "sha1-OTvnMKlEb9Hq1tpZoBQwjzbCics="
+			"integrity": "sha1-OTvnMKlEb9Hq1tpZoBQwjzbCics=",
+			"dev": true
 		},
 		"tunnel-agent": {
 			"version": "0.6.0",
 			"resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
 			"integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
+			"dev": true,
 			"requires": {
 				"safe-buffer": "5.1.1"
 			}
@@ -5012,12 +4756,14 @@
 			"version": "0.14.5",
 			"resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
 			"integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
+			"dev": true,
 			"optional": true
 		},
 		"type-check": {
 			"version": "0.3.2",
 			"resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
 			"integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
+			"dev": true,
 			"requires": {
 				"prelude-ls": "1.1.2"
 			}
@@ -5025,7 +4771,8 @@
 		"typedarray": {
 			"version": "0.0.6",
 			"resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
-			"integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
+			"integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
+			"dev": true
 		},
 		"ua-parser-js": {
 			"version": "0.7.14",
@@ -5036,6 +4783,7 @@
 			"version": "2.8.29",
 			"resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.29.tgz",
 			"integrity": "sha1-KcVzMUgFe7Th913zW3qcty5qWd0=",
+			"dev": true,
 			"optional": true,
 			"requires": {
 				"source-map": "0.5.6",
@@ -5047,6 +4795,7 @@
 					"version": "3.10.0",
 					"resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
 					"integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"camelcase": "1.2.1",
@@ -5061,27 +4810,32 @@
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
 			"integrity": "sha1-bgkk1r2mta/jSeOabWMoUKD4grc=",
+			"dev": true,
 			"optional": true
 		},
 		"user-home": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/user-home/-/user-home-1.1.1.tgz",
-			"integrity": "sha1-K1viOjK2Onyd640PKNSFcko98ZA="
+			"integrity": "sha1-K1viOjK2Onyd640PKNSFcko98ZA=",
+			"dev": true
 		},
 		"util-deprecate": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-			"integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
+			"integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+			"dev": true
 		},
 		"uuid": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/uuid/-/uuid-3.1.0.tgz",
-			"integrity": "sha512-DIWtzUkw04M4k3bf1IcpS2tngXEL26YUD2M0tMDUpnUrz2hgzUBlD55a4FjdLGPvfHxS6uluGWvaVEqgBcVa+g=="
+			"integrity": "sha512-DIWtzUkw04M4k3bf1IcpS2tngXEL26YUD2M0tMDUpnUrz2hgzUBlD55a4FjdLGPvfHxS6uluGWvaVEqgBcVa+g==",
+			"dev": true
 		},
 		"v8flags": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/v8flags/-/v8flags-2.1.1.tgz",
 			"integrity": "sha1-qrGh+jDUX4jdMhFIh1rALAtV5bQ=",
+			"dev": true,
 			"requires": {
 				"user-home": "1.1.1"
 			}
@@ -5090,6 +4844,7 @@
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz",
 			"integrity": "sha1-KAS6vnEq0zeUWaz74kdGqywwP7w=",
+			"dev": true,
 			"requires": {
 				"spdx-correct": "1.0.2",
 				"spdx-expression-parse": "1.0.4"
@@ -5104,6 +4859,7 @@
 			"version": "1.10.0",
 			"resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
 			"integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
+			"dev": true,
 			"requires": {
 				"assert-plus": "1.0.0",
 				"core-util-is": "1.0.2",
@@ -5113,19 +4869,22 @@
 				"assert-plus": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-					"integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
+					"integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+					"dev": true
 				}
 			}
 		},
 		"vlq": {
 			"version": "0.2.2",
 			"resolved": "https://registry.npmjs.org/vlq/-/vlq-0.2.2.tgz",
-			"integrity": "sha1-4xbVJXtAuGu0PLjV/qXX9U1rDKE="
+			"integrity": "sha1-4xbVJXtAuGu0PLjV/qXX9U1rDKE=",
+			"dev": true
 		},
 		"walker": {
 			"version": "1.0.7",
 			"resolved": "https://registry.npmjs.org/walker/-/walker-1.0.7.tgz",
 			"integrity": "sha1-L3+bj9ENZ3JisYqITijRlhjgKPs=",
+			"dev": true,
 			"requires": {
 				"makeerror": "1.0.11"
 			}
@@ -5141,17 +4900,20 @@
 		"watch": {
 			"version": "0.10.0",
 			"resolved": "https://registry.npmjs.org/watch/-/watch-0.10.0.tgz",
-			"integrity": "sha1-d3mLLaD5kQ1ZXxrOWwwiWFIfIdw="
+			"integrity": "sha1-d3mLLaD5kQ1ZXxrOWwwiWFIfIdw=",
+			"dev": true
 		},
 		"webidl-conversions": {
 			"version": "4.0.1",
 			"resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-4.0.1.tgz",
-			"integrity": "sha1-gBWherg+fhsxFjhIas6B2mziBqA="
+			"integrity": "sha1-gBWherg+fhsxFjhIas6B2mziBqA=",
+			"dev": true
 		},
 		"whatwg-encoding": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-1.0.1.tgz",
 			"integrity": "sha1-PGxFGhmO567FWx7GHQkgxngBpfQ=",
+			"dev": true,
 			"requires": {
 				"iconv-lite": "0.4.13"
 			}
@@ -5165,6 +4927,7 @@
 			"version": "4.8.0",
 			"resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-4.8.0.tgz",
 			"integrity": "sha1-0pgaqRSMHgCkHFphMRZqtGg7vMA=",
+			"dev": true,
 			"requires": {
 				"tr46": "0.0.3",
 				"webidl-conversions": "3.0.1"
@@ -5173,7 +4936,8 @@
 				"webidl-conversions": {
 					"version": "3.0.1",
 					"resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-					"integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE="
+					"integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE=",
+					"dev": true
 				}
 			}
 		},
@@ -5181,6 +4945,7 @@
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/which/-/which-1.3.0.tgz",
 			"integrity": "sha512-xcJpopdamTuY5duC/KnTTNBraPK54YwpenP4lzxU8H91GudWpFv38u0CKjclE1Wi2EH2EDz5LRcHcKbCIzqGyg==",
+			"dev": true,
 			"requires": {
 				"isexe": "2.0.0"
 			}
@@ -5188,23 +4953,27 @@
 		"which-module": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/which-module/-/which-module-1.0.0.tgz",
-			"integrity": "sha1-u6Y8qGGUiZT/MHc2CJ47lgJsKk8="
+			"integrity": "sha1-u6Y8qGGUiZT/MHc2CJ47lgJsKk8=",
+			"dev": true
 		},
 		"window-size": {
 			"version": "0.1.0",
 			"resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz",
 			"integrity": "sha1-VDjNLqk7IC76Ohn+iIeu58lPnJ0=",
+			"dev": true,
 			"optional": true
 		},
 		"wordwrap": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
-			"integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus="
+			"integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
+			"dev": true
 		},
 		"worker-farm": {
 			"version": "1.4.1",
 			"resolved": "https://registry.npmjs.org/worker-farm/-/worker-farm-1.4.1.tgz",
 			"integrity": "sha512-tgFAtgOYLPutkAyzgpS6VJFL5HY+0ui1Tvua+fITgz8ByaJTMFGtazR6xxQfwfiAcbwE+2fLG/K49wc2TfwCNw==",
+			"dev": true,
 			"requires": {
 				"errno": "0.1.4",
 				"xtend": "4.0.1"
@@ -5214,6 +4983,7 @@
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
 			"integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
+			"dev": true,
 			"requires": {
 				"string-width": "1.0.2",
 				"strip-ansi": "3.0.1"
@@ -5222,12 +4992,14 @@
 		"wrappy": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-			"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+			"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+			"dev": true
 		},
 		"write": {
 			"version": "0.2.1",
 			"resolved": "https://registry.npmjs.org/write/-/write-0.2.1.tgz",
 			"integrity": "sha1-X8A4KOJkzqP+kUVUdvejxWbLB1c=",
+			"dev": true,
 			"requires": {
 				"mkdirp": "0.5.1"
 			}
@@ -5235,22 +5007,26 @@
 		"xml-name-validator": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-2.0.1.tgz",
-			"integrity": "sha1-TYuPHszTQZqjYgYb7O9RXh5VljU="
+			"integrity": "sha1-TYuPHszTQZqjYgYb7O9RXh5VljU=",
+			"dev": true
 		},
 		"xtend": {
 			"version": "4.0.1",
 			"resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
-			"integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68="
+			"integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
+			"dev": true
 		},
 		"y18n": {
 			"version": "3.2.1",
 			"resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
-			"integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE="
+			"integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE=",
+			"dev": true
 		},
 		"yargs": {
 			"version": "7.1.0",
 			"resolved": "https://registry.npmjs.org/yargs/-/yargs-7.1.0.tgz",
 			"integrity": "sha1-a6MY6xaWFyf10oT46gA+jWFU0Mg=",
+			"dev": true,
 			"requires": {
 				"camelcase": "3.0.0",
 				"cliui": "3.2.0",
@@ -5270,12 +5046,14 @@
 				"camelcase": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
-					"integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo="
+					"integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo=",
+					"dev": true
 				},
 				"cliui": {
 					"version": "3.2.0",
 					"resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
 					"integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
+					"dev": true,
 					"requires": {
 						"string-width": "1.0.2",
 						"strip-ansi": "3.0.1",
@@ -5288,6 +5066,7 @@
 			"version": "5.0.0",
 			"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-5.0.0.tgz",
 			"integrity": "sha1-J17PDX/+Bcd+ZOfIbkzZS/DhIoo=",
+			"dev": true,
 			"requires": {
 				"camelcase": "3.0.0"
 			},
@@ -5295,7 +5074,8 @@
 				"camelcase": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
-					"integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo="
+					"integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo=",
+					"dev": true
 				}
 			}
 		}

--- a/packages/react-router-dom/package.json
+++ b/packages/react-router-dom/package.json
@@ -65,9 +65,9 @@
     "react": "^15.4.2",
     "react-addons-test-utils": "^15.4.2",
     "react-dom": "^15.3.0",
-    "rollup": "^0.45.2",
-    "rollup-plugin-babel": "^2.7.1",
-    "rollup-plugin-commonjs": "^8.0.2",
+    "rollup": "^0.48.2",
+    "rollup-plugin-babel": "^3.0.2",
+    "rollup-plugin-commonjs": "^8.2.0",
     "rollup-plugin-node-resolve": "^3.0.0",
     "rollup-plugin-replace": "^1.1.1",
     "rollup-plugin-uglify": "^2.0.1"

--- a/packages/react-router-dom/rollup.config.js
+++ b/packages/react-router-dom/rollup.config.js
@@ -5,8 +5,8 @@ import commonjs from 'rollup-plugin-commonjs'
 import resolve from 'rollup-plugin-node-resolve'
 
 const config = {
-  entry: 'modules/index.js',
-  moduleName: 'ReactRouterDOM',
+  input: 'modules/index.js',
+  name: 'ReactRouterDOM',
   globals: {
     react: 'React'
   },

--- a/packages/react-router/package-lock.json
+++ b/packages/react-router/package-lock.json
@@ -1,21 +1,26 @@
 {
-	"requires": true,
+	"name": "react-router",
+	"version": "4.1.1",
 	"lockfileVersion": 1,
+	"requires": true,
 	"dependencies": {
 		"abab": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/abab/-/abab-1.0.3.tgz",
-			"integrity": "sha1-uB3l9ydOxOdW15fNg08wNkJyTl0="
+			"integrity": "sha1-uB3l9ydOxOdW15fNg08wNkJyTl0=",
+			"dev": true
 		},
 		"acorn": {
 			"version": "5.1.1",
 			"resolved": "https://registry.npmjs.org/acorn/-/acorn-5.1.1.tgz",
-			"integrity": "sha512-vOk6uEMctu0vQrvuSqFdJyqj1Q0S5VTDL79qtjo+DhRr+1mmaD+tluFSCZqhvi/JUhXSzoZN2BhtstaPEeE8cw=="
+			"integrity": "sha512-vOk6uEMctu0vQrvuSqFdJyqj1Q0S5VTDL79qtjo+DhRr+1mmaD+tluFSCZqhvi/JUhXSzoZN2BhtstaPEeE8cw==",
+			"dev": true
 		},
 		"acorn-globals": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-3.1.0.tgz",
 			"integrity": "sha1-/YJw9x+7SZawBPqIDuXUZXOnMb8=",
+			"dev": true,
 			"requires": {
 				"acorn": "4.0.13"
 			},
@@ -23,7 +28,8 @@
 				"acorn": {
 					"version": "4.0.13",
 					"resolved": "https://registry.npmjs.org/acorn/-/acorn-4.0.13.tgz",
-					"integrity": "sha1-EFSVrlNh1pe9GVyCUZLhrX8lN4c="
+					"integrity": "sha1-EFSVrlNh1pe9GVyCUZLhrX8lN4c=",
+					"dev": true
 				}
 			}
 		},
@@ -31,6 +37,7 @@
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-3.0.1.tgz",
 			"integrity": "sha1-r9+UiPsezvyDSPb7IvRk4ypYs2s=",
+			"dev": true,
 			"requires": {
 				"acorn": "3.3.0"
 			},
@@ -38,7 +45,8 @@
 				"acorn": {
 					"version": "3.3.0",
 					"resolved": "https://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz",
-					"integrity": "sha1-ReN/s56No/JbruP/U2niu18iAXo="
+					"integrity": "sha1-ReN/s56No/JbruP/U2niu18iAXo=",
+					"dev": true
 				}
 			}
 		},
@@ -46,6 +54,7 @@
 			"version": "4.11.8",
 			"resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz",
 			"integrity": "sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY=",
+			"dev": true,
 			"requires": {
 				"co": "4.6.0",
 				"json-stable-stringify": "1.0.1"
@@ -54,12 +63,14 @@
 		"ajv-keywords": {
 			"version": "1.5.1",
 			"resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-1.5.1.tgz",
-			"integrity": "sha1-MU3QpLM2j609/NxU7eYXG4htrzw="
+			"integrity": "sha1-MU3QpLM2j609/NxU7eYXG4htrzw=",
+			"dev": true
 		},
 		"align-text": {
 			"version": "0.1.4",
 			"resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
 			"integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
+			"dev": true,
 			"requires": {
 				"kind-of": "3.2.2",
 				"longest": "1.0.1",
@@ -69,27 +80,32 @@
 		"amdefine": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
-			"integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU="
+			"integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU=",
+			"dev": true
 		},
 		"ansi-escapes": {
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-1.4.0.tgz",
-			"integrity": "sha1-06ioOzGapneTZisT52HHkRQiMG4="
+			"integrity": "sha1-06ioOzGapneTZisT52HHkRQiMG4=",
+			"dev": true
 		},
 		"ansi-regex": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-			"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
+			"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+			"dev": true
 		},
 		"ansi-styles": {
 			"version": "2.2.1",
 			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-			"integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
+			"integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+			"dev": true
 		},
 		"anymatch": {
 			"version": "1.3.2",
 			"resolved": "https://registry.npmjs.org/anymatch/-/anymatch-1.3.2.tgz",
 			"integrity": "sha512-0XNayC8lTHQ2OI8aljNCN3sSx6hsr/1+rlcDAotXJR7C1oZZHCNsfpbKwMjRA3Uqb5tF1Rae2oloTr4xpq+WjA==",
+			"dev": true,
 			"requires": {
 				"micromatch": "2.3.11",
 				"normalize-path": "2.1.1"
@@ -99,6 +115,7 @@
 			"version": "0.4.0",
 			"resolved": "https://registry.npmjs.org/append-transform/-/append-transform-0.4.0.tgz",
 			"integrity": "sha1-126/jKlNJ24keja61EpLdKthGZE=",
+			"dev": true,
 			"requires": {
 				"default-require-extensions": "1.0.0"
 			}
@@ -107,6 +124,7 @@
 			"version": "1.0.9",
 			"resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.9.tgz",
 			"integrity": "sha1-c9g7wmP4bpf4zE9rrhsOkKfSLIY=",
+			"dev": true,
 			"requires": {
 				"sprintf-js": "1.0.3"
 			}
@@ -115,6 +133,7 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
 			"integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
+			"dev": true,
 			"requires": {
 				"arr-flatten": "1.1.0"
 			}
@@ -122,17 +141,20 @@
 		"arr-flatten": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
-			"integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg=="
+			"integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg==",
+			"dev": true
 		},
 		"array-equal": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/array-equal/-/array-equal-1.0.0.tgz",
-			"integrity": "sha1-jCpe8kcv2ep0KwTHenUJO6J1fJM="
+			"integrity": "sha1-jCpe8kcv2ep0KwTHenUJO6J1fJM=",
+			"dev": true
 		},
 		"array-union": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
 			"integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
+			"dev": true,
 			"requires": {
 				"array-uniq": "1.0.3"
 			}
@@ -140,17 +162,20 @@
 		"array-uniq": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.3.tgz",
-			"integrity": "sha1-r2rId6Jcx/dOBYiUdThY39sk/bY="
+			"integrity": "sha1-r2rId6Jcx/dOBYiUdThY39sk/bY=",
+			"dev": true
 		},
 		"array-unique": {
 			"version": "0.2.1",
 			"resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
-			"integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM="
+			"integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM=",
+			"dev": true
 		},
 		"array.prototype.find": {
 			"version": "2.0.4",
 			"resolved": "https://registry.npmjs.org/array.prototype.find/-/array.prototype.find-2.0.4.tgz",
 			"integrity": "sha1-VWpcU2LAhkgyPdrrnenRS8GGTJA=",
+			"dev": true,
 			"requires": {
 				"define-properties": "1.1.2",
 				"es-abstract": "1.7.0"
@@ -159,7 +184,8 @@
 		"arrify": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
-			"integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0="
+			"integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
+			"dev": true
 		},
 		"asap": {
 			"version": "2.0.6",
@@ -169,17 +195,20 @@
 		"asn1": {
 			"version": "0.2.3",
 			"resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
-			"integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y="
+			"integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y=",
+			"dev": true
 		},
 		"assert-plus": {
 			"version": "0.2.0",
 			"resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
-			"integrity": "sha1-104bh+ev/A24qttwIfP+SBAasjQ="
+			"integrity": "sha1-104bh+ev/A24qttwIfP+SBAasjQ=",
+			"dev": true
 		},
 		"async": {
 			"version": "2.5.0",
 			"resolved": "https://registry.npmjs.org/async/-/async-2.5.0.tgz",
 			"integrity": "sha512-e+lJAJeNWuPCNyxZKOBdaJGyLGHugXVQtrAwtuAe2vhxTYxFTKE73p8JuTmdH0qdQZtDvI4dhJwjZc5zsfIsYw==",
+			"dev": true,
 			"requires": {
 				"lodash": "4.17.4"
 			}
@@ -188,27 +217,32 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/async-each/-/async-each-1.0.1.tgz",
 			"integrity": "sha1-GdOGodntxufByF04iu28xW0zYC0=",
+			"dev": true,
 			"optional": true
 		},
 		"asynckit": {
 			"version": "0.4.0",
 			"resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-			"integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
+			"integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
+			"dev": true
 		},
 		"aws-sign2": {
 			"version": "0.6.0",
 			"resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
-			"integrity": "sha1-FDQt0428yU0OW4fXY81jYSwOeU8="
+			"integrity": "sha1-FDQt0428yU0OW4fXY81jYSwOeU8=",
+			"dev": true
 		},
 		"aws4": {
 			"version": "1.6.0",
 			"resolved": "https://registry.npmjs.org/aws4/-/aws4-1.6.0.tgz",
-			"integrity": "sha1-g+9cqGCysy5KDe7e6MdxudtXRx4="
+			"integrity": "sha1-g+9cqGCysy5KDe7e6MdxudtXRx4=",
+			"dev": true
 		},
 		"babel-cli": {
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-cli/-/babel-cli-6.24.1.tgz",
 			"integrity": "sha1-IHzXBbumFImy6kG1MSNBz2rKIoM=",
+			"dev": true,
 			"requires": {
 				"babel-core": "6.25.0",
 				"babel-polyfill": "6.23.0",
@@ -231,6 +265,7 @@
 			"version": "6.22.0",
 			"resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.22.0.tgz",
 			"integrity": "sha1-AnYgvuVnqIwyVhV05/0IAdMxGOQ=",
+			"dev": true,
 			"requires": {
 				"chalk": "1.1.3",
 				"esutils": "2.0.2",
@@ -241,6 +276,7 @@
 			"version": "6.25.0",
 			"resolved": "https://registry.npmjs.org/babel-core/-/babel-core-6.25.0.tgz",
 			"integrity": "sha1-fdQrBGPHQunVKW3rPsZ6kyLa1yk=",
+			"dev": true,
 			"requires": {
 				"babel-code-frame": "6.22.0",
 				"babel-generator": "6.25.0",
@@ -267,6 +303,7 @@
 			"version": "6.1.2",
 			"resolved": "https://registry.npmjs.org/babel-eslint/-/babel-eslint-6.1.2.tgz",
 			"integrity": "sha1-UpNBn+NnLWZZjTJ9qWlFZ7pqXy8=",
+			"dev": true,
 			"requires": {
 				"babel-traverse": "6.25.0",
 				"babel-types": "6.25.0",
@@ -279,6 +316,7 @@
 			"version": "6.25.0",
 			"resolved": "https://registry.npmjs.org/babel-generator/-/babel-generator-6.25.0.tgz",
 			"integrity": "sha1-M6GvcNXyiQrrRlpKd5PB32qeqfw=",
+			"dev": true,
 			"requires": {
 				"babel-messages": "6.23.0",
 				"babel-runtime": "6.25.0",
@@ -294,6 +332,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-helper-bindify-decorators/-/babel-helper-bindify-decorators-6.24.1.tgz",
 			"integrity": "sha1-FMGeXxQte0fxmlJDHlKxzLxAozA=",
+			"dev": true,
 			"requires": {
 				"babel-runtime": "6.25.0",
 				"babel-traverse": "6.25.0",
@@ -304,6 +343,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-helper-builder-binary-assignment-operator-visitor/-/babel-helper-builder-binary-assignment-operator-visitor-6.24.1.tgz",
 			"integrity": "sha1-zORReto1b0IgvK6KAsKzRvmlZmQ=",
+			"dev": true,
 			"requires": {
 				"babel-helper-explode-assignable-expression": "6.24.1",
 				"babel-runtime": "6.25.0",
@@ -314,6 +354,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-helper-builder-react-jsx/-/babel-helper-builder-react-jsx-6.24.1.tgz",
 			"integrity": "sha1-CteRfjPI11HmRtrKTnfMGTd9LLw=",
+			"dev": true,
 			"requires": {
 				"babel-runtime": "6.25.0",
 				"babel-types": "6.25.0",
@@ -324,6 +365,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-helper-call-delegate/-/babel-helper-call-delegate-6.24.1.tgz",
 			"integrity": "sha1-7Oaqzdx25Bw0YfiL/Fdb0Nqi340=",
+			"dev": true,
 			"requires": {
 				"babel-helper-hoist-variables": "6.24.1",
 				"babel-runtime": "6.25.0",
@@ -335,6 +377,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-helper-define-map/-/babel-helper-define-map-6.24.1.tgz",
 			"integrity": "sha1-epdH8ljYlH0y1RX2qhx70CIEoIA=",
+			"dev": true,
 			"requires": {
 				"babel-helper-function-name": "6.24.1",
 				"babel-runtime": "6.25.0",
@@ -346,6 +389,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-helper-explode-assignable-expression/-/babel-helper-explode-assignable-expression-6.24.1.tgz",
 			"integrity": "sha1-8luCz33BBDPFX3BZLVdGQArCLKo=",
+			"dev": true,
 			"requires": {
 				"babel-runtime": "6.25.0",
 				"babel-traverse": "6.25.0",
@@ -356,6 +400,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-helper-explode-class/-/babel-helper-explode-class-6.24.1.tgz",
 			"integrity": "sha1-fcKjkQ3uAHBW4eMdZAztPVTqqes=",
+			"dev": true,
 			"requires": {
 				"babel-helper-bindify-decorators": "6.24.1",
 				"babel-runtime": "6.25.0",
@@ -367,6 +412,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-helper-function-name/-/babel-helper-function-name-6.24.1.tgz",
 			"integrity": "sha1-00dbjAPtmCQqJbSDUasYOZ01gKk=",
+			"dev": true,
 			"requires": {
 				"babel-helper-get-function-arity": "6.24.1",
 				"babel-runtime": "6.25.0",
@@ -379,6 +425,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-helper-get-function-arity/-/babel-helper-get-function-arity-6.24.1.tgz",
 			"integrity": "sha1-j3eCqpNAfEHTqlCQj4mwMbG2hT0=",
+			"dev": true,
 			"requires": {
 				"babel-runtime": "6.25.0",
 				"babel-types": "6.25.0"
@@ -388,6 +435,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-helper-hoist-variables/-/babel-helper-hoist-variables-6.24.1.tgz",
 			"integrity": "sha1-HssnaJydJVE+rbyZFKc/VAi+enY=",
+			"dev": true,
 			"requires": {
 				"babel-runtime": "6.25.0",
 				"babel-types": "6.25.0"
@@ -397,6 +445,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-helper-optimise-call-expression/-/babel-helper-optimise-call-expression-6.24.1.tgz",
 			"integrity": "sha1-96E0J7qfc/j0+pk8VKl4gtEkQlc=",
+			"dev": true,
 			"requires": {
 				"babel-runtime": "6.25.0",
 				"babel-types": "6.25.0"
@@ -406,6 +455,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-helper-regex/-/babel-helper-regex-6.24.1.tgz",
 			"integrity": "sha1-024i+rEAjXnYhkjjIRaGgShFbOg=",
+			"dev": true,
 			"requires": {
 				"babel-runtime": "6.25.0",
 				"babel-types": "6.25.0",
@@ -416,6 +466,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-helper-remap-async-to-generator/-/babel-helper-remap-async-to-generator-6.24.1.tgz",
 			"integrity": "sha1-XsWBgnrXI/7N04HxySg5BnbkVRs=",
+			"dev": true,
 			"requires": {
 				"babel-helper-function-name": "6.24.1",
 				"babel-runtime": "6.25.0",
@@ -428,6 +479,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-helper-replace-supers/-/babel-helper-replace-supers-6.24.1.tgz",
 			"integrity": "sha1-v22/5Dk40XNpohPKiov3S2qQqxo=",
+			"dev": true,
 			"requires": {
 				"babel-helper-optimise-call-expression": "6.24.1",
 				"babel-messages": "6.23.0",
@@ -441,6 +493,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-helpers/-/babel-helpers-6.24.1.tgz",
 			"integrity": "sha1-NHHenK7DiOXIUOWX5Yom3fN2ArI=",
+			"dev": true,
 			"requires": {
 				"babel-runtime": "6.25.0",
 				"babel-template": "6.25.0"
@@ -450,6 +503,7 @@
 			"version": "20.0.3",
 			"resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-20.0.3.tgz",
 			"integrity": "sha1-5KA7E9wQOJ4UD8ZF0J/8TO0wFnE=",
+			"dev": true,
 			"requires": {
 				"babel-core": "6.25.0",
 				"babel-plugin-istanbul": "4.1.4",
@@ -460,6 +514,7 @@
 			"version": "6.23.0",
 			"resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz",
 			"integrity": "sha1-8830cDhYA1sqKVHG7F7fbGLyYw4=",
+			"dev": true,
 			"requires": {
 				"babel-runtime": "6.25.0"
 			}
@@ -468,6 +523,7 @@
 			"version": "6.22.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-check-es2015-constants/-/babel-plugin-check-es2015-constants-6.22.0.tgz",
 			"integrity": "sha1-NRV7EBQm/S/9PaP3XH0ekYNbv4o=",
+			"dev": true,
 			"requires": {
 				"babel-runtime": "6.25.0"
 			}
@@ -475,12 +531,14 @@
 		"babel-plugin-dev-expression": {
 			"version": "0.2.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-dev-expression/-/babel-plugin-dev-expression-0.2.1.tgz",
-			"integrity": "sha1-1Ke+7++7UOPyc0mQqCokhs+eue4="
+			"integrity": "sha1-1Ke+7++7UOPyc0mQqCokhs+eue4=",
+			"dev": true
 		},
 		"babel-plugin-external-helpers": {
 			"version": "6.22.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-external-helpers/-/babel-plugin-external-helpers-6.22.0.tgz",
 			"integrity": "sha1-IoX0iwK9Xe3oUXXK+MYuhq3M76E=",
+			"dev": true,
 			"requires": {
 				"babel-runtime": "6.25.0"
 			}
@@ -489,6 +547,7 @@
 			"version": "4.1.4",
 			"resolved": "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-4.1.4.tgz",
 			"integrity": "sha1-GN3oS/POMp/d8/QQP66SFFbY5Yc=",
+			"dev": true,
 			"requires": {
 				"find-up": "2.1.0",
 				"istanbul-lib-instrument": "1.7.4",
@@ -499,6 +558,7 @@
 					"version": "2.1.0",
 					"resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
 					"integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+					"dev": true,
 					"requires": {
 						"locate-path": "2.0.0"
 					}
@@ -508,72 +568,86 @@
 		"babel-plugin-jest-hoist": {
 			"version": "20.0.3",
 			"resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-20.0.3.tgz",
-			"integrity": "sha1-r+3IU70/jcNUjqZx++adA8wsF2c="
+			"integrity": "sha1-r+3IU70/jcNUjqZx++adA8wsF2c=",
+			"dev": true
 		},
 		"babel-plugin-syntax-async-functions": {
 			"version": "6.13.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-syntax-async-functions/-/babel-plugin-syntax-async-functions-6.13.0.tgz",
-			"integrity": "sha1-ytnK0RkbWtY0vzCuCHI5HgZHvpU="
+			"integrity": "sha1-ytnK0RkbWtY0vzCuCHI5HgZHvpU=",
+			"dev": true
 		},
 		"babel-plugin-syntax-async-generators": {
 			"version": "6.13.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-syntax-async-generators/-/babel-plugin-syntax-async-generators-6.13.0.tgz",
-			"integrity": "sha1-a8lj67FuzLrmuStZbrfzXDQqi5o="
+			"integrity": "sha1-a8lj67FuzLrmuStZbrfzXDQqi5o=",
+			"dev": true
 		},
 		"babel-plugin-syntax-class-constructor-call": {
 			"version": "6.18.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-syntax-class-constructor-call/-/babel-plugin-syntax-class-constructor-call-6.18.0.tgz",
-			"integrity": "sha1-nLnTn+Q8hgC+yBRkVt3L1OGnZBY="
+			"integrity": "sha1-nLnTn+Q8hgC+yBRkVt3L1OGnZBY=",
+			"dev": true
 		},
 		"babel-plugin-syntax-class-properties": {
 			"version": "6.13.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-syntax-class-properties/-/babel-plugin-syntax-class-properties-6.13.0.tgz",
-			"integrity": "sha1-1+sjt5oxf4VDlixQW4J8fWysJ94="
+			"integrity": "sha1-1+sjt5oxf4VDlixQW4J8fWysJ94=",
+			"dev": true
 		},
 		"babel-plugin-syntax-decorators": {
 			"version": "6.13.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-syntax-decorators/-/babel-plugin-syntax-decorators-6.13.0.tgz",
-			"integrity": "sha1-MSVjtNvePMgGzuPkFszurd0RrAs="
+			"integrity": "sha1-MSVjtNvePMgGzuPkFszurd0RrAs=",
+			"dev": true
 		},
 		"babel-plugin-syntax-dynamic-import": {
 			"version": "6.18.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-syntax-dynamic-import/-/babel-plugin-syntax-dynamic-import-6.18.0.tgz",
-			"integrity": "sha1-jWomIpyDdFqZgqRBBRVyyqF5sdo="
+			"integrity": "sha1-jWomIpyDdFqZgqRBBRVyyqF5sdo=",
+			"dev": true
 		},
 		"babel-plugin-syntax-exponentiation-operator": {
 			"version": "6.13.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-syntax-exponentiation-operator/-/babel-plugin-syntax-exponentiation-operator-6.13.0.tgz",
-			"integrity": "sha1-nufoM3KQ2pUoggGmpX9BcDF4MN4="
+			"integrity": "sha1-nufoM3KQ2pUoggGmpX9BcDF4MN4=",
+			"dev": true
 		},
 		"babel-plugin-syntax-export-extensions": {
 			"version": "6.13.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-syntax-export-extensions/-/babel-plugin-syntax-export-extensions-6.13.0.tgz",
-			"integrity": "sha1-cKFITw+QiaToStRLrDU8lbmxJyE="
+			"integrity": "sha1-cKFITw+QiaToStRLrDU8lbmxJyE=",
+			"dev": true
 		},
 		"babel-plugin-syntax-flow": {
 			"version": "6.18.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-syntax-flow/-/babel-plugin-syntax-flow-6.18.0.tgz",
-			"integrity": "sha1-TDqyCiryaqIM0lmVw5jE63AxDI0="
+			"integrity": "sha1-TDqyCiryaqIM0lmVw5jE63AxDI0=",
+			"dev": true
 		},
 		"babel-plugin-syntax-jsx": {
 			"version": "6.18.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-syntax-jsx/-/babel-plugin-syntax-jsx-6.18.0.tgz",
-			"integrity": "sha1-CvMqmm4Tyno/1QaeYtew9Y0NiUY="
+			"integrity": "sha1-CvMqmm4Tyno/1QaeYtew9Y0NiUY=",
+			"dev": true
 		},
 		"babel-plugin-syntax-object-rest-spread": {
 			"version": "6.13.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-syntax-object-rest-spread/-/babel-plugin-syntax-object-rest-spread-6.13.0.tgz",
-			"integrity": "sha1-/WU28rzhODb/o6VFjEkDpZe7O/U="
+			"integrity": "sha1-/WU28rzhODb/o6VFjEkDpZe7O/U=",
+			"dev": true
 		},
 		"babel-plugin-syntax-trailing-function-commas": {
 			"version": "6.22.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-syntax-trailing-function-commas/-/babel-plugin-syntax-trailing-function-commas-6.22.0.tgz",
-			"integrity": "sha1-ugNgk3+NBuQBgKQ/4NVhb/9TLPM="
+			"integrity": "sha1-ugNgk3+NBuQBgKQ/4NVhb/9TLPM=",
+			"dev": true
 		},
 		"babel-plugin-transform-async-generator-functions": {
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-async-generator-functions/-/babel-plugin-transform-async-generator-functions-6.24.1.tgz",
 			"integrity": "sha1-8FiQAUX9PpkHpt3yjaWfIVJYpds=",
+			"dev": true,
 			"requires": {
 				"babel-helper-remap-async-to-generator": "6.24.1",
 				"babel-plugin-syntax-async-generators": "6.13.0",
@@ -584,6 +658,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-async-to-generator/-/babel-plugin-transform-async-to-generator-6.24.1.tgz",
 			"integrity": "sha1-ZTbjeK/2yx1VF6wOQOs+n8jQh2E=",
+			"dev": true,
 			"requires": {
 				"babel-helper-remap-async-to-generator": "6.24.1",
 				"babel-plugin-syntax-async-functions": "6.13.0",
@@ -594,6 +669,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-class-constructor-call/-/babel-plugin-transform-class-constructor-call-6.24.1.tgz",
 			"integrity": "sha1-gNwoVQWsBn3LjWxl4vbxGrd2Xvk=",
+			"dev": true,
 			"requires": {
 				"babel-plugin-syntax-class-constructor-call": "6.18.0",
 				"babel-runtime": "6.25.0",
@@ -604,6 +680,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-class-properties/-/babel-plugin-transform-class-properties-6.24.1.tgz",
 			"integrity": "sha1-anl2PqYdM9NvN7YRqp3vgagbRqw=",
+			"dev": true,
 			"requires": {
 				"babel-helper-function-name": "6.24.1",
 				"babel-plugin-syntax-class-properties": "6.13.0",
@@ -615,6 +692,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-decorators/-/babel-plugin-transform-decorators-6.24.1.tgz",
 			"integrity": "sha1-eIAT2PjGtSIr33s0Q5Df13Vp4k0=",
+			"dev": true,
 			"requires": {
 				"babel-helper-explode-class": "6.24.1",
 				"babel-plugin-syntax-decorators": "6.13.0",
@@ -627,6 +705,7 @@
 			"version": "6.22.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-arrow-functions/-/babel-plugin-transform-es2015-arrow-functions-6.22.0.tgz",
 			"integrity": "sha1-RSaSy3EdX3ncf4XkQM5BufJE0iE=",
+			"dev": true,
 			"requires": {
 				"babel-runtime": "6.25.0"
 			}
@@ -635,6 +714,7 @@
 			"version": "6.22.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoped-functions/-/babel-plugin-transform-es2015-block-scoped-functions-6.22.0.tgz",
 			"integrity": "sha1-u8UbSflk1wy42OC5ToICRs46YUE=",
+			"dev": true,
 			"requires": {
 				"babel-runtime": "6.25.0"
 			}
@@ -643,6 +723,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoping/-/babel-plugin-transform-es2015-block-scoping-6.24.1.tgz",
 			"integrity": "sha1-dsKV3DpHQbFmWt/TFnIV3P8ypXY=",
+			"dev": true,
 			"requires": {
 				"babel-runtime": "6.25.0",
 				"babel-template": "6.25.0",
@@ -655,6 +736,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-classes/-/babel-plugin-transform-es2015-classes-6.24.1.tgz",
 			"integrity": "sha1-WkxYpQyclGHlZLSyo7+ryXolhNs=",
+			"dev": true,
 			"requires": {
 				"babel-helper-define-map": "6.24.1",
 				"babel-helper-function-name": "6.24.1",
@@ -671,6 +753,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-computed-properties/-/babel-plugin-transform-es2015-computed-properties-6.24.1.tgz",
 			"integrity": "sha1-b+Ko0WiV1WNPTNmZttNICjCBWbM=",
+			"dev": true,
 			"requires": {
 				"babel-runtime": "6.25.0",
 				"babel-template": "6.25.0"
@@ -680,6 +763,7 @@
 			"version": "6.23.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-destructuring/-/babel-plugin-transform-es2015-destructuring-6.23.0.tgz",
 			"integrity": "sha1-mXux8auWf2gtKwh2/jWNYOdlxW0=",
+			"dev": true,
 			"requires": {
 				"babel-runtime": "6.25.0"
 			}
@@ -688,6 +772,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-duplicate-keys/-/babel-plugin-transform-es2015-duplicate-keys-6.24.1.tgz",
 			"integrity": "sha1-c+s9MQypaePvnskcU3QabxV2Qj4=",
+			"dev": true,
 			"requires": {
 				"babel-runtime": "6.25.0",
 				"babel-types": "6.25.0"
@@ -697,6 +782,7 @@
 			"version": "6.23.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-for-of/-/babel-plugin-transform-es2015-for-of-6.23.0.tgz",
 			"integrity": "sha1-9HyVsrYT3x0+zC/bdXNiPHUkhpE=",
+			"dev": true,
 			"requires": {
 				"babel-runtime": "6.25.0"
 			}
@@ -705,6 +791,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-function-name/-/babel-plugin-transform-es2015-function-name-6.24.1.tgz",
 			"integrity": "sha1-g0yJhTvDaxrw86TF26qU/Y6sqos=",
+			"dev": true,
 			"requires": {
 				"babel-helper-function-name": "6.24.1",
 				"babel-runtime": "6.25.0",
@@ -715,6 +802,7 @@
 			"version": "6.22.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-literals/-/babel-plugin-transform-es2015-literals-6.22.0.tgz",
 			"integrity": "sha1-T1SgLWzWbPkVKAAZox0xklN3yi4=",
+			"dev": true,
 			"requires": {
 				"babel-runtime": "6.25.0"
 			}
@@ -723,6 +811,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-amd/-/babel-plugin-transform-es2015-modules-amd-6.24.1.tgz",
 			"integrity": "sha1-Oz5UAXI5hC1tGcMBHEvS8AoA0VQ=",
+			"dev": true,
 			"requires": {
 				"babel-plugin-transform-es2015-modules-commonjs": "6.24.1",
 				"babel-runtime": "6.25.0",
@@ -733,6 +822,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-commonjs/-/babel-plugin-transform-es2015-modules-commonjs-6.24.1.tgz",
 			"integrity": "sha1-0+MQtA72ZKNmIiAAl8bUQCmPK/4=",
+			"dev": true,
 			"requires": {
 				"babel-plugin-transform-strict-mode": "6.24.1",
 				"babel-runtime": "6.25.0",
@@ -744,6 +834,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-systemjs/-/babel-plugin-transform-es2015-modules-systemjs-6.24.1.tgz",
 			"integrity": "sha1-/4mhQrkRmpBhlfXxBuzzBdlAfSM=",
+			"dev": true,
 			"requires": {
 				"babel-helper-hoist-variables": "6.24.1",
 				"babel-runtime": "6.25.0",
@@ -754,6 +845,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-umd/-/babel-plugin-transform-es2015-modules-umd-6.24.1.tgz",
 			"integrity": "sha1-rJl+YoXNGO1hdq22B9YCNErThGg=",
+			"dev": true,
 			"requires": {
 				"babel-plugin-transform-es2015-modules-amd": "6.24.1",
 				"babel-runtime": "6.25.0",
@@ -764,6 +856,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-object-super/-/babel-plugin-transform-es2015-object-super-6.24.1.tgz",
 			"integrity": "sha1-JM72muIcuDp/hgPa0CH1cusnj40=",
+			"dev": true,
 			"requires": {
 				"babel-helper-replace-supers": "6.24.1",
 				"babel-runtime": "6.25.0"
@@ -773,6 +866,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-parameters/-/babel-plugin-transform-es2015-parameters-6.24.1.tgz",
 			"integrity": "sha1-V6w1GrScrxSpfNE7CfZv3wpiXys=",
+			"dev": true,
 			"requires": {
 				"babel-helper-call-delegate": "6.24.1",
 				"babel-helper-get-function-arity": "6.24.1",
@@ -786,6 +880,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-shorthand-properties/-/babel-plugin-transform-es2015-shorthand-properties-6.24.1.tgz",
 			"integrity": "sha1-JPh11nIch2YbvZmkYi5R8U3jiqA=",
+			"dev": true,
 			"requires": {
 				"babel-runtime": "6.25.0",
 				"babel-types": "6.25.0"
@@ -795,6 +890,7 @@
 			"version": "6.22.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-spread/-/babel-plugin-transform-es2015-spread-6.22.0.tgz",
 			"integrity": "sha1-1taKmfia7cRTbIGlQujdnxdG+NE=",
+			"dev": true,
 			"requires": {
 				"babel-runtime": "6.25.0"
 			}
@@ -803,6 +899,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-sticky-regex/-/babel-plugin-transform-es2015-sticky-regex-6.24.1.tgz",
 			"integrity": "sha1-AMHNsaynERLN8M9hJsLta0V8zbw=",
+			"dev": true,
 			"requires": {
 				"babel-helper-regex": "6.24.1",
 				"babel-runtime": "6.25.0",
@@ -813,6 +910,7 @@
 			"version": "6.22.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-template-literals/-/babel-plugin-transform-es2015-template-literals-6.22.0.tgz",
 			"integrity": "sha1-qEs0UPfp+PH2g51taH2oS7EjbY0=",
+			"dev": true,
 			"requires": {
 				"babel-runtime": "6.25.0"
 			}
@@ -821,6 +919,7 @@
 			"version": "6.23.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-typeof-symbol/-/babel-plugin-transform-es2015-typeof-symbol-6.23.0.tgz",
 			"integrity": "sha1-3sCfHN3/lLUqxz1QXITfWdzOs3I=",
+			"dev": true,
 			"requires": {
 				"babel-runtime": "6.25.0"
 			}
@@ -829,6 +928,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-unicode-regex/-/babel-plugin-transform-es2015-unicode-regex-6.24.1.tgz",
 			"integrity": "sha1-04sS9C6nMj9yk4fxinxa4frrNek=",
+			"dev": true,
 			"requires": {
 				"babel-helper-regex": "6.24.1",
 				"babel-runtime": "6.25.0",
@@ -839,6 +939,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-exponentiation-operator/-/babel-plugin-transform-exponentiation-operator-6.24.1.tgz",
 			"integrity": "sha1-KrDJx/MJj6SJB3cruBP+QejeOg4=",
+			"dev": true,
 			"requires": {
 				"babel-helper-builder-binary-assignment-operator-visitor": "6.24.1",
 				"babel-plugin-syntax-exponentiation-operator": "6.13.0",
@@ -849,6 +950,7 @@
 			"version": "6.22.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-export-extensions/-/babel-plugin-transform-export-extensions-6.22.0.tgz",
 			"integrity": "sha1-U3OLR+deghhYnuqUbLvTkQm75lM=",
+			"dev": true,
 			"requires": {
 				"babel-plugin-syntax-export-extensions": "6.13.0",
 				"babel-runtime": "6.25.0"
@@ -858,6 +960,7 @@
 			"version": "6.22.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-flow-strip-types/-/babel-plugin-transform-flow-strip-types-6.22.0.tgz",
 			"integrity": "sha1-hMtnKTXUNxT9wyvOhFaNh0Qc988=",
+			"dev": true,
 			"requires": {
 				"babel-plugin-syntax-flow": "6.18.0",
 				"babel-runtime": "6.25.0"
@@ -867,6 +970,7 @@
 			"version": "6.23.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-object-rest-spread/-/babel-plugin-transform-object-rest-spread-6.23.0.tgz",
 			"integrity": "sha1-h11ryb52HFiirj/u5dxIldjH+SE=",
+			"dev": true,
 			"requires": {
 				"babel-plugin-syntax-object-rest-spread": "6.13.0",
 				"babel-runtime": "6.25.0"
@@ -876,6 +980,7 @@
 			"version": "6.25.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-react-display-name/-/babel-plugin-transform-react-display-name-6.25.0.tgz",
 			"integrity": "sha1-Z+K/Hx6ck6sI25Z5LgU5K/LMKNE=",
+			"dev": true,
 			"requires": {
 				"babel-runtime": "6.25.0"
 			}
@@ -884,6 +989,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-react-jsx/-/babel-plugin-transform-react-jsx-6.24.1.tgz",
 			"integrity": "sha1-hAoCjn30YN/DotKfDA2R9jduZqM=",
+			"dev": true,
 			"requires": {
 				"babel-helper-builder-react-jsx": "6.24.1",
 				"babel-plugin-syntax-jsx": "6.18.0",
@@ -894,6 +1000,7 @@
 			"version": "6.22.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-react-jsx-self/-/babel-plugin-transform-react-jsx-self-6.22.0.tgz",
 			"integrity": "sha1-322AqdomEqEh5t3XVYvL7PBuY24=",
+			"dev": true,
 			"requires": {
 				"babel-plugin-syntax-jsx": "6.18.0",
 				"babel-runtime": "6.25.0"
@@ -903,6 +1010,7 @@
 			"version": "6.22.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-react-jsx-source/-/babel-plugin-transform-react-jsx-source-6.22.0.tgz",
 			"integrity": "sha1-ZqwSFT9c0tF7PBkmj0vwGX9E7NY=",
+			"dev": true,
 			"requires": {
 				"babel-plugin-syntax-jsx": "6.18.0",
 				"babel-runtime": "6.25.0"
@@ -911,12 +1019,14 @@
 		"babel-plugin-transform-react-remove-prop-types": {
 			"version": "0.2.12",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-react-remove-prop-types/-/babel-plugin-transform-react-remove-prop-types-0.2.12.tgz",
-			"integrity": "sha1-NAZpbfC4tFYIn51ybSfn4SPS+Sk="
+			"integrity": "sha1-NAZpbfC4tFYIn51ybSfn4SPS+Sk=",
+			"dev": true
 		},
 		"babel-plugin-transform-regenerator": {
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-regenerator/-/babel-plugin-transform-regenerator-6.24.1.tgz",
 			"integrity": "sha1-uNowWtQ8PJm0hI5P5AN7dw0jxBg=",
+			"dev": true,
 			"requires": {
 				"regenerator-transform": "0.9.11"
 			}
@@ -925,6 +1035,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-strict-mode/-/babel-plugin-transform-strict-mode-6.24.1.tgz",
 			"integrity": "sha1-1fr3qleKZbvlkc9e2uBKDGcCB1g=",
+			"dev": true,
 			"requires": {
 				"babel-runtime": "6.25.0",
 				"babel-types": "6.25.0"
@@ -934,6 +1045,7 @@
 			"version": "6.23.0",
 			"resolved": "https://registry.npmjs.org/babel-polyfill/-/babel-polyfill-6.23.0.tgz",
 			"integrity": "sha1-g2TKYt+Or7gwSZ9pkXdGbDsDSZ0=",
+			"dev": true,
 			"requires": {
 				"babel-runtime": "6.25.0",
 				"core-js": "2.4.1",
@@ -944,6 +1056,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-preset-es2015/-/babel-preset-es2015-6.24.1.tgz",
 			"integrity": "sha1-1EBQ1rwsn+6nAqrzjXJ6AhBTiTk=",
+			"dev": true,
 			"requires": {
 				"babel-plugin-check-es2015-constants": "6.22.0",
 				"babel-plugin-transform-es2015-arrow-functions": "6.22.0",
@@ -975,6 +1088,7 @@
 			"version": "6.23.0",
 			"resolved": "https://registry.npmjs.org/babel-preset-flow/-/babel-preset-flow-6.23.0.tgz",
 			"integrity": "sha1-5xIYiHCFrpoktb5Baa/7WZgWxJ0=",
+			"dev": true,
 			"requires": {
 				"babel-plugin-transform-flow-strip-types": "6.22.0"
 			}
@@ -983,6 +1097,7 @@
 			"version": "20.0.3",
 			"resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-20.0.3.tgz",
 			"integrity": "sha1-y6yq3stdaJyh4d4TYOv8ZoYsF4o=",
+			"dev": true,
 			"requires": {
 				"babel-plugin-jest-hoist": "20.0.3"
 			}
@@ -991,6 +1106,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-preset-react/-/babel-preset-react-6.24.1.tgz",
 			"integrity": "sha1-umnfrqRfw+xjm2pOzqbhdwLJE4A=",
+			"dev": true,
 			"requires": {
 				"babel-plugin-syntax-jsx": "6.18.0",
 				"babel-plugin-transform-react-display-name": "6.25.0",
@@ -1004,6 +1120,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-preset-stage-1/-/babel-preset-stage-1-6.24.1.tgz",
 			"integrity": "sha1-dpLNfc1oSZB+auSgqFWJz7niv7A=",
+			"dev": true,
 			"requires": {
 				"babel-plugin-transform-class-constructor-call": "6.24.1",
 				"babel-plugin-transform-export-extensions": "6.22.0",
@@ -1014,6 +1131,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-preset-stage-2/-/babel-preset-stage-2-6.24.1.tgz",
 			"integrity": "sha1-2eKWD7PXEYfw5k7sYrwHdnIZvcE=",
+			"dev": true,
 			"requires": {
 				"babel-plugin-syntax-dynamic-import": "6.18.0",
 				"babel-plugin-transform-class-properties": "6.24.1",
@@ -1025,6 +1143,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-preset-stage-3/-/babel-preset-stage-3-6.24.1.tgz",
 			"integrity": "sha1-g2raCp56f6N8sTj7kyb4eTSkg5U=",
+			"dev": true,
 			"requires": {
 				"babel-plugin-syntax-trailing-function-commas": "6.22.0",
 				"babel-plugin-transform-async-generator-functions": "6.24.1",
@@ -1037,6 +1156,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-register/-/babel-register-6.24.1.tgz",
 			"integrity": "sha1-fhDhOi9xBlvfrVoXh7pFvKbe118=",
+			"dev": true,
 			"requires": {
 				"babel-core": "6.25.0",
 				"babel-runtime": "6.25.0",
@@ -1051,6 +1171,7 @@
 			"version": "6.25.0",
 			"resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.25.0.tgz",
 			"integrity": "sha1-M7mOql1IK7AajRqmtDetKwGuxBw=",
+			"dev": true,
 			"requires": {
 				"core-js": "2.4.1",
 				"regenerator-runtime": "0.10.5"
@@ -1060,6 +1181,7 @@
 			"version": "6.25.0",
 			"resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.25.0.tgz",
 			"integrity": "sha1-ZlJBFmt8KqTGGdceGSlpVSsQwHE=",
+			"dev": true,
 			"requires": {
 				"babel-runtime": "6.25.0",
 				"babel-traverse": "6.25.0",
@@ -1072,6 +1194,7 @@
 			"version": "6.25.0",
 			"resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.25.0.tgz",
 			"integrity": "sha1-IldJfi/NGbie3BPEyROB+VEklvE=",
+			"dev": true,
 			"requires": {
 				"babel-code-frame": "6.22.0",
 				"babel-messages": "6.23.0",
@@ -1088,6 +1211,7 @@
 			"version": "6.25.0",
 			"resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.25.0.tgz",
 			"integrity": "sha1-cK+ySNVmDl0Y+BHZHIMDtUE0oY4=",
+			"dev": true,
 			"requires": {
 				"babel-runtime": "6.25.0",
 				"esutils": "2.0.2",
@@ -1098,17 +1222,20 @@
 		"babylon": {
 			"version": "6.17.4",
 			"resolved": "https://registry.npmjs.org/babylon/-/babylon-6.17.4.tgz",
-			"integrity": "sha512-kChlV+0SXkjE0vUn9OZ7pBMWRFd8uq3mZe8x1K6jhuNcAFAtEnjchFAqB+dYEXKyd+JpT6eppRR78QAr5gTsUw=="
+			"integrity": "sha512-kChlV+0SXkjE0vUn9OZ7pBMWRFd8uq3mZe8x1K6jhuNcAFAtEnjchFAqB+dYEXKyd+JpT6eppRR78QAr5gTsUw==",
+			"dev": true
 		},
 		"balanced-match": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-			"integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
+			"integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+			"dev": true
 		},
 		"bcrypt-pbkdf": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
 			"integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
+			"dev": true,
 			"optional": true,
 			"requires": {
 				"tweetnacl": "0.14.5"
@@ -1118,12 +1245,14 @@
 			"version": "1.9.0",
 			"resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.9.0.tgz",
 			"integrity": "sha1-ZlBsFs5vTWkopbPNajPKQelB43s=",
+			"dev": true,
 			"optional": true
 		},
 		"boom": {
 			"version": "2.10.1",
 			"resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
 			"integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
+			"dev": true,
 			"requires": {
 				"hoek": "2.16.3"
 			}
@@ -1132,6 +1261,7 @@
 			"version": "1.1.8",
 			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
 			"integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
+			"dev": true,
 			"requires": {
 				"balanced-match": "1.0.0",
 				"concat-map": "0.0.1"
@@ -1141,6 +1271,7 @@
 			"version": "1.8.5",
 			"resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
 			"integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
+			"dev": true,
 			"requires": {
 				"expand-range": "1.8.2",
 				"preserve": "0.2.0",
@@ -1151,6 +1282,7 @@
 			"version": "1.11.2",
 			"resolved": "https://registry.npmjs.org/browser-resolve/-/browser-resolve-1.11.2.tgz",
 			"integrity": "sha1-j/CbCixCFxihBRwmCzLkj0QpOM4=",
+			"dev": true,
 			"requires": {
 				"resolve": "1.1.7"
 			},
@@ -1158,7 +1290,8 @@
 				"resolve": {
 					"version": "1.1.7",
 					"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
-					"integrity": "sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs="
+					"integrity": "sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs=",
+					"dev": true
 				}
 			}
 		},
@@ -1166,6 +1299,7 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/bser/-/bser-2.0.0.tgz",
 			"integrity": "sha1-mseNPtXZFYBP2HrLFYvHlxR6Fxk=",
+			"dev": true,
 			"requires": {
 				"node-int64": "0.4.0"
 			}
@@ -1173,12 +1307,14 @@
 		"builtin-modules": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
-			"integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8="
+			"integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=",
+			"dev": true
 		},
 		"caller-path": {
 			"version": "0.1.0",
 			"resolved": "https://registry.npmjs.org/caller-path/-/caller-path-0.1.0.tgz",
 			"integrity": "sha1-lAhe9jWB7NPaqSREqP6U6CV3dR8=",
+			"dev": true,
 			"requires": {
 				"callsites": "0.2.0"
 			}
@@ -1186,23 +1322,27 @@
 		"callsites": {
 			"version": "0.2.0",
 			"resolved": "https://registry.npmjs.org/callsites/-/callsites-0.2.0.tgz",
-			"integrity": "sha1-r6uWJikQp/M8GaV3WCXGnzTjUMo="
+			"integrity": "sha1-r6uWJikQp/M8GaV3WCXGnzTjUMo=",
+			"dev": true
 		},
 		"camelcase": {
 			"version": "1.2.1",
 			"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
 			"integrity": "sha1-m7UwTS4LVmmLLHWLCKPqqdqlijk=",
+			"dev": true,
 			"optional": true
 		},
 		"caseless": {
 			"version": "0.12.0",
 			"resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
-			"integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
+			"integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
+			"dev": true
 		},
 		"center-align": {
 			"version": "0.1.3",
 			"resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
 			"integrity": "sha1-qg0yYptu6XIgBBHL1EYckHvCt60=",
+			"dev": true,
 			"optional": true,
 			"requires": {
 				"align-text": "0.1.4",
@@ -1213,6 +1353,7 @@
 			"version": "1.1.3",
 			"resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
 			"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+			"dev": true,
 			"requires": {
 				"ansi-styles": "2.2.1",
 				"escape-string-regexp": "1.0.5",
@@ -1225,11 +1366,11 @@
 			"version": "1.7.0",
 			"resolved": "https://registry.npmjs.org/chokidar/-/chokidar-1.7.0.tgz",
 			"integrity": "sha1-eY5ol3gVHIB2tLNg5e3SjNortGg=",
+			"dev": true,
 			"optional": true,
 			"requires": {
 				"anymatch": "1.3.2",
 				"async-each": "1.0.1",
-				"fsevents": "1.1.2",
 				"glob-parent": "2.0.0",
 				"inherits": "2.0.3",
 				"is-binary-path": "1.0.1",
@@ -1241,17 +1382,20 @@
 		"ci-info": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/ci-info/-/ci-info-1.0.0.tgz",
-			"integrity": "sha1-3FKF8rTiUYIWg2gcOBwziPRuxTQ="
+			"integrity": "sha1-3FKF8rTiUYIWg2gcOBwziPRuxTQ=",
+			"dev": true
 		},
 		"circular-json": {
 			"version": "0.3.3",
 			"resolved": "https://registry.npmjs.org/circular-json/-/circular-json-0.3.3.tgz",
-			"integrity": "sha512-UZK3NBx2Mca+b5LsG7bY183pHWt5Y1xts4P3Pz7ENTwGVnJOUWbRb3ocjvX7hx9tq/yTAdclXm9sZ38gNuem4A=="
+			"integrity": "sha512-UZK3NBx2Mca+b5LsG7bY183pHWt5Y1xts4P3Pz7ENTwGVnJOUWbRb3ocjvX7hx9tq/yTAdclXm9sZ38gNuem4A==",
+			"dev": true
 		},
 		"cli-cursor": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-1.0.2.tgz",
 			"integrity": "sha1-ZNo/fValRBLll5S9Ytw1KV6PKYc=",
+			"dev": true,
 			"requires": {
 				"restore-cursor": "1.0.1"
 			}
@@ -1259,12 +1403,14 @@
 		"cli-width": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.1.0.tgz",
-			"integrity": "sha1-sjTKIJsp72b8UY2bmNWEewDt8Ao="
+			"integrity": "sha1-sjTKIJsp72b8UY2bmNWEewDt8Ao=",
+			"dev": true
 		},
 		"cliui": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
 			"integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
+			"dev": true,
 			"optional": true,
 			"requires": {
 				"center-align": "0.1.3",
@@ -1276,6 +1422,7 @@
 					"version": "0.0.2",
 					"resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
 					"integrity": "sha1-t5Zpu0LstAn4PVg8rVLKF+qhZD8=",
+					"dev": true,
 					"optional": true
 				}
 			}
@@ -1283,17 +1430,20 @@
 		"co": {
 			"version": "4.6.0",
 			"resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
-			"integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ="
+			"integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
+			"dev": true
 		},
 		"code-point-at": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
-			"integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
+			"integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
+			"dev": true
 		},
 		"color-convert": {
 			"version": "1.9.0",
 			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.0.tgz",
 			"integrity": "sha1-Gsz5fdc5uYO/mU1W/sj5WFNkG3o=",
+			"dev": true,
 			"requires": {
 				"color-name": "1.1.3"
 			}
@@ -1301,12 +1451,14 @@
 		"color-name": {
 			"version": "1.1.3",
 			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-			"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
+			"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+			"dev": true
 		},
 		"combined-stream": {
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
 			"integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
+			"dev": true,
 			"requires": {
 				"delayed-stream": "1.0.0"
 			}
@@ -1314,17 +1466,20 @@
 		"commander": {
 			"version": "2.11.0",
 			"resolved": "https://registry.npmjs.org/commander/-/commander-2.11.0.tgz",
-			"integrity": "sha512-b0553uYA5YAEGgyYIGYROzKQ7X5RAqedkfjiZxwi0kL1g3bOaBNNZfYkzt/CL0umgD5wc9Jec2FbB98CjkMRvQ=="
+			"integrity": "sha512-b0553uYA5YAEGgyYIGYROzKQ7X5RAqedkfjiZxwi0kL1g3bOaBNNZfYkzt/CL0umgD5wc9Jec2FbB98CjkMRvQ==",
+			"dev": true
 		},
 		"concat-map": {
 			"version": "0.0.1",
 			"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-			"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+			"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+			"dev": true
 		},
 		"concat-stream": {
 			"version": "1.6.0",
 			"resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.0.tgz",
 			"integrity": "sha1-CqxmL9Ur54lk1VMvaUeE5wEQrPc=",
+			"dev": true,
 			"requires": {
 				"inherits": "2.0.3",
 				"readable-stream": "2.3.3",
@@ -1334,32 +1489,38 @@
 		"contains-path": {
 			"version": "0.1.0",
 			"resolved": "https://registry.npmjs.org/contains-path/-/contains-path-0.1.0.tgz",
-			"integrity": "sha1-/ozxhP9mcLa67wGp1IYaXL7EEgo="
+			"integrity": "sha1-/ozxhP9mcLa67wGp1IYaXL7EEgo=",
+			"dev": true
 		},
 		"content-type-parser": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/content-type-parser/-/content-type-parser-1.0.1.tgz",
-			"integrity": "sha1-w+VpiMU8ZRJ/tG1AMqOpACRv3JQ="
+			"integrity": "sha1-w+VpiMU8ZRJ/tG1AMqOpACRv3JQ=",
+			"dev": true
 		},
 		"convert-source-map": {
 			"version": "1.5.0",
 			"resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.5.0.tgz",
-			"integrity": "sha1-ms1whRxtXf3ZPZKC5e35SgP/RrU="
+			"integrity": "sha1-ms1whRxtXf3ZPZKC5e35SgP/RrU=",
+			"dev": true
 		},
 		"core-js": {
 			"version": "2.4.1",
 			"resolved": "https://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz",
-			"integrity": "sha1-TekR5mew6ukSTjQlS1OupvxhjT4="
+			"integrity": "sha1-TekR5mew6ukSTjQlS1OupvxhjT4=",
+			"dev": true
 		},
 		"core-util-is": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-			"integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+			"integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+			"dev": true
 		},
 		"create-react-class": {
 			"version": "15.6.0",
 			"resolved": "https://registry.npmjs.org/create-react-class/-/create-react-class-15.6.0.tgz",
 			"integrity": "sha1-q0SEl8JlZuHilBPogyB9V8/nvtQ=",
+			"dev": true,
 			"requires": {
 				"fbjs": "0.8.14",
 				"loose-envify": "1.3.1",
@@ -1370,6 +1531,7 @@
 			"version": "2.0.5",
 			"resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
 			"integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
+			"dev": true,
 			"requires": {
 				"boom": "2.10.1"
 			}
@@ -1377,12 +1539,14 @@
 		"cssom": {
 			"version": "0.3.2",
 			"resolved": "https://registry.npmjs.org/cssom/-/cssom-0.3.2.tgz",
-			"integrity": "sha1-uANhcMefB6kP8vFuIihAJ6JDhIs="
+			"integrity": "sha1-uANhcMefB6kP8vFuIihAJ6JDhIs=",
+			"dev": true
 		},
 		"cssstyle": {
 			"version": "0.2.37",
 			"resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-0.2.37.tgz",
 			"integrity": "sha1-VBCXI0yyUTyDzu06zdwn/yeYfVQ=",
+			"dev": true,
 			"requires": {
 				"cssom": "0.3.2"
 			}
@@ -1391,6 +1555,7 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/d/-/d-1.0.0.tgz",
 			"integrity": "sha1-dUu1v+VUUdpppYuU1F9MWwRi1Y8=",
+			"dev": true,
 			"requires": {
 				"es5-ext": "0.10.26"
 			}
@@ -1399,6 +1564,7 @@
 			"version": "1.14.1",
 			"resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
 			"integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
+			"dev": true,
 			"requires": {
 				"assert-plus": "1.0.0"
 			},
@@ -1406,7 +1572,8 @@
 				"assert-plus": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-					"integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
+					"integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+					"dev": true
 				}
 			}
 		},
@@ -1414,6 +1581,7 @@
 			"version": "2.6.8",
 			"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
 			"integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw=",
+			"dev": true,
 			"requires": {
 				"ms": "2.0.0"
 			}
@@ -1421,17 +1589,20 @@
 		"decamelize": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
-			"integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA="
+			"integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
+			"dev": true
 		},
 		"deep-is": {
 			"version": "0.1.3",
 			"resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
-			"integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ="
+			"integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
+			"dev": true
 		},
 		"default-require-extensions": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/default-require-extensions/-/default-require-extensions-1.0.0.tgz",
 			"integrity": "sha1-836hXT4T/9m0N9M+GnW1+5eHTLg=",
+			"dev": true,
 			"requires": {
 				"strip-bom": "2.0.0"
 			},
@@ -1440,6 +1611,7 @@
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
 					"integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
+					"dev": true,
 					"requires": {
 						"is-utf8": "0.2.1"
 					}
@@ -1450,6 +1622,7 @@
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.2.tgz",
 			"integrity": "sha1-g6c/L+pWmJj7c3GTyPhzyvbUXJQ=",
+			"dev": true,
 			"requires": {
 				"foreach": "2.0.5",
 				"object-keys": "1.0.11"
@@ -1459,6 +1632,7 @@
 			"version": "2.2.2",
 			"resolved": "https://registry.npmjs.org/del/-/del-2.2.2.tgz",
 			"integrity": "sha1-wSyYHQZ4RshLyvhiz/kw2Qf/0ag=",
+			"dev": true,
 			"requires": {
 				"globby": "5.0.0",
 				"is-path-cwd": "1.0.0",
@@ -1472,12 +1646,14 @@
 		"delayed-stream": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-			"integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
+			"integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
+			"dev": true
 		},
 		"detect-indent": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-4.0.0.tgz",
 			"integrity": "sha1-920GQ1LN9Docts5hnE7jqUdd4gg=",
+			"dev": true,
 			"requires": {
 				"repeating": "2.0.1"
 			}
@@ -1485,12 +1661,14 @@
 		"diff": {
 			"version": "3.3.0",
 			"resolved": "https://registry.npmjs.org/diff/-/diff-3.3.0.tgz",
-			"integrity": "sha512-w0XZubFWn0Adlsapj9EAWX0FqWdO4tz8kc3RiYdWLh4k/V8PTb6i0SMgXt0vRM3zyKnT8tKO7mUlieRQHIjMNg=="
+			"integrity": "sha512-w0XZubFWn0Adlsapj9EAWX0FqWdO4tz8kc3RiYdWLh4k/V8PTb6i0SMgXt0vRM3zyKnT8tKO7mUlieRQHIjMNg==",
+			"dev": true
 		},
 		"doctrine": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.0.0.tgz",
 			"integrity": "sha1-xz2NKQnSIpHhoAejlYBNqLZl/mM=",
+			"dev": true,
 			"requires": {
 				"esutils": "2.0.2",
 				"isarray": "1.0.0"
@@ -1499,12 +1677,14 @@
 		"duplexer": {
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz",
-			"integrity": "sha1-rOb/gIwc5mtX0ev5eXessCM0z8E="
+			"integrity": "sha1-rOb/gIwc5mtX0ev5eXessCM0z8E=",
+			"dev": true
 		},
 		"ecc-jsbn": {
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
 			"integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
+			"dev": true,
 			"optional": true,
 			"requires": {
 				"jsbn": "0.1.1"
@@ -1522,6 +1702,7 @@
 			"version": "0.1.4",
 			"resolved": "https://registry.npmjs.org/errno/-/errno-0.1.4.tgz",
 			"integrity": "sha1-uJbiOp5ei6M4cfyZar02NfyaHH0=",
+			"dev": true,
 			"requires": {
 				"prr": "0.0.0"
 			}
@@ -1530,6 +1711,7 @@
 			"version": "1.3.1",
 			"resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.1.tgz",
 			"integrity": "sha1-+FWobOYa3E6GIcPNoh56dhLDqNw=",
+			"dev": true,
 			"requires": {
 				"is-arrayish": "0.2.1"
 			}
@@ -1538,6 +1720,7 @@
 			"version": "1.7.0",
 			"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.7.0.tgz",
 			"integrity": "sha1-363ndOAb/Nl/lhgCmMRJyGI/uUw=",
+			"dev": true,
 			"requires": {
 				"es-to-primitive": "1.1.1",
 				"function-bind": "1.1.0",
@@ -1549,6 +1732,7 @@
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.1.1.tgz",
 			"integrity": "sha1-RTVSSKiJeQNLZ5Lhm7gfK3l13Q0=",
+			"dev": true,
 			"requires": {
 				"is-callable": "1.1.3",
 				"is-date-object": "1.0.1",
@@ -1559,6 +1743,7 @@
 			"version": "0.10.26",
 			"resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.26.tgz",
 			"integrity": "sha1-UbISilMbcMT2dkCTpzy+u4IYY3I=",
+			"dev": true,
 			"requires": {
 				"es6-iterator": "2.0.1",
 				"es6-symbol": "3.1.1"
@@ -1568,6 +1753,7 @@
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.1.tgz",
 			"integrity": "sha1-jjGcnwRTv1ddN0lAplWSDlnKVRI=",
+			"dev": true,
 			"requires": {
 				"d": "1.0.0",
 				"es5-ext": "0.10.26",
@@ -1578,6 +1764,7 @@
 			"version": "0.1.5",
 			"resolved": "https://registry.npmjs.org/es6-map/-/es6-map-0.1.5.tgz",
 			"integrity": "sha1-kTbgUD3MBqMBaQ8LsU/042TpSfA=",
+			"dev": true,
 			"requires": {
 				"d": "1.0.0",
 				"es5-ext": "0.10.26",
@@ -1591,6 +1778,7 @@
 			"version": "0.1.5",
 			"resolved": "https://registry.npmjs.org/es6-set/-/es6-set-0.1.5.tgz",
 			"integrity": "sha1-0rPsXU2ADO2BjbU40ol02wpzzLE=",
+			"dev": true,
 			"requires": {
 				"d": "1.0.0",
 				"es5-ext": "0.10.26",
@@ -1603,6 +1791,7 @@
 			"version": "3.1.1",
 			"resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.1.tgz",
 			"integrity": "sha1-vwDvT9q2uhtG7Le2KbTH7VcVzHc=",
+			"dev": true,
 			"requires": {
 				"d": "1.0.0",
 				"es5-ext": "0.10.26"
@@ -1612,6 +1801,7 @@
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-2.0.2.tgz",
 			"integrity": "sha1-XjqzIlH/0VOKH45f+hNXdy+S2W8=",
+			"dev": true,
 			"requires": {
 				"d": "1.0.0",
 				"es5-ext": "0.10.26",
@@ -1622,12 +1812,14 @@
 		"escape-string-regexp": {
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-			"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
+			"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+			"dev": true
 		},
 		"escodegen": {
 			"version": "1.8.1",
 			"resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.8.1.tgz",
 			"integrity": "sha1-WltTr0aTEQvrsIZ6o0MN07cKEBg=",
+			"dev": true,
 			"requires": {
 				"esprima": "2.7.3",
 				"estraverse": "1.9.3",
@@ -1639,17 +1831,20 @@
 				"esprima": {
 					"version": "2.7.3",
 					"resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.3.tgz",
-					"integrity": "sha1-luO3DVd59q1JzQMmc9HDEnZ7pYE="
+					"integrity": "sha1-luO3DVd59q1JzQMmc9HDEnZ7pYE=",
+					"dev": true
 				},
 				"estraverse": {
 					"version": "1.9.3",
 					"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-1.9.3.tgz",
-					"integrity": "sha1-r2fy3JIlgkFZUJJgkaQAXSnJu0Q="
+					"integrity": "sha1-r2fy3JIlgkFZUJJgkaQAXSnJu0Q=",
+					"dev": true
 				},
 				"source-map": {
 					"version": "0.2.0",
 					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.2.0.tgz",
 					"integrity": "sha1-2rc/vPwrqBm03gO9b26qSBZLP50=",
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"amdefine": "1.0.1"
@@ -1661,6 +1856,7 @@
 			"version": "3.6.0",
 			"resolved": "https://registry.npmjs.org/escope/-/escope-3.6.0.tgz",
 			"integrity": "sha1-4Bl16BJ4GhY6ba392AOY3GTIicM=",
+			"dev": true,
 			"requires": {
 				"es6-map": "0.1.5",
 				"es6-weak-map": "2.0.2",
@@ -1672,6 +1868,7 @@
 			"version": "3.19.0",
 			"resolved": "https://registry.npmjs.org/eslint/-/eslint-3.19.0.tgz",
 			"integrity": "sha1-yPxiAcf0DdCJQbh8CFdnOGpnmsw=",
+			"dev": true,
 			"requires": {
 				"babel-code-frame": "6.22.0",
 				"chalk": "1.1.3",
@@ -1714,6 +1911,7 @@
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/user-home/-/user-home-2.0.0.tgz",
 					"integrity": "sha1-nHC/2Babwdy/SGBODwS4tJzenp8=",
+					"dev": true,
 					"requires": {
 						"os-homedir": "1.0.2"
 					}
@@ -1724,6 +1922,7 @@
 			"version": "0.3.1",
 			"resolved": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.1.tgz",
 			"integrity": "sha512-yUtXS15gIcij68NmXmP9Ni77AQuCN0itXbCc/jWd8C6/yKZaSNXicpC8cgvjnxVdmfsosIXrjpzFq7GcDryb6A==",
+			"dev": true,
 			"requires": {
 				"debug": "2.6.8",
 				"resolve": "1.4.0"
@@ -1733,6 +1932,7 @@
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.1.1.tgz",
 			"integrity": "sha512-jDI/X5l/6D1rRD/3T43q8Qgbls2nq5km5KSqiwlyUbGo5+04fXhMKdCPhjwbqAa6HXWaMxj8Q4hQDIh7IadJQw==",
+			"dev": true,
 			"requires": {
 				"debug": "2.6.8",
 				"pkg-dir": "1.0.0"
@@ -1742,6 +1942,7 @@
 			"version": "2.7.0",
 			"resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.7.0.tgz",
 			"integrity": "sha512-HGYmpU9f/zJaQiKNQOVfHUh2oLWW3STBrCgH0sHTX1xtsxYlH1zjLh8FlQGEIdZSdTbUMaV36WaZ6ImXkenGxQ==",
+			"dev": true,
 			"requires": {
 				"builtin-modules": "1.1.1",
 				"contains-path": "0.1.0",
@@ -1759,6 +1960,7 @@
 					"version": "1.5.0",
 					"resolved": "https://registry.npmjs.org/doctrine/-/doctrine-1.5.0.tgz",
 					"integrity": "sha1-N53Ocw9hZvds76TmcHoVmwLFpvo=",
+					"dev": true,
 					"requires": {
 						"esutils": "2.0.2",
 						"isarray": "1.0.0"
@@ -1770,6 +1972,7 @@
 			"version": "6.10.3",
 			"resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-6.10.3.tgz",
 			"integrity": "sha1-xUNb6wZ3ThLH2y9qut3L+QDNP3g=",
+			"dev": true,
 			"requires": {
 				"array.prototype.find": "2.0.4",
 				"doctrine": "1.5.0",
@@ -1782,6 +1985,7 @@
 					"version": "1.5.0",
 					"resolved": "https://registry.npmjs.org/doctrine/-/doctrine-1.5.0.tgz",
 					"integrity": "sha1-N53Ocw9hZvds76TmcHoVmwLFpvo=",
+					"dev": true,
 					"requires": {
 						"esutils": "2.0.2",
 						"isarray": "1.0.0"
@@ -1793,6 +1997,7 @@
 			"version": "3.4.3",
 			"resolved": "https://registry.npmjs.org/espree/-/espree-3.4.3.tgz",
 			"integrity": "sha1-KRC1zNSc6JPC//+qtP2LOjG4I3Q=",
+			"dev": true,
 			"requires": {
 				"acorn": "5.1.1",
 				"acorn-jsx": "3.0.1"
@@ -1801,12 +2006,14 @@
 		"esprima": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.0.tgz",
-			"integrity": "sha512-oftTcaMu/EGrEIu904mWteKIv8vMuOgGYo7EhVJJN00R/EED9DCua/xxHRdYnKtcECzVg7xOWhflvJMnqcFZjw=="
+			"integrity": "sha512-oftTcaMu/EGrEIu904mWteKIv8vMuOgGYo7EhVJJN00R/EED9DCua/xxHRdYnKtcECzVg7xOWhflvJMnqcFZjw==",
+			"dev": true
 		},
 		"esquery": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/esquery/-/esquery-1.0.0.tgz",
 			"integrity": "sha1-z7qLV9f7qT8XKYqKAGoEzaE9gPo=",
+			"dev": true,
 			"requires": {
 				"estraverse": "4.2.0"
 			}
@@ -1815,6 +2022,7 @@
 			"version": "4.2.0",
 			"resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.2.0.tgz",
 			"integrity": "sha1-+pVo2Y04I/mkHZHpAtyrnqblsWM=",
+			"dev": true,
 			"requires": {
 				"estraverse": "4.2.0",
 				"object-assign": "4.1.1"
@@ -1823,22 +2031,26 @@
 		"estraverse": {
 			"version": "4.2.0",
 			"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.2.0.tgz",
-			"integrity": "sha1-De4/7TH81GlhjOc0IJn8GvoL2xM="
+			"integrity": "sha1-De4/7TH81GlhjOc0IJn8GvoL2xM=",
+			"dev": true
 		},
 		"estree-walker": {
 			"version": "0.2.1",
 			"resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-0.2.1.tgz",
-			"integrity": "sha1-va/oCVOD2EFNXcLs9MkXO225QS4="
+			"integrity": "sha1-va/oCVOD2EFNXcLs9MkXO225QS4=",
+			"dev": true
 		},
 		"esutils": {
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
-			"integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs="
+			"integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
+			"dev": true
 		},
 		"event-emitter": {
 			"version": "0.3.5",
 			"resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.5.tgz",
 			"integrity": "sha1-34xp7vFkeSPHFXuc6DhAYQsCzDk=",
+			"dev": true,
 			"requires": {
 				"d": "1.0.0",
 				"es5-ext": "0.10.26"
@@ -1848,6 +2060,7 @@
 			"version": "0.2.0",
 			"resolved": "https://registry.npmjs.org/exec-sh/-/exec-sh-0.2.0.tgz",
 			"integrity": "sha1-FPdd4/INKG75MwmbLOUKkDWc7xA=",
+			"dev": true,
 			"requires": {
 				"merge": "1.2.0"
 			}
@@ -1855,12 +2068,14 @@
 		"exit-hook": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/exit-hook/-/exit-hook-1.1.1.tgz",
-			"integrity": "sha1-8FyiM7SMBdVP/wd2XfhQfpXAL/g="
+			"integrity": "sha1-8FyiM7SMBdVP/wd2XfhQfpXAL/g=",
+			"dev": true
 		},
 		"expand-brackets": {
 			"version": "0.1.5",
 			"resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
 			"integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
+			"dev": true,
 			"requires": {
 				"is-posix-bracket": "0.1.1"
 			}
@@ -1869,6 +2084,7 @@
 			"version": "1.8.2",
 			"resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
 			"integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
+			"dev": true,
 			"requires": {
 				"fill-range": "2.2.3"
 			}
@@ -1876,12 +2092,14 @@
 		"extend": {
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
-			"integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ="
+			"integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ=",
+			"dev": true
 		},
 		"extglob": {
 			"version": "0.3.2",
 			"resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
 			"integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
+			"dev": true,
 			"requires": {
 				"is-extglob": "1.0.0"
 			}
@@ -1889,17 +2107,20 @@
 		"extsprintf": {
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
-			"integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU="
+			"integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
+			"dev": true
 		},
 		"fast-levenshtein": {
 			"version": "2.0.6",
 			"resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
-			"integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc="
+			"integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
+			"dev": true
 		},
 		"fb-watchman": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/fb-watchman/-/fb-watchman-2.0.0.tgz",
 			"integrity": "sha1-VOmr99+i8mzZsWNsWIwa/AXeXVg=",
+			"dev": true,
 			"requires": {
 				"bser": "2.0.0"
 			}
@@ -1929,6 +2150,7 @@
 			"version": "1.7.0",
 			"resolved": "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
 			"integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
+			"dev": true,
 			"requires": {
 				"escape-string-regexp": "1.0.5",
 				"object-assign": "4.1.1"
@@ -1938,6 +2160,7 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-2.0.0.tgz",
 			"integrity": "sha1-w5KZDD5oR4PYOLjISkXYoEhFg2E=",
+			"dev": true,
 			"requires": {
 				"flat-cache": "1.2.2",
 				"object-assign": "4.1.1"
@@ -1946,12 +2169,14 @@
 		"filename-regex": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.1.tgz",
-			"integrity": "sha1-wcS5vuPglyXdsQa3XB4wH+LxiyY="
+			"integrity": "sha1-wcS5vuPglyXdsQa3XB4wH+LxiyY=",
+			"dev": true
 		},
 		"fileset": {
 			"version": "2.0.3",
 			"resolved": "https://registry.npmjs.org/fileset/-/fileset-2.0.3.tgz",
 			"integrity": "sha1-jnVIqW08wjJ+5eZ0FocjozO7oqA=",
+			"dev": true,
 			"requires": {
 				"glob": "7.1.2",
 				"minimatch": "3.0.4"
@@ -1961,6 +2186,7 @@
 			"version": "2.2.3",
 			"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.3.tgz",
 			"integrity": "sha1-ULd9/X5Gm8dJJHCWNpn+eoSFpyM=",
+			"dev": true,
 			"requires": {
 				"is-number": "2.1.0",
 				"isobject": "2.1.0",
@@ -1973,6 +2199,7 @@
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
 			"integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
+			"dev": true,
 			"requires": {
 				"path-exists": "2.1.0",
 				"pinkie-promise": "2.0.1"
@@ -1982,6 +2209,7 @@
 			"version": "1.2.2",
 			"resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-1.2.2.tgz",
 			"integrity": "sha1-+oZxTnLCHbiGAXYezy9VXRq8a5Y=",
+			"dev": true,
 			"requires": {
 				"circular-json": "0.3.3",
 				"del": "2.2.2",
@@ -1992,12 +2220,14 @@
 		"for-in": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
-			"integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA="
+			"integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA=",
+			"dev": true
 		},
 		"for-own": {
 			"version": "0.1.5",
 			"resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
 			"integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
+			"dev": true,
 			"requires": {
 				"for-in": "1.0.2"
 			}
@@ -2005,17 +2235,20 @@
 		"foreach": {
 			"version": "2.0.5",
 			"resolved": "https://registry.npmjs.org/foreach/-/foreach-2.0.5.tgz",
-			"integrity": "sha1-C+4AUBiusmDQo6865ljdATbsG5k="
+			"integrity": "sha1-C+4AUBiusmDQo6865ljdATbsG5k=",
+			"dev": true
 		},
 		"forever-agent": {
 			"version": "0.6.1",
 			"resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
-			"integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE="
+			"integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
+			"dev": true
 		},
 		"form-data": {
 			"version": "2.1.4",
 			"resolved": "https://registry.npmjs.org/form-data/-/form-data-2.1.4.tgz",
 			"integrity": "sha1-M8GDrPGTJ27KqYFDpp6Uv+4XUNE=",
+			"dev": true,
 			"requires": {
 				"asynckit": "0.4.0",
 				"combined-stream": "1.0.5",
@@ -2025,812 +2258,32 @@
 		"fs-readdir-recursive": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/fs-readdir-recursive/-/fs-readdir-recursive-1.0.0.tgz",
-			"integrity": "sha1-jNF0XItPiinIyuw5JHaSG6GV9WA="
+			"integrity": "sha1-jNF0XItPiinIyuw5JHaSG6GV9WA=",
+			"dev": true
 		},
 		"fs.realpath": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-			"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
-		},
-		"fsevents": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.1.2.tgz",
-			"integrity": "sha512-Sn44E5wQW4bTHXvQmvSHwqbuiXtduD6Rrjm2ZtUEGbyrig+nUH3t/QD4M4/ZXViY556TBpRgZkHLDx3JxPwxiw==",
-			"optional": true,
-			"requires": {
-				"nan": "2.6.2",
-				"node-pre-gyp": "0.6.36"
-			},
-			"dependencies": {
-				"abbrev": {
-					"version": "1.1.0",
-					"bundled": true,
-					"optional": true
-				},
-				"ajv": {
-					"version": "4.11.8",
-					"bundled": true,
-					"optional": true,
-					"requires": {
-						"co": "4.6.0",
-						"json-stable-stringify": "1.0.1"
-					}
-				},
-				"ansi-regex": {
-					"version": "2.1.1",
-					"bundled": true
-				},
-				"aproba": {
-					"version": "1.1.1",
-					"bundled": true,
-					"optional": true
-				},
-				"are-we-there-yet": {
-					"version": "1.1.4",
-					"bundled": true,
-					"optional": true,
-					"requires": {
-						"delegates": "1.0.0",
-						"readable-stream": "2.2.9"
-					}
-				},
-				"asn1": {
-					"version": "0.2.3",
-					"bundled": true,
-					"optional": true
-				},
-				"assert-plus": {
-					"version": "0.2.0",
-					"bundled": true,
-					"optional": true
-				},
-				"asynckit": {
-					"version": "0.4.0",
-					"bundled": true,
-					"optional": true
-				},
-				"aws-sign2": {
-					"version": "0.6.0",
-					"bundled": true,
-					"optional": true
-				},
-				"aws4": {
-					"version": "1.6.0",
-					"bundled": true,
-					"optional": true
-				},
-				"balanced-match": {
-					"version": "0.4.2",
-					"bundled": true
-				},
-				"bcrypt-pbkdf": {
-					"version": "1.0.1",
-					"bundled": true,
-					"optional": true,
-					"requires": {
-						"tweetnacl": "0.14.5"
-					}
-				},
-				"block-stream": {
-					"version": "0.0.9",
-					"bundled": true,
-					"requires": {
-						"inherits": "2.0.3"
-					}
-				},
-				"boom": {
-					"version": "2.10.1",
-					"bundled": true,
-					"requires": {
-						"hoek": "2.16.3"
-					}
-				},
-				"brace-expansion": {
-					"version": "1.1.7",
-					"bundled": true,
-					"requires": {
-						"balanced-match": "0.4.2",
-						"concat-map": "0.0.1"
-					}
-				},
-				"buffer-shims": {
-					"version": "1.0.0",
-					"bundled": true
-				},
-				"caseless": {
-					"version": "0.12.0",
-					"bundled": true,
-					"optional": true
-				},
-				"co": {
-					"version": "4.6.0",
-					"bundled": true,
-					"optional": true
-				},
-				"code-point-at": {
-					"version": "1.1.0",
-					"bundled": true
-				},
-				"combined-stream": {
-					"version": "1.0.5",
-					"bundled": true,
-					"requires": {
-						"delayed-stream": "1.0.0"
-					}
-				},
-				"concat-map": {
-					"version": "0.0.1",
-					"bundled": true
-				},
-				"console-control-strings": {
-					"version": "1.1.0",
-					"bundled": true
-				},
-				"core-util-is": {
-					"version": "1.0.2",
-					"bundled": true
-				},
-				"cryptiles": {
-					"version": "2.0.5",
-					"bundled": true,
-					"optional": true,
-					"requires": {
-						"boom": "2.10.1"
-					}
-				},
-				"dashdash": {
-					"version": "1.14.1",
-					"bundled": true,
-					"optional": true,
-					"requires": {
-						"assert-plus": "1.0.0"
-					},
-					"dependencies": {
-						"assert-plus": {
-							"version": "1.0.0",
-							"bundled": true,
-							"optional": true
-						}
-					}
-				},
-				"debug": {
-					"version": "2.6.8",
-					"bundled": true,
-					"optional": true,
-					"requires": {
-						"ms": "2.0.0"
-					}
-				},
-				"deep-extend": {
-					"version": "0.4.2",
-					"bundled": true,
-					"optional": true
-				},
-				"delayed-stream": {
-					"version": "1.0.0",
-					"bundled": true
-				},
-				"delegates": {
-					"version": "1.0.0",
-					"bundled": true,
-					"optional": true
-				},
-				"ecc-jsbn": {
-					"version": "0.1.1",
-					"bundled": true,
-					"optional": true,
-					"requires": {
-						"jsbn": "0.1.1"
-					}
-				},
-				"extend": {
-					"version": "3.0.1",
-					"bundled": true,
-					"optional": true
-				},
-				"extsprintf": {
-					"version": "1.0.2",
-					"bundled": true
-				},
-				"forever-agent": {
-					"version": "0.6.1",
-					"bundled": true,
-					"optional": true
-				},
-				"form-data": {
-					"version": "2.1.4",
-					"bundled": true,
-					"optional": true,
-					"requires": {
-						"asynckit": "0.4.0",
-						"combined-stream": "1.0.5",
-						"mime-types": "2.1.15"
-					}
-				},
-				"fs.realpath": {
-					"version": "1.0.0",
-					"bundled": true
-				},
-				"fstream": {
-					"version": "1.0.11",
-					"bundled": true,
-					"requires": {
-						"graceful-fs": "4.1.11",
-						"inherits": "2.0.3",
-						"mkdirp": "0.5.1",
-						"rimraf": "2.6.1"
-					}
-				},
-				"fstream-ignore": {
-					"version": "1.0.5",
-					"bundled": true,
-					"optional": true,
-					"requires": {
-						"fstream": "1.0.11",
-						"inherits": "2.0.3",
-						"minimatch": "3.0.4"
-					}
-				},
-				"gauge": {
-					"version": "2.7.4",
-					"bundled": true,
-					"optional": true,
-					"requires": {
-						"aproba": "1.1.1",
-						"console-control-strings": "1.1.0",
-						"has-unicode": "2.0.1",
-						"object-assign": "4.1.1",
-						"signal-exit": "3.0.2",
-						"string-width": "1.0.2",
-						"strip-ansi": "3.0.1",
-						"wide-align": "1.1.2"
-					}
-				},
-				"getpass": {
-					"version": "0.1.7",
-					"bundled": true,
-					"optional": true,
-					"requires": {
-						"assert-plus": "1.0.0"
-					},
-					"dependencies": {
-						"assert-plus": {
-							"version": "1.0.0",
-							"bundled": true,
-							"optional": true
-						}
-					}
-				},
-				"glob": {
-					"version": "7.1.2",
-					"bundled": true,
-					"requires": {
-						"fs.realpath": "1.0.0",
-						"inflight": "1.0.6",
-						"inherits": "2.0.3",
-						"minimatch": "3.0.4",
-						"once": "1.4.0",
-						"path-is-absolute": "1.0.1"
-					}
-				},
-				"graceful-fs": {
-					"version": "4.1.11",
-					"bundled": true
-				},
-				"har-schema": {
-					"version": "1.0.5",
-					"bundled": true,
-					"optional": true
-				},
-				"har-validator": {
-					"version": "4.2.1",
-					"bundled": true,
-					"optional": true,
-					"requires": {
-						"ajv": "4.11.8",
-						"har-schema": "1.0.5"
-					}
-				},
-				"has-unicode": {
-					"version": "2.0.1",
-					"bundled": true,
-					"optional": true
-				},
-				"hawk": {
-					"version": "3.1.3",
-					"bundled": true,
-					"optional": true,
-					"requires": {
-						"boom": "2.10.1",
-						"cryptiles": "2.0.5",
-						"hoek": "2.16.3",
-						"sntp": "1.0.9"
-					}
-				},
-				"hoek": {
-					"version": "2.16.3",
-					"bundled": true
-				},
-				"http-signature": {
-					"version": "1.1.1",
-					"bundled": true,
-					"optional": true,
-					"requires": {
-						"assert-plus": "0.2.0",
-						"jsprim": "1.4.0",
-						"sshpk": "1.13.0"
-					}
-				},
-				"inflight": {
-					"version": "1.0.6",
-					"bundled": true,
-					"requires": {
-						"once": "1.4.0",
-						"wrappy": "1.0.2"
-					}
-				},
-				"inherits": {
-					"version": "2.0.3",
-					"bundled": true
-				},
-				"ini": {
-					"version": "1.3.4",
-					"bundled": true,
-					"optional": true
-				},
-				"is-fullwidth-code-point": {
-					"version": "1.0.0",
-					"bundled": true,
-					"requires": {
-						"number-is-nan": "1.0.1"
-					}
-				},
-				"is-typedarray": {
-					"version": "1.0.0",
-					"bundled": true,
-					"optional": true
-				},
-				"isarray": {
-					"version": "1.0.0",
-					"bundled": true
-				},
-				"isstream": {
-					"version": "0.1.2",
-					"bundled": true,
-					"optional": true
-				},
-				"jodid25519": {
-					"version": "1.0.2",
-					"bundled": true,
-					"optional": true,
-					"requires": {
-						"jsbn": "0.1.1"
-					}
-				},
-				"jsbn": {
-					"version": "0.1.1",
-					"bundled": true,
-					"optional": true
-				},
-				"json-schema": {
-					"version": "0.2.3",
-					"bundled": true,
-					"optional": true
-				},
-				"json-stable-stringify": {
-					"version": "1.0.1",
-					"bundled": true,
-					"optional": true,
-					"requires": {
-						"jsonify": "0.0.0"
-					}
-				},
-				"json-stringify-safe": {
-					"version": "5.0.1",
-					"bundled": true,
-					"optional": true
-				},
-				"jsonify": {
-					"version": "0.0.0",
-					"bundled": true,
-					"optional": true
-				},
-				"jsprim": {
-					"version": "1.4.0",
-					"bundled": true,
-					"optional": true,
-					"requires": {
-						"assert-plus": "1.0.0",
-						"extsprintf": "1.0.2",
-						"json-schema": "0.2.3",
-						"verror": "1.3.6"
-					},
-					"dependencies": {
-						"assert-plus": {
-							"version": "1.0.0",
-							"bundled": true,
-							"optional": true
-						}
-					}
-				},
-				"mime-db": {
-					"version": "1.27.0",
-					"bundled": true
-				},
-				"mime-types": {
-					"version": "2.1.15",
-					"bundled": true,
-					"requires": {
-						"mime-db": "1.27.0"
-					}
-				},
-				"minimatch": {
-					"version": "3.0.4",
-					"bundled": true,
-					"requires": {
-						"brace-expansion": "1.1.7"
-					}
-				},
-				"minimist": {
-					"version": "0.0.8",
-					"bundled": true
-				},
-				"mkdirp": {
-					"version": "0.5.1",
-					"bundled": true,
-					"requires": {
-						"minimist": "0.0.8"
-					}
-				},
-				"ms": {
-					"version": "2.0.0",
-					"bundled": true,
-					"optional": true
-				},
-				"node-pre-gyp": {
-					"version": "0.6.36",
-					"bundled": true,
-					"optional": true,
-					"requires": {
-						"mkdirp": "0.5.1",
-						"nopt": "4.0.1",
-						"npmlog": "4.1.0",
-						"rc": "1.2.1",
-						"request": "2.81.0",
-						"rimraf": "2.6.1",
-						"semver": "5.3.0",
-						"tar": "2.2.1",
-						"tar-pack": "3.4.0"
-					}
-				},
-				"nopt": {
-					"version": "4.0.1",
-					"bundled": true,
-					"optional": true,
-					"requires": {
-						"abbrev": "1.1.0",
-						"osenv": "0.1.4"
-					}
-				},
-				"npmlog": {
-					"version": "4.1.0",
-					"bundled": true,
-					"optional": true,
-					"requires": {
-						"are-we-there-yet": "1.1.4",
-						"console-control-strings": "1.1.0",
-						"gauge": "2.7.4",
-						"set-blocking": "2.0.0"
-					}
-				},
-				"number-is-nan": {
-					"version": "1.0.1",
-					"bundled": true
-				},
-				"oauth-sign": {
-					"version": "0.8.2",
-					"bundled": true,
-					"optional": true
-				},
-				"object-assign": {
-					"version": "4.1.1",
-					"bundled": true,
-					"optional": true
-				},
-				"once": {
-					"version": "1.4.0",
-					"bundled": true,
-					"requires": {
-						"wrappy": "1.0.2"
-					}
-				},
-				"os-homedir": {
-					"version": "1.0.2",
-					"bundled": true,
-					"optional": true
-				},
-				"os-tmpdir": {
-					"version": "1.0.2",
-					"bundled": true,
-					"optional": true
-				},
-				"osenv": {
-					"version": "0.1.4",
-					"bundled": true,
-					"optional": true,
-					"requires": {
-						"os-homedir": "1.0.2",
-						"os-tmpdir": "1.0.2"
-					}
-				},
-				"path-is-absolute": {
-					"version": "1.0.1",
-					"bundled": true
-				},
-				"performance-now": {
-					"version": "0.2.0",
-					"bundled": true,
-					"optional": true
-				},
-				"process-nextick-args": {
-					"version": "1.0.7",
-					"bundled": true
-				},
-				"punycode": {
-					"version": "1.4.1",
-					"bundled": true,
-					"optional": true
-				},
-				"qs": {
-					"version": "6.4.0",
-					"bundled": true,
-					"optional": true
-				},
-				"rc": {
-					"version": "1.2.1",
-					"bundled": true,
-					"optional": true,
-					"requires": {
-						"deep-extend": "0.4.2",
-						"ini": "1.3.4",
-						"minimist": "1.2.0",
-						"strip-json-comments": "2.0.1"
-					},
-					"dependencies": {
-						"minimist": {
-							"version": "1.2.0",
-							"bundled": true,
-							"optional": true
-						}
-					}
-				},
-				"readable-stream": {
-					"version": "2.2.9",
-					"bundled": true,
-					"requires": {
-						"buffer-shims": "1.0.0",
-						"core-util-is": "1.0.2",
-						"inherits": "2.0.3",
-						"isarray": "1.0.0",
-						"process-nextick-args": "1.0.7",
-						"string_decoder": "1.0.1",
-						"util-deprecate": "1.0.2"
-					}
-				},
-				"request": {
-					"version": "2.81.0",
-					"bundled": true,
-					"optional": true,
-					"requires": {
-						"aws-sign2": "0.6.0",
-						"aws4": "1.6.0",
-						"caseless": "0.12.0",
-						"combined-stream": "1.0.5",
-						"extend": "3.0.1",
-						"forever-agent": "0.6.1",
-						"form-data": "2.1.4",
-						"har-validator": "4.2.1",
-						"hawk": "3.1.3",
-						"http-signature": "1.1.1",
-						"is-typedarray": "1.0.0",
-						"isstream": "0.1.2",
-						"json-stringify-safe": "5.0.1",
-						"mime-types": "2.1.15",
-						"oauth-sign": "0.8.2",
-						"performance-now": "0.2.0",
-						"qs": "6.4.0",
-						"safe-buffer": "5.0.1",
-						"stringstream": "0.0.5",
-						"tough-cookie": "2.3.2",
-						"tunnel-agent": "0.6.0",
-						"uuid": "3.0.1"
-					}
-				},
-				"rimraf": {
-					"version": "2.6.1",
-					"bundled": true,
-					"requires": {
-						"glob": "7.1.2"
-					}
-				},
-				"safe-buffer": {
-					"version": "5.0.1",
-					"bundled": true
-				},
-				"semver": {
-					"version": "5.3.0",
-					"bundled": true,
-					"optional": true
-				},
-				"set-blocking": {
-					"version": "2.0.0",
-					"bundled": true,
-					"optional": true
-				},
-				"signal-exit": {
-					"version": "3.0.2",
-					"bundled": true,
-					"optional": true
-				},
-				"sntp": {
-					"version": "1.0.9",
-					"bundled": true,
-					"optional": true,
-					"requires": {
-						"hoek": "2.16.3"
-					}
-				},
-				"sshpk": {
-					"version": "1.13.0",
-					"bundled": true,
-					"optional": true,
-					"requires": {
-						"asn1": "0.2.3",
-						"assert-plus": "1.0.0",
-						"bcrypt-pbkdf": "1.0.1",
-						"dashdash": "1.14.1",
-						"ecc-jsbn": "0.1.1",
-						"getpass": "0.1.7",
-						"jodid25519": "1.0.2",
-						"jsbn": "0.1.1",
-						"tweetnacl": "0.14.5"
-					},
-					"dependencies": {
-						"assert-plus": {
-							"version": "1.0.0",
-							"bundled": true,
-							"optional": true
-						}
-					}
-				},
-				"string_decoder": {
-					"version": "1.0.1",
-					"bundled": true,
-					"requires": {
-						"safe-buffer": "5.0.1"
-					}
-				},
-				"string-width": {
-					"version": "1.0.2",
-					"bundled": true,
-					"requires": {
-						"code-point-at": "1.1.0",
-						"is-fullwidth-code-point": "1.0.0",
-						"strip-ansi": "3.0.1"
-					}
-				},
-				"stringstream": {
-					"version": "0.0.5",
-					"bundled": true,
-					"optional": true
-				},
-				"strip-ansi": {
-					"version": "3.0.1",
-					"bundled": true,
-					"requires": {
-						"ansi-regex": "2.1.1"
-					}
-				},
-				"strip-json-comments": {
-					"version": "2.0.1",
-					"bundled": true,
-					"optional": true
-				},
-				"tar": {
-					"version": "2.2.1",
-					"bundled": true,
-					"requires": {
-						"block-stream": "0.0.9",
-						"fstream": "1.0.11",
-						"inherits": "2.0.3"
-					}
-				},
-				"tar-pack": {
-					"version": "3.4.0",
-					"bundled": true,
-					"optional": true,
-					"requires": {
-						"debug": "2.6.8",
-						"fstream": "1.0.11",
-						"fstream-ignore": "1.0.5",
-						"once": "1.4.0",
-						"readable-stream": "2.2.9",
-						"rimraf": "2.6.1",
-						"tar": "2.2.1",
-						"uid-number": "0.0.6"
-					}
-				},
-				"tough-cookie": {
-					"version": "2.3.2",
-					"bundled": true,
-					"optional": true,
-					"requires": {
-						"punycode": "1.4.1"
-					}
-				},
-				"tunnel-agent": {
-					"version": "0.6.0",
-					"bundled": true,
-					"optional": true,
-					"requires": {
-						"safe-buffer": "5.0.1"
-					}
-				},
-				"tweetnacl": {
-					"version": "0.14.5",
-					"bundled": true,
-					"optional": true
-				},
-				"uid-number": {
-					"version": "0.0.6",
-					"bundled": true,
-					"optional": true
-				},
-				"util-deprecate": {
-					"version": "1.0.2",
-					"bundled": true
-				},
-				"uuid": {
-					"version": "3.0.1",
-					"bundled": true,
-					"optional": true
-				},
-				"verror": {
-					"version": "1.3.6",
-					"bundled": true,
-					"optional": true,
-					"requires": {
-						"extsprintf": "1.0.2"
-					}
-				},
-				"wide-align": {
-					"version": "1.1.2",
-					"bundled": true,
-					"optional": true,
-					"requires": {
-						"string-width": "1.0.2"
-					}
-				},
-				"wrappy": {
-					"version": "1.0.2",
-					"bundled": true
-				}
-			}
+			"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+			"dev": true
 		},
 		"function-bind": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.0.tgz",
-			"integrity": "sha1-FhdnFMgBeY5Ojyz391KUZ7tKV3E="
+			"integrity": "sha1-FhdnFMgBeY5Ojyz391KUZ7tKV3E=",
+			"dev": true
 		},
 		"generate-function": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz",
-			"integrity": "sha1-aFj+fAlpt9TpCTM3ZHrHn2DfvnQ="
+			"integrity": "sha1-aFj+fAlpt9TpCTM3ZHrHn2DfvnQ=",
+			"dev": true
 		},
 		"generate-object-property": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
 			"integrity": "sha1-nA4cQDCM6AT0eDYYuTf6iPmdUNA=",
+			"dev": true,
 			"requires": {
 				"is-property": "1.0.2"
 			}
@@ -2838,12 +2291,14 @@
 		"get-caller-file": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.2.tgz",
-			"integrity": "sha1-9wLmMSfn4jHBYKgMFVSstw1QR+U="
+			"integrity": "sha1-9wLmMSfn4jHBYKgMFVSstw1QR+U=",
+			"dev": true
 		},
 		"getpass": {
 			"version": "0.1.7",
 			"resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
 			"integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
+			"dev": true,
 			"requires": {
 				"assert-plus": "1.0.0"
 			},
@@ -2851,7 +2306,8 @@
 				"assert-plus": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-					"integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
+					"integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+					"dev": true
 				}
 			}
 		},
@@ -2859,6 +2315,7 @@
 			"version": "7.1.2",
 			"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
 			"integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+			"dev": true,
 			"requires": {
 				"fs.realpath": "1.0.0",
 				"inflight": "1.0.6",
@@ -2872,6 +2329,7 @@
 			"version": "0.3.0",
 			"resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz",
 			"integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
+			"dev": true,
 			"requires": {
 				"glob-parent": "2.0.0",
 				"is-glob": "2.0.1"
@@ -2881,6 +2339,7 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
 			"integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
+			"dev": true,
 			"requires": {
 				"is-glob": "2.0.1"
 			}
@@ -2888,12 +2347,14 @@
 		"globals": {
 			"version": "9.18.0",
 			"resolved": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz",
-			"integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ=="
+			"integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ==",
+			"dev": true
 		},
 		"globby": {
 			"version": "5.0.0",
 			"resolved": "https://registry.npmjs.org/globby/-/globby-5.0.0.tgz",
 			"integrity": "sha1-69hGZ8oNuzMLmbz8aOrCvFQ3Dg0=",
+			"dev": true,
 			"requires": {
 				"array-union": "1.0.2",
 				"arrify": "1.0.1",
@@ -2906,17 +2367,20 @@
 		"graceful-fs": {
 			"version": "4.1.11",
 			"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
-			"integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg="
+			"integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
+			"dev": true
 		},
 		"growly": {
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/growly/-/growly-1.3.0.tgz",
-			"integrity": "sha1-8QdIy+dq+WS3yWyTxrzCivEgwIE="
+			"integrity": "sha1-8QdIy+dq+WS3yWyTxrzCivEgwIE=",
+			"dev": true
 		},
 		"gzip-size": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/gzip-size/-/gzip-size-3.0.0.tgz",
 			"integrity": "sha1-VGGI6b3DN/Zzdy+BZgRks4nc5SA=",
+			"dev": true,
 			"requires": {
 				"duplexer": "0.1.1"
 			}
@@ -2925,6 +2389,7 @@
 			"version": "4.0.10",
 			"resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.10.tgz",
 			"integrity": "sha1-PTDHGLCaPZbyPqTMH0A8TTup/08=",
+			"dev": true,
 			"requires": {
 				"async": "1.5.2",
 				"optimist": "0.6.1",
@@ -2935,12 +2400,14 @@
 				"async": {
 					"version": "1.5.2",
 					"resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
-					"integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo="
+					"integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
+					"dev": true
 				},
 				"source-map": {
 					"version": "0.4.4",
 					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
 					"integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
+					"dev": true,
 					"requires": {
 						"amdefine": "1.0.1"
 					}
@@ -2950,12 +2417,14 @@
 		"har-schema": {
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/har-schema/-/har-schema-1.0.5.tgz",
-			"integrity": "sha1-0mMTX0MwfALGAq/I/pWXDAFRNp4="
+			"integrity": "sha1-0mMTX0MwfALGAq/I/pWXDAFRNp4=",
+			"dev": true
 		},
 		"har-validator": {
 			"version": "4.2.1",
 			"resolved": "https://registry.npmjs.org/har-validator/-/har-validator-4.2.1.tgz",
 			"integrity": "sha1-M0gdDxu/9gDdID11gSpqX7oALio=",
+			"dev": true,
 			"requires": {
 				"ajv": "4.11.8",
 				"har-schema": "1.0.5"
@@ -2965,6 +2434,7 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/has/-/has-1.0.1.tgz",
 			"integrity": "sha1-hGFzP1OLCDfJNh45qauelwTcLyg=",
+			"dev": true,
 			"requires": {
 				"function-bind": "1.1.0"
 			}
@@ -2973,6 +2443,7 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
 			"integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+			"dev": true,
 			"requires": {
 				"ansi-regex": "2.1.1"
 			}
@@ -2980,12 +2451,14 @@
 		"has-flag": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
-			"integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo="
+			"integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
+			"dev": true
 		},
 		"hawk": {
 			"version": "3.1.3",
 			"resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
 			"integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
+			"dev": true,
 			"requires": {
 				"boom": "2.10.1",
 				"cryptiles": "2.0.5",
@@ -3008,7 +2481,8 @@
 		"hoek": {
 			"version": "2.16.3",
 			"resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
-			"integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0="
+			"integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0=",
+			"dev": true
 		},
 		"hoist-non-react-statics": {
 			"version": "2.2.1",
@@ -3019,6 +2493,7 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-2.0.0.tgz",
 			"integrity": "sha1-42w/LSyufXRqhX440Y1fMqeILbg=",
+			"dev": true,
 			"requires": {
 				"os-homedir": "1.0.2",
 				"os-tmpdir": "1.0.2"
@@ -3027,12 +2502,14 @@
 		"hosted-git-info": {
 			"version": "2.5.0",
 			"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.5.0.tgz",
-			"integrity": "sha512-pNgbURSuab90KbTqvRPsseaTxOJCZBD0a7t+haSN33piP9cCM4l0CqdzAif2hUqm716UovKB2ROmiabGAKVXyg=="
+			"integrity": "sha512-pNgbURSuab90KbTqvRPsseaTxOJCZBD0a7t+haSN33piP9cCM4l0CqdzAif2hUqm716UovKB2ROmiabGAKVXyg==",
+			"dev": true
 		},
 		"html-encoding-sniffer": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-1.0.1.tgz",
 			"integrity": "sha1-eb96eF6klf5mFl5zQVPzY/9UN9o=",
+			"dev": true,
 			"requires": {
 				"whatwg-encoding": "1.0.1"
 			}
@@ -3041,6 +2518,7 @@
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
 			"integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
+			"dev": true,
 			"requires": {
 				"assert-plus": "0.2.0",
 				"jsprim": "1.4.1",
@@ -3055,17 +2533,20 @@
 		"ignore": {
 			"version": "3.3.3",
 			"resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.3.tgz",
-			"integrity": "sha1-QyNS5XrM2HqzEQ6C0/6g5HgSFW0="
+			"integrity": "sha1-QyNS5XrM2HqzEQ6C0/6g5HgSFW0=",
+			"dev": true
 		},
 		"imurmurhash": {
 			"version": "0.1.4",
 			"resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
-			"integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o="
+			"integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
+			"dev": true
 		},
 		"inflight": {
 			"version": "1.0.6",
 			"resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
 			"integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+			"dev": true,
 			"requires": {
 				"once": "1.4.0",
 				"wrappy": "1.0.2"
@@ -3074,12 +2555,14 @@
 		"inherits": {
 			"version": "2.0.3",
 			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-			"integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+			"integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+			"dev": true
 		},
 		"inquirer": {
 			"version": "0.12.0",
 			"resolved": "https://registry.npmjs.org/inquirer/-/inquirer-0.12.0.tgz",
 			"integrity": "sha1-HvK/1jUE3wvHV4X/+MLEHfEvB34=",
+			"dev": true,
 			"requires": {
 				"ansi-escapes": "1.4.0",
 				"ansi-regex": "2.1.1",
@@ -3099,7 +2582,8 @@
 		"interpret": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/interpret/-/interpret-1.0.3.tgz",
-			"integrity": "sha1-y8NcYu7uc/Gat7EKgBURQBr8D5A="
+			"integrity": "sha1-y8NcYu7uc/Gat7EKgBURQBr8D5A=",
+			"dev": true
 		},
 		"invariant": {
 			"version": "2.2.2",
@@ -3112,17 +2596,20 @@
 		"invert-kv": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
-			"integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY="
+			"integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY=",
+			"dev": true
 		},
 		"is-arrayish": {
 			"version": "0.2.1",
 			"resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
-			"integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0="
+			"integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
+			"dev": true
 		},
 		"is-binary-path": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
 			"integrity": "sha1-dfFmQrSA8YenEcgUFh/TpKdlWJg=",
+			"dev": true,
 			"optional": true,
 			"requires": {
 				"binary-extensions": "1.9.0"
@@ -3131,12 +2618,14 @@
 		"is-buffer": {
 			"version": "1.1.5",
 			"resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.5.tgz",
-			"integrity": "sha1-Hzsm72E7IUuIy8ojzGwB2Hlh7sw="
+			"integrity": "sha1-Hzsm72E7IUuIy8ojzGwB2Hlh7sw=",
+			"dev": true
 		},
 		"is-builtin-module": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
 			"integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
+			"dev": true,
 			"requires": {
 				"builtin-modules": "1.1.1"
 			}
@@ -3144,12 +2633,14 @@
 		"is-callable": {
 			"version": "1.1.3",
 			"resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.3.tgz",
-			"integrity": "sha1-hut1OSgF3cM69xySoO7fdO52BLI="
+			"integrity": "sha1-hut1OSgF3cM69xySoO7fdO52BLI=",
+			"dev": true
 		},
 		"is-ci": {
 			"version": "1.0.10",
 			"resolved": "https://registry.npmjs.org/is-ci/-/is-ci-1.0.10.tgz",
 			"integrity": "sha1-9zkzayYyNlBhqdSCcM1WrjNpMY4=",
+			"dev": true,
 			"requires": {
 				"ci-info": "1.0.0"
 			}
@@ -3157,17 +2648,20 @@
 		"is-date-object": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.1.tgz",
-			"integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY="
+			"integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY=",
+			"dev": true
 		},
 		"is-dotfile": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.3.tgz",
-			"integrity": "sha1-pqLzL/0t+wT1yiXs0Pa4PPeYoeE="
+			"integrity": "sha1-pqLzL/0t+wT1yiXs0Pa4PPeYoeE=",
+			"dev": true
 		},
 		"is-equal-shallow": {
 			"version": "0.1.3",
 			"resolved": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
 			"integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
+			"dev": true,
 			"requires": {
 				"is-primitive": "2.0.0"
 			}
@@ -3175,17 +2669,20 @@
 		"is-extendable": {
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
-			"integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik="
+			"integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik=",
+			"dev": true
 		},
 		"is-extglob": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-			"integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA="
+			"integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
+			"dev": true
 		},
 		"is-finite": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
 			"integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
+			"dev": true,
 			"requires": {
 				"number-is-nan": "1.0.1"
 			}
@@ -3194,6 +2691,7 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
 			"integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+			"dev": true,
 			"requires": {
 				"number-is-nan": "1.0.1"
 			}
@@ -3202,6 +2700,7 @@
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
 			"integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
+			"dev": true,
 			"requires": {
 				"is-extglob": "1.0.0"
 			}
@@ -3209,12 +2708,14 @@
 		"is-module": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/is-module/-/is-module-1.0.0.tgz",
-			"integrity": "sha1-Mlj7afeMFNW4FdZkM2tM/7ZEFZE="
+			"integrity": "sha1-Mlj7afeMFNW4FdZkM2tM/7ZEFZE=",
+			"dev": true
 		},
 		"is-my-json-valid": {
 			"version": "2.16.0",
 			"resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.16.0.tgz",
 			"integrity": "sha1-8Hndm/2uZe4gOKrorLyGqxCeNpM=",
+			"dev": true,
 			"requires": {
 				"generate-function": "2.0.0",
 				"generate-object-property": "1.2.0",
@@ -3226,6 +2727,7 @@
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
 			"integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
+			"dev": true,
 			"requires": {
 				"kind-of": "3.2.2"
 			}
@@ -3233,12 +2735,14 @@
 		"is-path-cwd": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/is-path-cwd/-/is-path-cwd-1.0.0.tgz",
-			"integrity": "sha1-0iXsIxMuie3Tj9p2dHLmLmXxEG0="
+			"integrity": "sha1-0iXsIxMuie3Tj9p2dHLmLmXxEG0=",
+			"dev": true
 		},
 		"is-path-in-cwd": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/is-path-in-cwd/-/is-path-in-cwd-1.0.0.tgz",
 			"integrity": "sha1-ZHdYK4IU1gI0YJRWcAO+ip6sBNw=",
+			"dev": true,
 			"requires": {
 				"is-path-inside": "1.0.0"
 			}
@@ -3247,6 +2751,7 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.0.tgz",
 			"integrity": "sha1-/AbloWg/vaE95mev9xe7wQpI838=",
+			"dev": true,
 			"requires": {
 				"path-is-inside": "1.0.2"
 			}
@@ -3254,22 +2759,26 @@
 		"is-posix-bracket": {
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz",
-			"integrity": "sha1-MzTceXdDaOkvAW5vvAqI9c1ua8Q="
+			"integrity": "sha1-MzTceXdDaOkvAW5vvAqI9c1ua8Q=",
+			"dev": true
 		},
 		"is-primitive": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz",
-			"integrity": "sha1-IHurkWOEmcB7Kt8kCkGochADRXU="
+			"integrity": "sha1-IHurkWOEmcB7Kt8kCkGochADRXU=",
+			"dev": true
 		},
 		"is-property": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
-			"integrity": "sha1-V/4cTkhHTt1lsJkR8msc1Ald2oQ="
+			"integrity": "sha1-V/4cTkhHTt1lsJkR8msc1Ald2oQ=",
+			"dev": true
 		},
 		"is-regex": {
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.4.tgz",
 			"integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
+			"dev": true,
 			"requires": {
 				"has": "1.0.1"
 			}
@@ -3278,6 +2787,7 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/is-resolvable/-/is-resolvable-1.0.0.tgz",
 			"integrity": "sha1-jfV8YeouPFAUCNEA+wE8+NbgzGI=",
+			"dev": true,
 			"requires": {
 				"tryit": "1.0.3"
 			}
@@ -3290,32 +2800,38 @@
 		"is-symbol": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.1.tgz",
-			"integrity": "sha1-PMWfAAJRlLarLjjbrmaJJWtmBXI="
+			"integrity": "sha1-PMWfAAJRlLarLjjbrmaJJWtmBXI=",
+			"dev": true
 		},
 		"is-typedarray": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-			"integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
+			"integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
+			"dev": true
 		},
 		"is-utf8": {
 			"version": "0.2.1",
 			"resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
-			"integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI="
+			"integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI=",
+			"dev": true
 		},
 		"isarray": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-			"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+			"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+			"dev": true
 		},
 		"isexe": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-			"integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
+			"integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
+			"dev": true
 		},
 		"isobject": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
 			"integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
+			"dev": true,
 			"requires": {
 				"isarray": "1.0.0"
 			}
@@ -3332,12 +2848,14 @@
 		"isstream": {
 			"version": "0.1.2",
 			"resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
-			"integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
+			"integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
+			"dev": true
 		},
 		"istanbul-api": {
 			"version": "1.1.11",
 			"resolved": "https://registry.npmjs.org/istanbul-api/-/istanbul-api-1.1.11.tgz",
 			"integrity": "sha1-/MC0YeKzvaceMFFVE4I4doJX2d4=",
+			"dev": true,
 			"requires": {
 				"async": "2.5.0",
 				"fileset": "2.0.3",
@@ -3355,12 +2873,14 @@
 		"istanbul-lib-coverage": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-1.1.1.tgz",
-			"integrity": "sha512-0+1vDkmzxqJIn5rcoEqapSB4DmPxE31EtI2dF2aCkV5esN9EWHxZ0dwgDClivMXJqE7zaYQxq30hj5L0nlTN5Q=="
+			"integrity": "sha512-0+1vDkmzxqJIn5rcoEqapSB4DmPxE31EtI2dF2aCkV5esN9EWHxZ0dwgDClivMXJqE7zaYQxq30hj5L0nlTN5Q==",
+			"dev": true
 		},
 		"istanbul-lib-hook": {
 			"version": "1.0.7",
 			"resolved": "https://registry.npmjs.org/istanbul-lib-hook/-/istanbul-lib-hook-1.0.7.tgz",
 			"integrity": "sha512-3U2HB9y1ZV9UmFlE12Fx+nPtFqIymzrqCksrXujm3NVbAZIJg/RfYgO1XiIa0mbmxTjWpVEVlkIZJ25xVIAfkQ==",
+			"dev": true,
 			"requires": {
 				"append-transform": "0.4.0"
 			}
@@ -3369,6 +2889,7 @@
 			"version": "1.7.4",
 			"resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-1.7.4.tgz",
 			"integrity": "sha1-6f2SDkdn89Ge3HZeLWs/XMvQ7qg=",
+			"dev": true,
 			"requires": {
 				"babel-generator": "6.25.0",
 				"babel-template": "6.25.0",
@@ -3383,6 +2904,7 @@
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-1.1.1.tgz",
 			"integrity": "sha512-tvF+YmCmH4thnez6JFX06ujIA19WPa9YUiwjc1uALF2cv5dmE3It8b5I8Ob7FHJ70H9Y5yF+TDkVa/mcADuw1Q==",
+			"dev": true,
 			"requires": {
 				"istanbul-lib-coverage": "1.1.1",
 				"mkdirp": "0.5.1",
@@ -3394,6 +2916,7 @@
 					"version": "3.2.3",
 					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
 					"integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
+					"dev": true,
 					"requires": {
 						"has-flag": "1.0.0"
 					}
@@ -3404,6 +2927,7 @@
 			"version": "1.2.1",
 			"resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-1.2.1.tgz",
 			"integrity": "sha512-mukVvSXCn9JQvdJl8wP/iPhqig0MRtuWuD4ZNKo6vB2Ik//AmhAKe3QnPN02dmkRe3lTudFk3rzoHhwU4hb94w==",
+			"dev": true,
 			"requires": {
 				"debug": "2.6.8",
 				"istanbul-lib-coverage": "1.1.1",
@@ -3416,6 +2940,7 @@
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-1.1.1.tgz",
 			"integrity": "sha512-P8G873A0kW24XRlxHVGhMJBhQ8gWAec+dae7ZxOBzxT4w+a9ATSPvRVK3LB1RAJ9S8bg2tOyWHAGW40Zd2dKfw==",
+			"dev": true,
 			"requires": {
 				"handlebars": "4.0.10"
 			}
@@ -3424,6 +2949,7 @@
 			"version": "20.0.4",
 			"resolved": "https://registry.npmjs.org/jest/-/jest-20.0.4.tgz",
 			"integrity": "sha1-PdJgwpidba1nix6cxNkZRPbWAqw=",
+			"dev": true,
 			"requires": {
 				"jest-cli": "20.0.4"
 			},
@@ -3431,12 +2957,14 @@
 				"callsites": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/callsites/-/callsites-2.0.0.tgz",
-					"integrity": "sha1-BuuE8A7qQT2oav/vrL/7Ngk7PFA="
+					"integrity": "sha1-BuuE8A7qQT2oav/vrL/7Ngk7PFA=",
+					"dev": true
 				},
 				"jest-cli": {
 					"version": "20.0.4",
 					"resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-20.0.4.tgz",
 					"integrity": "sha1-5TKxnYiuW8bEF+iwWTpv6VSx3JM=",
+					"dev": true,
 					"requires": {
 						"ansi-escapes": "1.4.0",
 						"callsites": "2.0.0",
@@ -3475,12 +3003,14 @@
 		"jest-changed-files": {
 			"version": "20.0.3",
 			"resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-20.0.3.tgz",
-			"integrity": "sha1-k5TVzGXEOEBhSb7xv01Sto4D4/g="
+			"integrity": "sha1-k5TVzGXEOEBhSb7xv01Sto4D4/g=",
+			"dev": true
 		},
 		"jest-config": {
 			"version": "20.0.4",
 			"resolved": "https://registry.npmjs.org/jest-config/-/jest-config-20.0.4.tgz",
 			"integrity": "sha1-43kwqyIXyRNgXv8T5712PsSPruo=",
+			"dev": true,
 			"requires": {
 				"chalk": "1.1.3",
 				"glob": "7.1.2",
@@ -3498,6 +3028,7 @@
 			"version": "20.0.3",
 			"resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-20.0.3.tgz",
 			"integrity": "sha1-gfKI/Z5nXw+yPHXxwrGURf5YZhc=",
+			"dev": true,
 			"requires": {
 				"chalk": "1.1.3",
 				"diff": "3.3.0",
@@ -3508,12 +3039,14 @@
 		"jest-docblock": {
 			"version": "20.0.3",
 			"resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-20.0.3.tgz",
-			"integrity": "sha1-F76phDQswz2DxQ++FUXqDvqkRxI="
+			"integrity": "sha1-F76phDQswz2DxQ++FUXqDvqkRxI=",
+			"dev": true
 		},
 		"jest-environment-jsdom": {
 			"version": "20.0.3",
 			"resolved": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-20.0.3.tgz",
 			"integrity": "sha1-BIqKwS7iJfcZBBdxODS7mZeH3pk=",
+			"dev": true,
 			"requires": {
 				"jest-mock": "20.0.3",
 				"jest-util": "20.0.3",
@@ -3524,6 +3057,7 @@
 			"version": "20.0.3",
 			"resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-20.0.3.tgz",
 			"integrity": "sha1-1Ii8RhKvLCRumG6K52caCZFj1AM=",
+			"dev": true,
 			"requires": {
 				"jest-mock": "20.0.3",
 				"jest-util": "20.0.3"
@@ -3533,6 +3067,7 @@
 			"version": "20.0.4",
 			"resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-20.0.4.tgz",
 			"integrity": "sha1-ZT61XIic48Ah97lGk/IKQVm63wM=",
+			"dev": true,
 			"requires": {
 				"fb-watchman": "2.0.0",
 				"graceful-fs": "4.1.11",
@@ -3546,6 +3081,7 @@
 			"version": "20.0.4",
 			"resolved": "https://registry.npmjs.org/jest-jasmine2/-/jest-jasmine2-20.0.4.tgz",
 			"integrity": "sha1-/MWxQReA2RHQQpAu8YWehS5g1eE=",
+			"dev": true,
 			"requires": {
 				"chalk": "1.1.3",
 				"graceful-fs": "4.1.11",
@@ -3562,6 +3098,7 @@
 			"version": "20.0.3",
 			"resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-20.0.3.tgz",
 			"integrity": "sha1-s6a443yld4A7CDKpixZPRLeBVhI=",
+			"dev": true,
 			"requires": {
 				"chalk": "1.1.3",
 				"pretty-format": "20.0.3"
@@ -3571,6 +3108,7 @@
 			"version": "20.0.3",
 			"resolved": "https://registry.npmjs.org/jest-matchers/-/jest-matchers-20.0.3.tgz",
 			"integrity": "sha1-ymnbHDLbWm9wf6XgQBq7VXAN/WA=",
+			"dev": true,
 			"requires": {
 				"jest-diff": "20.0.3",
 				"jest-matcher-utils": "20.0.3",
@@ -3582,6 +3120,7 @@
 			"version": "20.0.3",
 			"resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-20.0.3.tgz",
 			"integrity": "sha1-auwoRDBvyw5udNV5bBAG2W/dgxw=",
+			"dev": true,
 			"requires": {
 				"chalk": "1.1.3",
 				"micromatch": "2.3.11",
@@ -3591,17 +3130,20 @@
 		"jest-mock": {
 			"version": "20.0.3",
 			"resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-20.0.3.tgz",
-			"integrity": "sha1-i8Bw6QQUqhVcEajWTIaaDVxx2lk="
+			"integrity": "sha1-i8Bw6QQUqhVcEajWTIaaDVxx2lk=",
+			"dev": true
 		},
 		"jest-regex-util": {
 			"version": "20.0.3",
 			"resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-20.0.3.tgz",
-			"integrity": "sha1-hburXRM+RGJbGfr4xqpRItCF12I="
+			"integrity": "sha1-hburXRM+RGJbGfr4xqpRItCF12I=",
+			"dev": true
 		},
 		"jest-resolve": {
 			"version": "20.0.4",
 			"resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-20.0.4.tgz",
 			"integrity": "sha1-lEiz6La6/BVHlETGSZBFt//ll6U=",
+			"dev": true,
 			"requires": {
 				"browser-resolve": "1.11.2",
 				"is-builtin-module": "1.0.0",
@@ -3612,6 +3154,7 @@
 			"version": "20.0.3",
 			"resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-20.0.3.tgz",
 			"integrity": "sha1-bhSntxevDyyzZnxUneQK8Bexcjo=",
+			"dev": true,
 			"requires": {
 				"jest-regex-util": "20.0.3"
 			}
@@ -3620,6 +3163,7 @@
 			"version": "20.0.4",
 			"resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-20.0.4.tgz",
 			"integrity": "sha1-osgCIZxCA/dU3xQE5JAYYWnRJNg=",
+			"dev": true,
 			"requires": {
 				"babel-core": "6.25.0",
 				"babel-jest": "20.0.3",
@@ -3642,6 +3186,7 @@
 			"version": "20.0.3",
 			"resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-20.0.3.tgz",
 			"integrity": "sha1-W4R+GtsaTZCFKn+fElCG4YfHZWY=",
+			"dev": true,
 			"requires": {
 				"chalk": "1.1.3",
 				"jest-diff": "20.0.3",
@@ -3655,6 +3200,7 @@
 			"version": "20.0.3",
 			"resolved": "https://registry.npmjs.org/jest-util/-/jest-util-20.0.3.tgz",
 			"integrity": "sha1-DAf32A2C9OWmfG+LnD/n9lz9Mq0=",
+			"dev": true,
 			"requires": {
 				"chalk": "1.1.3",
 				"graceful-fs": "4.1.11",
@@ -3669,6 +3215,7 @@
 			"version": "20.0.3",
 			"resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-20.0.3.tgz",
 			"integrity": "sha1-0M/R3k9XnymEhJJcKA+PHZTsPKs=",
+			"dev": true,
 			"requires": {
 				"chalk": "1.1.3",
 				"jest-matcher-utils": "20.0.3",
@@ -3685,6 +3232,7 @@
 			"version": "3.9.1",
 			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.9.1.tgz",
 			"integrity": "sha512-CbcG379L1e+mWBnLvHWWeLs8GyV/EMw862uLI3c+GxVyDHWZcjZinwuBd3iW2pgxgIlksW/1vNJa4to+RvDOww==",
+			"dev": true,
 			"requires": {
 				"argparse": "1.0.9",
 				"esprima": "4.0.0"
@@ -3694,12 +3242,14 @@
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
 			"integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
+			"dev": true,
 			"optional": true
 		},
 		"jsdom": {
 			"version": "9.12.0",
 			"resolved": "https://registry.npmjs.org/jsdom/-/jsdom-9.12.0.tgz",
 			"integrity": "sha1-6MVG//ywbADUgzyoRBD+1/igl9Q=",
+			"dev": true,
 			"requires": {
 				"abab": "1.0.3",
 				"acorn": "4.0.13",
@@ -3725,24 +3275,28 @@
 				"acorn": {
 					"version": "4.0.13",
 					"resolved": "https://registry.npmjs.org/acorn/-/acorn-4.0.13.tgz",
-					"integrity": "sha1-EFSVrlNh1pe9GVyCUZLhrX8lN4c="
+					"integrity": "sha1-EFSVrlNh1pe9GVyCUZLhrX8lN4c=",
+					"dev": true
 				}
 			}
 		},
 		"jsesc": {
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/jsesc/-/jsesc-1.3.0.tgz",
-			"integrity": "sha1-RsP+yMGJKxKwgz25vHYiF226s0s="
+			"integrity": "sha1-RsP+yMGJKxKwgz25vHYiF226s0s=",
+			"dev": true
 		},
 		"json-schema": {
 			"version": "0.2.3",
 			"resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
-			"integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM="
+			"integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
+			"dev": true
 		},
 		"json-stable-stringify": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
 			"integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
+			"dev": true,
 			"requires": {
 				"jsonify": "0.0.0"
 			}
@@ -3750,27 +3304,32 @@
 		"json-stringify-safe": {
 			"version": "5.0.1",
 			"resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-			"integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
+			"integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
+			"dev": true
 		},
 		"json5": {
 			"version": "0.5.1",
 			"resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
-			"integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE="
+			"integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE=",
+			"dev": true
 		},
 		"jsonify": {
 			"version": "0.0.0",
 			"resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
-			"integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM="
+			"integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=",
+			"dev": true
 		},
 		"jsonpointer": {
 			"version": "4.0.1",
 			"resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-4.0.1.tgz",
-			"integrity": "sha1-T9kss04OnbPInIYi7PUfm5eMbLk="
+			"integrity": "sha1-T9kss04OnbPInIYi7PUfm5eMbLk=",
+			"dev": true
 		},
 		"jsprim": {
 			"version": "1.4.1",
 			"resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
 			"integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
+			"dev": true,
 			"requires": {
 				"assert-plus": "1.0.0",
 				"extsprintf": "1.3.0",
@@ -3781,19 +3340,22 @@
 				"assert-plus": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-					"integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
+					"integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+					"dev": true
 				}
 			}
 		},
 		"jsx-ast-utils": {
 			"version": "1.4.1",
 			"resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-1.4.1.tgz",
-			"integrity": "sha1-OGchPo3Xm/Ho8jAMDPwe+xgsDfE="
+			"integrity": "sha1-OGchPo3Xm/Ho8jAMDPwe+xgsDfE=",
+			"dev": true
 		},
 		"kind-of": {
 			"version": "3.2.2",
 			"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
 			"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+			"dev": true,
 			"requires": {
 				"is-buffer": "1.1.5"
 			}
@@ -3802,12 +3364,14 @@
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz",
 			"integrity": "sha1-odePw6UEdMuAhF07O24dpJpEbo4=",
+			"dev": true,
 			"optional": true
 		},
 		"lcid": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
 			"integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
+			"dev": true,
 			"requires": {
 				"invert-kv": "1.0.0"
 			}
@@ -3815,12 +3379,14 @@
 		"leven": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/leven/-/leven-2.1.0.tgz",
-			"integrity": "sha1-wuep93IJTe6dNCAq6KzORoeHVYA="
+			"integrity": "sha1-wuep93IJTe6dNCAq6KzORoeHVYA=",
+			"dev": true
 		},
 		"levn": {
 			"version": "0.3.0",
 			"resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
 			"integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
+			"dev": true,
 			"requires": {
 				"prelude-ls": "1.1.2",
 				"type-check": "0.3.2"
@@ -3830,6 +3396,7 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
 			"integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
+			"dev": true,
 			"requires": {
 				"graceful-fs": "4.1.11",
 				"parse-json": "2.2.0",
@@ -3841,6 +3408,7 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
 			"integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
+			"dev": true,
 			"requires": {
 				"p-locate": "2.0.0",
 				"path-exists": "3.0.0"
@@ -3849,34 +3417,40 @@
 				"path-exists": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
-					"integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU="
+					"integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
+					"dev": true
 				}
 			}
 		},
 		"lodash": {
 			"version": "4.17.4",
 			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
-			"integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4="
+			"integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4=",
+			"dev": true
 		},
 		"lodash.assign": {
 			"version": "4.2.0",
 			"resolved": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-4.2.0.tgz",
-			"integrity": "sha1-DZnzzNem0mHRm9rrkkUAXShYCOc="
+			"integrity": "sha1-DZnzzNem0mHRm9rrkkUAXShYCOc=",
+			"dev": true
 		},
 		"lodash.cond": {
 			"version": "4.5.2",
 			"resolved": "https://registry.npmjs.org/lodash.cond/-/lodash.cond-4.5.2.tgz",
-			"integrity": "sha1-9HGh2khr5g9quVXRcRVSPdHSVdU="
+			"integrity": "sha1-9HGh2khr5g9quVXRcRVSPdHSVdU=",
+			"dev": true
 		},
 		"lodash.pickby": {
 			"version": "4.6.0",
 			"resolved": "https://registry.npmjs.org/lodash.pickby/-/lodash.pickby-4.6.0.tgz",
-			"integrity": "sha1-feoh2MGNdwOifHBMFdO4SmfjOv8="
+			"integrity": "sha1-feoh2MGNdwOifHBMFdO4SmfjOv8=",
+			"dev": true
 		},
 		"longest": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
-			"integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc="
+			"integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc=",
+			"dev": true
 		},
 		"loose-envify": {
 			"version": "1.3.1",
@@ -3887,9 +3461,10 @@
 			}
 		},
 		"magic-string": {
-			"version": "0.19.1",
-			"resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.19.1.tgz",
-			"integrity": "sha1-FNdoATyvLsj96hakmvgvw3fnUgE=",
+			"version": "0.22.4",
+			"resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.22.4.tgz",
+			"integrity": "sha512-kxBL06p6iO2qPBHsqGK2b3cRwiRGpnmSuVWNhwHcMX7qJOUr1HvricYP1LZOCdkQBUp0jiWg2d6WJwR3vYgByw==",
+			"dev": true,
 			"requires": {
 				"vlq": "0.2.2"
 			}
@@ -3898,6 +3473,7 @@
 			"version": "1.0.11",
 			"resolved": "https://registry.npmjs.org/makeerror/-/makeerror-1.0.11.tgz",
 			"integrity": "sha1-4BpckQnyr3lmDk6LlYd5AYT1qWw=",
+			"dev": true,
 			"requires": {
 				"tmpl": "1.0.4"
 			}
@@ -3905,12 +3481,14 @@
 		"merge": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/merge/-/merge-1.2.0.tgz",
-			"integrity": "sha1-dTHjnUlJwoGma4xabgJl6LBYlNo="
+			"integrity": "sha1-dTHjnUlJwoGma4xabgJl6LBYlNo=",
+			"dev": true
 		},
 		"micromatch": {
 			"version": "2.3.11",
 			"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
 			"integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
+			"dev": true,
 			"requires": {
 				"arr-diff": "2.0.0",
 				"array-unique": "0.2.1",
@@ -3930,12 +3508,14 @@
 		"mime-db": {
 			"version": "1.29.0",
 			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.29.0.tgz",
-			"integrity": "sha1-SNJtI1WJZRcErFkWygYAGRQmaHg="
+			"integrity": "sha1-SNJtI1WJZRcErFkWygYAGRQmaHg=",
+			"dev": true
 		},
 		"mime-types": {
 			"version": "2.1.16",
 			"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.16.tgz",
 			"integrity": "sha1-K4WKUuXs1RbbiXrCvodIeDBpjiM=",
+			"dev": true,
 			"requires": {
 				"mime-db": "1.29.0"
 			}
@@ -3944,6 +3524,7 @@
 			"version": "3.0.4",
 			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
 			"integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+			"dev": true,
 			"requires": {
 				"brace-expansion": "1.1.8"
 			}
@@ -3951,12 +3532,14 @@
 		"minimist": {
 			"version": "0.0.8",
 			"resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-			"integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
+			"integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+			"dev": true
 		},
 		"mkdirp": {
 			"version": "0.5.1",
 			"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
 			"integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+			"dev": true,
 			"requires": {
 				"minimist": "0.0.8"
 			}
@@ -3964,23 +3547,20 @@
 		"ms": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-			"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+			"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+			"dev": true
 		},
 		"mute-stream": {
 			"version": "0.0.5",
 			"resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.5.tgz",
-			"integrity": "sha1-j7+rsKmKJT0xhDMfno3rc3L6xsA="
-		},
-		"nan": {
-			"version": "2.6.2",
-			"resolved": "https://registry.npmjs.org/nan/-/nan-2.6.2.tgz",
-			"integrity": "sha1-5P805slf37WuzAjeZZb0NgWn20U=",
-			"optional": true
+			"integrity": "sha1-j7+rsKmKJT0xhDMfno3rc3L6xsA=",
+			"dev": true
 		},
 		"natural-compare": {
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
-			"integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc="
+			"integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
+			"dev": true
 		},
 		"node-fetch": {
 			"version": "1.7.1",
@@ -3994,12 +3574,14 @@
 		"node-int64": {
 			"version": "0.4.0",
 			"resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
-			"integrity": "sha1-h6kGXNs1XTGC2PlM4RGIuCXGijs="
+			"integrity": "sha1-h6kGXNs1XTGC2PlM4RGIuCXGijs=",
+			"dev": true
 		},
 		"node-notifier": {
 			"version": "5.1.2",
 			"resolved": "https://registry.npmjs.org/node-notifier/-/node-notifier-5.1.2.tgz",
 			"integrity": "sha1-L6nhJgX6EACdRFSdb82KY93g5P8=",
+			"dev": true,
 			"requires": {
 				"growly": "1.3.0",
 				"semver": "5.4.1",
@@ -4011,6 +3593,7 @@
 			"version": "2.4.0",
 			"resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
 			"integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
+			"dev": true,
 			"requires": {
 				"hosted-git-info": "2.5.0",
 				"is-builtin-module": "1.0.0",
@@ -4022,6 +3605,7 @@
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
 			"integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
+			"dev": true,
 			"requires": {
 				"remove-trailing-separator": "1.0.2"
 			}
@@ -4029,17 +3613,20 @@
 		"number-is-nan": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-			"integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
+			"integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
+			"dev": true
 		},
 		"nwmatcher": {
 			"version": "1.4.1",
 			"resolved": "https://registry.npmjs.org/nwmatcher/-/nwmatcher-1.4.1.tgz",
-			"integrity": "sha1-eumwew6oBNt+JfBctf5Al9TklJ8="
+			"integrity": "sha1-eumwew6oBNt+JfBctf5Al9TklJ8=",
+			"dev": true
 		},
 		"oauth-sign": {
 			"version": "0.8.2",
 			"resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
-			"integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM="
+			"integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM=",
+			"dev": true
 		},
 		"object-assign": {
 			"version": "4.1.1",
@@ -4049,12 +3636,14 @@
 		"object-keys": {
 			"version": "1.0.11",
 			"resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.0.11.tgz",
-			"integrity": "sha1-xUYBd4rVYPEULODgG8yotW0TQm0="
+			"integrity": "sha1-xUYBd4rVYPEULODgG8yotW0TQm0=",
+			"dev": true
 		},
 		"object.assign": {
 			"version": "4.0.4",
 			"resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.0.4.tgz",
 			"integrity": "sha1-scnMBE7xuf5jYG/BQau7MuFHMMw=",
+			"dev": true,
 			"requires": {
 				"define-properties": "1.1.2",
 				"function-bind": "1.1.0",
@@ -4065,6 +3654,7 @@
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
 			"integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
+			"dev": true,
 			"requires": {
 				"for-own": "0.1.5",
 				"is-extendable": "0.1.1"
@@ -4074,6 +3664,7 @@
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
 			"integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+			"dev": true,
 			"requires": {
 				"wrappy": "1.0.2"
 			}
@@ -4081,12 +3672,14 @@
 		"onetime": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
-			"integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k="
+			"integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k=",
+			"dev": true
 		},
 		"optimist": {
 			"version": "0.6.1",
 			"resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
 			"integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
+			"dev": true,
 			"requires": {
 				"minimist": "0.0.8",
 				"wordwrap": "0.0.3"
@@ -4095,7 +3688,8 @@
 				"wordwrap": {
 					"version": "0.0.3",
 					"resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
-					"integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc="
+					"integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc=",
+					"dev": true
 				}
 			}
 		},
@@ -4103,6 +3697,7 @@
 			"version": "0.8.2",
 			"resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
 			"integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
+			"dev": true,
 			"requires": {
 				"deep-is": "0.1.3",
 				"fast-levenshtein": "2.0.6",
@@ -4115,12 +3710,14 @@
 		"os-homedir": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
-			"integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M="
+			"integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
+			"dev": true
 		},
 		"os-locale": {
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
 			"integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
+			"dev": true,
 			"requires": {
 				"lcid": "1.0.0"
 			}
@@ -4128,12 +3725,14 @@
 		"os-tmpdir": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
-			"integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ="
+			"integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
+			"dev": true
 		},
 		"output-file-sync": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/output-file-sync/-/output-file-sync-1.1.2.tgz",
 			"integrity": "sha1-0KM+7+YaIF+suQCS6CZZjVJFznY=",
+			"dev": true,
 			"requires": {
 				"graceful-fs": "4.1.11",
 				"mkdirp": "0.5.1",
@@ -4143,12 +3742,14 @@
 		"p-limit": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.1.0.tgz",
-			"integrity": "sha1-sH/y2aXYi+yAYDWJWiurZqJ5iLw="
+			"integrity": "sha1-sH/y2aXYi+yAYDWJWiurZqJ5iLw=",
+			"dev": true
 		},
 		"p-locate": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
 			"integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
+			"dev": true,
 			"requires": {
 				"p-limit": "1.1.0"
 			}
@@ -4156,12 +3757,14 @@
 		"p-map": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/p-map/-/p-map-1.1.1.tgz",
-			"integrity": "sha1-BfXkrpegaDcbwqXMhr+9vBnErno="
+			"integrity": "sha1-BfXkrpegaDcbwqXMhr+9vBnErno=",
+			"dev": true
 		},
 		"parse-glob": {
 			"version": "3.0.4",
 			"resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
 			"integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
+			"dev": true,
 			"requires": {
 				"glob-base": "0.3.0",
 				"is-dotfile": "1.0.3",
@@ -4173,6 +3776,7 @@
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
 			"integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
+			"dev": true,
 			"requires": {
 				"error-ex": "1.3.1"
 			}
@@ -4180,12 +3784,14 @@
 		"parse5": {
 			"version": "1.5.1",
 			"resolved": "https://registry.npmjs.org/parse5/-/parse5-1.5.1.tgz",
-			"integrity": "sha1-m387DeMr543CQBsXVzzK8Pb1nZQ="
+			"integrity": "sha1-m387DeMr543CQBsXVzzK8Pb1nZQ=",
+			"dev": true
 		},
 		"path-exists": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
 			"integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
+			"dev": true,
 			"requires": {
 				"pinkie-promise": "2.0.1"
 			}
@@ -4193,17 +3799,20 @@
 		"path-is-absolute": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-			"integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
+			"integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+			"dev": true
 		},
 		"path-is-inside": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.2.tgz",
-			"integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM="
+			"integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM=",
+			"dev": true
 		},
 		"path-parse": {
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.5.tgz",
-			"integrity": "sha1-PBrfhx6pzWyUMbbqK9dKD/BVxME="
+			"integrity": "sha1-PBrfhx6pzWyUMbbqK9dKD/BVxME=",
+			"dev": true
 		},
 		"path-to-regexp": {
 			"version": "1.7.0",
@@ -4224,6 +3833,7 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/path-type/-/path-type-2.0.0.tgz",
 			"integrity": "sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM=",
+			"dev": true,
 			"requires": {
 				"pify": "2.3.0"
 			}
@@ -4231,22 +3841,26 @@
 		"performance-now": {
 			"version": "0.2.0",
 			"resolved": "https://registry.npmjs.org/performance-now/-/performance-now-0.2.0.tgz",
-			"integrity": "sha1-M+8wxcd9TqIcWlOGnZG1bY8lVeU="
+			"integrity": "sha1-M+8wxcd9TqIcWlOGnZG1bY8lVeU=",
+			"dev": true
 		},
 		"pify": {
 			"version": "2.3.0",
 			"resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-			"integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
+			"integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+			"dev": true
 		},
 		"pinkie": {
 			"version": "2.0.4",
 			"resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
-			"integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA="
+			"integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
+			"dev": true
 		},
 		"pinkie-promise": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
 			"integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
+			"dev": true,
 			"requires": {
 				"pinkie": "2.0.4"
 			}
@@ -4255,6 +3869,7 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-1.0.0.tgz",
 			"integrity": "sha1-ektQio1bstYp1EcFb/TpyTFM89Q=",
+			"dev": true,
 			"requires": {
 				"find-up": "1.1.2"
 			}
@@ -4262,22 +3877,26 @@
 		"pluralize": {
 			"version": "1.2.1",
 			"resolved": "https://registry.npmjs.org/pluralize/-/pluralize-1.2.1.tgz",
-			"integrity": "sha1-0aIUg/0iu0HlihL6NCGCMUCJfEU="
+			"integrity": "sha1-0aIUg/0iu0HlihL6NCGCMUCJfEU=",
+			"dev": true
 		},
 		"prelude-ls": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
-			"integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ="
+			"integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
+			"dev": true
 		},
 		"preserve": {
 			"version": "0.2.0",
 			"resolved": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz",
-			"integrity": "sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks="
+			"integrity": "sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks=",
+			"dev": true
 		},
 		"pretty-bytes": {
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-3.0.1.tgz",
 			"integrity": "sha1-J9AAjXeAY6C0gRuzXHnxvV1fvM8=",
+			"dev": true,
 			"requires": {
 				"number-is-nan": "1.0.1"
 			}
@@ -4286,6 +3905,7 @@
 			"version": "20.0.3",
 			"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-20.0.3.tgz",
 			"integrity": "sha1-Ag41ClYKH+GpjcO+tsz/s4beixQ=",
+			"dev": true,
 			"requires": {
 				"ansi-regex": "2.1.1",
 				"ansi-styles": "3.2.0"
@@ -4295,6 +3915,7 @@
 					"version": "3.2.0",
 					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
 					"integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+					"dev": true,
 					"requires": {
 						"color-convert": "1.9.0"
 					}
@@ -4304,17 +3925,20 @@
 		"private": {
 			"version": "0.1.7",
 			"resolved": "https://registry.npmjs.org/private/-/private-0.1.7.tgz",
-			"integrity": "sha1-aM5eih7woju1cMwoU3tTMqumPvE="
+			"integrity": "sha1-aM5eih7woju1cMwoU3tTMqumPvE=",
+			"dev": true
 		},
 		"process-nextick-args": {
 			"version": "1.0.7",
 			"resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
-			"integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M="
+			"integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M=",
+			"dev": true
 		},
 		"progress": {
 			"version": "1.1.8",
 			"resolved": "https://registry.npmjs.org/progress/-/progress-1.1.8.tgz",
-			"integrity": "sha1-4mDHj2Fhzdmw5WzD4Khd4Xx6V74="
+			"integrity": "sha1-4mDHj2Fhzdmw5WzD4Khd4Xx6V74=",
+			"dev": true
 		},
 		"promise": {
 			"version": "7.3.1",
@@ -4336,22 +3960,26 @@
 		"prr": {
 			"version": "0.0.0",
 			"resolved": "https://registry.npmjs.org/prr/-/prr-0.0.0.tgz",
-			"integrity": "sha1-GoS4WQgyVQFBGFPQCB7j+obikmo="
+			"integrity": "sha1-GoS4WQgyVQFBGFPQCB7j+obikmo=",
+			"dev": true
 		},
 		"punycode": {
 			"version": "1.4.1",
 			"resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
-			"integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
+			"integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
+			"dev": true
 		},
 		"qs": {
 			"version": "6.4.0",
 			"resolved": "https://registry.npmjs.org/qs/-/qs-6.4.0.tgz",
-			"integrity": "sha1-E+JtKK1rD/qpExLNO/cI7TUecjM="
+			"integrity": "sha1-E+JtKK1rD/qpExLNO/cI7TUecjM=",
+			"dev": true
 		},
 		"randomatic": {
 			"version": "1.1.7",
 			"resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.7.tgz",
 			"integrity": "sha512-D5JUjPyJbaJDkuAazpVnSfVkLlpeO3wDlPROTMLGKG1zMFNFRgrciKo1ltz/AzNTkqE0HzDx655QOL51N06how==",
+			"dev": true,
 			"requires": {
 				"is-number": "3.0.0",
 				"kind-of": "4.0.0"
@@ -4361,6 +3989,7 @@
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
 					"integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+					"dev": true,
 					"requires": {
 						"kind-of": "3.2.2"
 					},
@@ -4369,6 +3998,7 @@
 							"version": "3.2.2",
 							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
 							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+							"dev": true,
 							"requires": {
 								"is-buffer": "1.1.5"
 							}
@@ -4379,6 +4009,7 @@
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
 					"integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
+					"dev": true,
 					"requires": {
 						"is-buffer": "1.1.5"
 					}
@@ -4389,6 +4020,7 @@
 			"version": "15.6.1",
 			"resolved": "https://registry.npmjs.org/react/-/react-15.6.1.tgz",
 			"integrity": "sha1-uqhDTsZ4C96ZfNw4C3nNM7ljk98=",
+			"dev": true,
 			"requires": {
 				"create-react-class": "15.6.0",
 				"fbjs": "0.8.14",
@@ -4400,12 +4032,14 @@
 		"react-addons-test-utils": {
 			"version": "15.6.0",
 			"resolved": "https://registry.npmjs.org/react-addons-test-utils/-/react-addons-test-utils-15.6.0.tgz",
-			"integrity": "sha1-Bi02EX/o0Y87peBuszODsLhepbk="
+			"integrity": "sha1-Bi02EX/o0Y87peBuszODsLhepbk=",
+			"dev": true
 		},
 		"react-dom": {
 			"version": "15.6.1",
 			"resolved": "https://registry.npmjs.org/react-dom/-/react-dom-15.6.1.tgz",
 			"integrity": "sha1-LLDtQZEDjlPCCes6eaI+Kkz5lHA=",
+			"dev": true,
 			"requires": {
 				"fbjs": "0.8.14",
 				"loose-envify": "1.3.1",
@@ -4417,6 +4051,7 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-2.0.0.tgz",
 			"integrity": "sha1-jvHAYjxqbbDcZxPEv6xGMysjaPg=",
+			"dev": true,
 			"requires": {
 				"load-json-file": "2.0.0",
 				"normalize-package-data": "2.4.0",
@@ -4427,6 +4062,7 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-2.0.0.tgz",
 			"integrity": "sha1-a3KoBImE4MQeeVEP1en6mbO1Sb4=",
+			"dev": true,
 			"requires": {
 				"find-up": "2.1.0",
 				"read-pkg": "2.0.0"
@@ -4436,6 +4072,7 @@
 					"version": "2.1.0",
 					"resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
 					"integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+					"dev": true,
 					"requires": {
 						"locate-path": "2.0.0"
 					}
@@ -4446,6 +4083,7 @@
 			"version": "2.3.3",
 			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
 			"integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
+			"dev": true,
 			"requires": {
 				"core-util-is": "1.0.2",
 				"inherits": "2.0.3",
@@ -4460,6 +4098,7 @@
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/readdirp/-/readdirp-2.1.0.tgz",
 			"integrity": "sha1-TtCtBg3zBzMAxIRANz9y0cxkLXg=",
+			"dev": true,
 			"optional": true,
 			"requires": {
 				"graceful-fs": "4.1.11",
@@ -4472,6 +4111,7 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/readline2/-/readline2-1.0.1.tgz",
 			"integrity": "sha1-QQWWCP/BVHV7cV2ZidGZ/783LjU=",
+			"dev": true,
 			"requires": {
 				"code-point-at": "1.1.0",
 				"is-fullwidth-code-point": "1.0.0",
@@ -4482,6 +4122,7 @@
 			"version": "0.6.2",
 			"resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
 			"integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
+			"dev": true,
 			"requires": {
 				"resolve": "1.4.0"
 			}
@@ -4489,17 +4130,20 @@
 		"regenerate": {
 			"version": "1.3.2",
 			"resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.3.2.tgz",
-			"integrity": "sha1-0ZQcZ7rUN+G+dkM63Vs4X5WxkmA="
+			"integrity": "sha1-0ZQcZ7rUN+G+dkM63Vs4X5WxkmA=",
+			"dev": true
 		},
 		"regenerator-runtime": {
 			"version": "0.10.5",
 			"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz",
-			"integrity": "sha1-M2w+/BIgrc7dosn6tntaeVWjNlg="
+			"integrity": "sha1-M2w+/BIgrc7dosn6tntaeVWjNlg=",
+			"dev": true
 		},
 		"regenerator-transform": {
 			"version": "0.9.11",
 			"resolved": "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.9.11.tgz",
 			"integrity": "sha1-On0GdSDLe3F2dp61/4aGkb7+EoM=",
+			"dev": true,
 			"requires": {
 				"babel-runtime": "6.25.0",
 				"babel-types": "6.25.0",
@@ -4510,6 +4154,7 @@
 			"version": "0.4.3",
 			"resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.3.tgz",
 			"integrity": "sha1-mxpsNdTQ3871cRrmUejp09cRQUU=",
+			"dev": true,
 			"requires": {
 				"is-equal-shallow": "0.1.3",
 				"is-primitive": "2.0.0"
@@ -4519,6 +4164,7 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-2.0.0.tgz",
 			"integrity": "sha1-SdA4g3uNz4v6W5pCE5k45uoq4kA=",
+			"dev": true,
 			"requires": {
 				"regenerate": "1.3.2",
 				"regjsgen": "0.2.0",
@@ -4528,12 +4174,14 @@
 		"regjsgen": {
 			"version": "0.2.0",
 			"resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.2.0.tgz",
-			"integrity": "sha1-bAFq3qxVT3WCP+N6wFuS1aTtsfc="
+			"integrity": "sha1-bAFq3qxVT3WCP+N6wFuS1aTtsfc=",
+			"dev": true
 		},
 		"regjsparser": {
 			"version": "0.1.5",
 			"resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.1.5.tgz",
 			"integrity": "sha1-fuj4Tcb6eS0/0K4ijSS9lJ6tIFw=",
+			"dev": true,
 			"requires": {
 				"jsesc": "0.5.0"
 			},
@@ -4541,29 +4189,34 @@
 				"jsesc": {
 					"version": "0.5.0",
 					"resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
-					"integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0="
+					"integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0=",
+					"dev": true
 				}
 			}
 		},
 		"remove-trailing-separator": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.0.2.tgz",
-			"integrity": "sha1-abBi2XhyetFNxrVrpKt3L9jXBRE="
+			"integrity": "sha1-abBi2XhyetFNxrVrpKt3L9jXBRE=",
+			"dev": true
 		},
 		"repeat-element": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz",
-			"integrity": "sha1-7wiaF40Ug7quTZPrmLT55OEdmQo="
+			"integrity": "sha1-7wiaF40Ug7quTZPrmLT55OEdmQo=",
+			"dev": true
 		},
 		"repeat-string": {
 			"version": "1.6.1",
 			"resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
-			"integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc="
+			"integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
+			"dev": true
 		},
 		"repeating": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
 			"integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
+			"dev": true,
 			"requires": {
 				"is-finite": "1.0.2"
 			}
@@ -4572,6 +4225,7 @@
 			"version": "2.81.0",
 			"resolved": "https://registry.npmjs.org/request/-/request-2.81.0.tgz",
 			"integrity": "sha1-xpKJRqDgbF+Nb4qTM0af/aRimKA=",
+			"dev": true,
 			"requires": {
 				"aws-sign2": "0.6.0",
 				"aws4": "1.6.0",
@@ -4600,17 +4254,20 @@
 		"require-directory": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
-			"integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I="
+			"integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
+			"dev": true
 		},
 		"require-main-filename": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
-			"integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE="
+			"integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE=",
+			"dev": true
 		},
 		"require-uncached": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/require-uncached/-/require-uncached-1.0.3.tgz",
 			"integrity": "sha1-Tg1W1slmL9MeQwEcS5WqSZVUIdM=",
+			"dev": true,
 			"requires": {
 				"caller-path": "0.1.0",
 				"resolve-from": "1.0.1"
@@ -4620,6 +4277,7 @@
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.4.0.tgz",
 			"integrity": "sha512-aW7sVKPufyHqOmyyLzg/J+8606v5nevBgaliIlV7nUpVMsDnoBGV/cbSLNjZAg9q0Cfd/+easKVKQ8vOu8fn1Q==",
+			"dev": true,
 			"requires": {
 				"path-parse": "1.0.5"
 			}
@@ -4627,7 +4285,8 @@
 		"resolve-from": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-1.0.1.tgz",
-			"integrity": "sha1-Jsv+k10a7uq7Kbw/5a6wHpPUQiY="
+			"integrity": "sha1-Jsv+k10a7uq7Kbw/5a6wHpPUQiY=",
+			"dev": true
 		},
 		"resolve-pathname": {
 			"version": "2.1.0",
@@ -4638,6 +4297,7 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-1.0.1.tgz",
 			"integrity": "sha1-NGYfRohjJ/7SmRR5FSJS35LapUE=",
+			"dev": true,
 			"requires": {
 				"exit-hook": "1.1.1",
 				"onetime": "1.1.0"
@@ -4647,6 +4307,7 @@
 			"version": "0.1.3",
 			"resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
 			"integrity": "sha1-YTObci/mo1FWiSENJOFMlhSGE+8=",
+			"dev": true,
 			"optional": true,
 			"requires": {
 				"align-text": "0.1.4"
@@ -4656,58 +4317,61 @@
 			"version": "2.6.1",
 			"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.1.tgz",
 			"integrity": "sha1-wjOOxkPfeht/5cVPqG9XQopV8z0=",
+			"dev": true,
 			"requires": {
 				"glob": "7.1.2"
 			}
 		},
 		"rollup": {
-			"version": "0.45.2",
-			"resolved": "https://registry.npmjs.org/rollup/-/rollup-0.45.2.tgz",
-			"integrity": "sha512-2+bq5GQSrocdhr+M92mOQRmF1evtLRzv9NdmEC2wo7BILvTG8irHCtD0q+zg8ikNu63iJicdN5IzyxAXRTFKOQ==",
-			"requires": {
-				"source-map-support": "0.4.15"
-			}
+			"version": "0.48.2",
+			"resolved": "https://registry.npmjs.org/rollup/-/rollup-0.48.2.tgz",
+			"integrity": "sha512-5IOVEA87/OWQlojaAPN0WStLAhlaY7GS/5p+pA/IHReXjtc+d7IJYgRD3Y/U2LVXoD7f1SBc3ymYd4g3M/zRzQ==",
+			"dev": true
 		},
 		"rollup-plugin-babel": {
-			"version": "2.7.1",
-			"resolved": "https://registry.npmjs.org/rollup-plugin-babel/-/rollup-plugin-babel-2.7.1.tgz",
-			"integrity": "sha1-FlKBl7D5OKFTb0RoPHqT1XMYL1c=",
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/rollup-plugin-babel/-/rollup-plugin-babel-3.0.2.tgz",
+			"integrity": "sha512-ALGPBFtwJZcYHsNPM6RGJlEncTzAARPvZOGjNPZgDe5hS5t6sJGjiOWibEFVEz5LQN7S7spvCBILaS4N1Cql2w==",
+			"dev": true,
 			"requires": {
-				"babel-core": "6.25.0",
-				"babel-plugin-transform-es2015-classes": "6.24.1",
-				"object-assign": "4.1.1",
 				"rollup-pluginutils": "1.5.2"
 			}
 		},
 		"rollup-plugin-commonjs": {
-			"version": "8.0.2",
-			"resolved": "https://registry.npmjs.org/rollup-plugin-commonjs/-/rollup-plugin-commonjs-8.0.2.tgz",
-			"integrity": "sha1-mLFYm/4ypsD2d5C2DAtJmXKv7Yk=",
+			"version": "8.2.0",
+			"resolved": "https://registry.npmjs.org/rollup-plugin-commonjs/-/rollup-plugin-commonjs-8.2.0.tgz",
+			"integrity": "sha512-EhSkStWuGtfFBI9l89KfUb7yOw3IpcQAtYao/R20FvkiKHDndEF9cyWhuUoSW0igY2/hdH0EeUl/3b9d5xHL3w==",
+			"dev": true,
 			"requires": {
-				"acorn": "4.0.13",
-				"estree-walker": "0.3.1",
-				"magic-string": "0.19.1",
+				"acorn": "5.1.1",
+				"estree-walker": "0.5.0",
+				"magic-string": "0.22.4",
 				"resolve": "1.4.0",
 				"rollup-pluginutils": "2.0.1"
 			},
 			"dependencies": {
-				"acorn": {
-					"version": "4.0.13",
-					"resolved": "https://registry.npmjs.org/acorn/-/acorn-4.0.13.tgz",
-					"integrity": "sha1-EFSVrlNh1pe9GVyCUZLhrX8lN4c="
-				},
 				"estree-walker": {
-					"version": "0.3.1",
-					"resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-0.3.1.tgz",
-					"integrity": "sha1-5rGlHPcpJSTnI3wxLl/mZgwc4ao="
+					"version": "0.5.0",
+					"resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-0.5.0.tgz",
+					"integrity": "sha512-/bEAy+yKAZQrEWUhGmS3H9XpGqSDBtRzX0I2PgMw9kA2n1jN22uV5B5p7MFdZdvWdXCRJztXAfx6ZeRfgkEETg==",
+					"dev": true
 				},
 				"rollup-pluginutils": {
 					"version": "2.0.1",
 					"resolved": "https://registry.npmjs.org/rollup-pluginutils/-/rollup-pluginutils-2.0.1.tgz",
 					"integrity": "sha1-fslbNXP2VDpGpkYb2afFRFJdD8A=",
+					"dev": true,
 					"requires": {
 						"estree-walker": "0.3.1",
 						"micromatch": "2.3.11"
+					},
+					"dependencies": {
+						"estree-walker": {
+							"version": "0.3.1",
+							"resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-0.3.1.tgz",
+							"integrity": "sha1-5rGlHPcpJSTnI3wxLl/mZgwc4ao=",
+							"dev": true
+						}
 					}
 				}
 			}
@@ -4716,6 +4380,7 @@
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/rollup-plugin-node-resolve/-/rollup-plugin-node-resolve-3.0.0.tgz",
 			"integrity": "sha1-i4l8TDAw1QASd7BRSyXSygloPuA=",
+			"dev": true,
 			"requires": {
 				"browser-resolve": "1.11.2",
 				"builtin-modules": "1.1.1",
@@ -4727,6 +4392,7 @@
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/rollup-plugin-replace/-/rollup-plugin-replace-1.1.1.tgz",
 			"integrity": "sha1-OWMV3tBQps5DuVGKiGo/YO+x6jM=",
+			"dev": true,
 			"requires": {
 				"magic-string": "0.15.2",
 				"minimatch": "3.0.4",
@@ -4737,6 +4403,7 @@
 					"version": "0.15.2",
 					"resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.15.2.tgz",
 					"integrity": "sha1-BoHXOIdBu8Ot2qZQYJkmJMbAnpw=",
+					"dev": true,
 					"requires": {
 						"vlq": "0.2.2"
 					}
@@ -4747,6 +4414,7 @@
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/rollup-plugin-uglify/-/rollup-plugin-uglify-2.0.1.tgz",
 			"integrity": "sha1-Z7N60e/a+9g69MNrQMGJ7khmyWk=",
+			"dev": true,
 			"requires": {
 				"uglify-js": "3.0.27"
 			},
@@ -4755,6 +4423,7 @@
 					"version": "3.0.27",
 					"resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.0.27.tgz",
 					"integrity": "sha512-HD8CmxPXUI62v5tweiulMcP/apAtx1DXGcNZkhKQZyC+MTrTsoCBb8yPAwVrbvpgw3EpRU76bRe6axjIiCYcQg==",
+					"dev": true,
 					"requires": {
 						"commander": "2.11.0",
 						"source-map": "0.5.6"
@@ -4766,6 +4435,7 @@
 			"version": "1.5.2",
 			"resolved": "https://registry.npmjs.org/rollup-pluginutils/-/rollup-pluginutils-1.5.2.tgz",
 			"integrity": "sha1-HhVud4+UtyVb+hs9AXi+j1xVJAg=",
+			"dev": true,
 			"requires": {
 				"estree-walker": "0.2.1",
 				"minimatch": "3.0.4"
@@ -4775,6 +4445,7 @@
 			"version": "0.1.0",
 			"resolved": "https://registry.npmjs.org/run-async/-/run-async-0.1.0.tgz",
 			"integrity": "sha1-yK1KXhEGYeQCp9IbUw4AnyX444k=",
+			"dev": true,
 			"requires": {
 				"once": "1.4.0"
 			}
@@ -4782,17 +4453,20 @@
 		"rx-lite": {
 			"version": "3.1.2",
 			"resolved": "https://registry.npmjs.org/rx-lite/-/rx-lite-3.1.2.tgz",
-			"integrity": "sha1-Gc5QLKVyZl87ZHsQk5+X/RYV8QI="
+			"integrity": "sha1-Gc5QLKVyZl87ZHsQk5+X/RYV8QI=",
+			"dev": true
 		},
 		"safe-buffer": {
 			"version": "5.1.1",
 			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
-			"integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg=="
+			"integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg==",
+			"dev": true
 		},
 		"sane": {
 			"version": "1.6.0",
 			"resolved": "https://registry.npmjs.org/sane/-/sane-1.6.0.tgz",
 			"integrity": "sha1-lhDEUjB6E10pwf3+JUcDQYDEZ3U=",
+			"dev": true,
 			"requires": {
 				"anymatch": "1.3.2",
 				"exec-sh": "0.2.0",
@@ -4807,6 +4481,7 @@
 					"version": "1.0.2",
 					"resolved": "https://registry.npmjs.org/bser/-/bser-1.0.2.tgz",
 					"integrity": "sha1-OBEWlwsqbe6lZG3RXdcnhES1YWk=",
+					"dev": true,
 					"requires": {
 						"node-int64": "0.4.0"
 					}
@@ -4815,6 +4490,7 @@
 					"version": "1.9.2",
 					"resolved": "https://registry.npmjs.org/fb-watchman/-/fb-watchman-1.9.2.tgz",
 					"integrity": "sha1-okz0eCf4LTj7Waaa1wt247auc4M=",
+					"dev": true,
 					"requires": {
 						"bser": "1.0.2"
 					}
@@ -4822,29 +4498,34 @@
 				"minimist": {
 					"version": "1.2.0",
 					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
+					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+					"dev": true
 				}
 			}
 		},
 		"sax": {
 			"version": "1.2.4",
 			"resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
-			"integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
+			"integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
+			"dev": true
 		},
 		"semver": {
 			"version": "5.4.1",
 			"resolved": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz",
-			"integrity": "sha512-WfG/X9+oATh81XtllIo/I8gOiY9EXRdv1cQdyykeXK17YcUW3EXUAi2To4pcH6nZtJPr7ZOpM5OMyWJZm+8Rsg=="
+			"integrity": "sha512-WfG/X9+oATh81XtllIo/I8gOiY9EXRdv1cQdyykeXK17YcUW3EXUAi2To4pcH6nZtJPr7ZOpM5OMyWJZm+8Rsg==",
+			"dev": true
 		},
 		"set-blocking": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
-			"integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc="
+			"integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
+			"dev": true
 		},
 		"set-immediate-shim": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz",
 			"integrity": "sha1-SysbJ+uAip+NzEgaWOXlb1mfP2E=",
+			"dev": true,
 			"optional": true
 		},
 		"setimmediate": {
@@ -4856,6 +4537,7 @@
 			"version": "0.7.8",
 			"resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.7.8.tgz",
 			"integrity": "sha1-3svPh0sNHl+3LhSxZKloMEjprLM=",
+			"dev": true,
 			"requires": {
 				"glob": "7.1.2",
 				"interpret": "1.0.3",
@@ -4865,22 +4547,26 @@
 		"shellwords": {
 			"version": "0.1.0",
 			"resolved": "https://registry.npmjs.org/shellwords/-/shellwords-0.1.0.tgz",
-			"integrity": "sha1-Zq/Ue2oSky2Qccv9mKUueFzQuhQ="
+			"integrity": "sha1-Zq/Ue2oSky2Qccv9mKUueFzQuhQ=",
+			"dev": true
 		},
 		"slash": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz",
-			"integrity": "sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU="
+			"integrity": "sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU=",
+			"dev": true
 		},
 		"slice-ansi": {
 			"version": "0.0.4",
 			"resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-0.0.4.tgz",
-			"integrity": "sha1-7b+JA/ZvfOL46v1s7tZeJkyDGzU="
+			"integrity": "sha1-7b+JA/ZvfOL46v1s7tZeJkyDGzU=",
+			"dev": true
 		},
 		"sntp": {
 			"version": "1.0.9",
 			"resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
 			"integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
+			"dev": true,
 			"requires": {
 				"hoek": "2.16.3"
 			}
@@ -4888,12 +4574,14 @@
 		"source-map": {
 			"version": "0.5.6",
 			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
-			"integrity": "sha1-dc449SvwczxafwwRjYEzSiu19BI="
+			"integrity": "sha1-dc449SvwczxafwwRjYEzSiu19BI=",
+			"dev": true
 		},
 		"source-map-support": {
 			"version": "0.4.15",
 			"resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.15.tgz",
 			"integrity": "sha1-AyAt9lwG0r2MfsI2KhkwVv7407E=",
+			"dev": true,
 			"requires": {
 				"source-map": "0.5.6"
 			}
@@ -4902,6 +4590,7 @@
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
 			"integrity": "sha1-SzBz2TP/UfORLwOsVRlJikFQ20A=",
+			"dev": true,
 			"requires": {
 				"spdx-license-ids": "1.2.2"
 			}
@@ -4909,22 +4598,26 @@
 		"spdx-expression-parse": {
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.4.tgz",
-			"integrity": "sha1-m98vIOH0DtRH++JzJmGR/O1RYmw="
+			"integrity": "sha1-m98vIOH0DtRH++JzJmGR/O1RYmw=",
+			"dev": true
 		},
 		"spdx-license-ids": {
 			"version": "1.2.2",
 			"resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.2.tgz",
-			"integrity": "sha1-yd96NCRZSt5r0RkA1ZZpbcBrrFc="
+			"integrity": "sha1-yd96NCRZSt5r0RkA1ZZpbcBrrFc=",
+			"dev": true
 		},
 		"sprintf-js": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-			"integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
+			"integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
+			"dev": true
 		},
 		"sshpk": {
 			"version": "1.13.1",
 			"resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.13.1.tgz",
 			"integrity": "sha1-US322mKHFEMW3EwY/hzx2UBzm+M=",
+			"dev": true,
 			"requires": {
 				"asn1": "0.2.3",
 				"assert-plus": "1.0.0",
@@ -4939,7 +4632,8 @@
 				"assert-plus": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-					"integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
+					"integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+					"dev": true
 				}
 			}
 		},
@@ -4947,6 +4641,7 @@
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
 			"integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+			"dev": true,
 			"requires": {
 				"safe-buffer": "5.1.1"
 			}
@@ -4955,6 +4650,7 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/string-length/-/string-length-1.0.1.tgz",
 			"integrity": "sha1-VpcPscOFWOnnC3KL894mmsRa36w=",
+			"dev": true,
 			"requires": {
 				"strip-ansi": "3.0.1"
 			}
@@ -4963,6 +4659,7 @@
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
 			"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+			"dev": true,
 			"requires": {
 				"code-point-at": "1.1.0",
 				"is-fullwidth-code-point": "1.0.0",
@@ -4972,12 +4669,14 @@
 		"stringstream": {
 			"version": "0.0.5",
 			"resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
-			"integrity": "sha1-TkhM1N5aC7vuGORjB3EKioFiGHg="
+			"integrity": "sha1-TkhM1N5aC7vuGORjB3EKioFiGHg=",
+			"dev": true
 		},
 		"strip-ansi": {
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
 			"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+			"dev": true,
 			"requires": {
 				"ansi-regex": "2.1.1"
 			}
@@ -4985,27 +4684,32 @@
 		"strip-bom": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
-			"integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM="
+			"integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
+			"dev": true
 		},
 		"strip-json-comments": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
-			"integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo="
+			"integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
+			"dev": true
 		},
 		"supports-color": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-			"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
+			"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+			"dev": true
 		},
 		"symbol-tree": {
 			"version": "3.2.2",
 			"resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.2.tgz",
-			"integrity": "sha1-rifbOPZgp64uHDt9G8KQgZuFGeY="
+			"integrity": "sha1-rifbOPZgp64uHDt9G8KQgZuFGeY=",
+			"dev": true
 		},
 		"table": {
 			"version": "3.8.3",
 			"resolved": "https://registry.npmjs.org/table/-/table-3.8.3.tgz",
 			"integrity": "sha1-K7xULw/amGGnVdOUf+/Ys/UThV8=",
+			"dev": true,
 			"requires": {
 				"ajv": "4.11.8",
 				"ajv-keywords": "1.5.1",
@@ -5018,17 +4722,20 @@
 				"ansi-regex": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
+					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+					"dev": true
 				},
 				"is-fullwidth-code-point": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-					"integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
+					"integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+					"dev": true
 				},
 				"string-width": {
 					"version": "2.1.1",
 					"resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
 					"integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+					"dev": true,
 					"requires": {
 						"is-fullwidth-code-point": "2.0.0",
 						"strip-ansi": "4.0.0"
@@ -5038,6 +4745,7 @@
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
 					"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+					"dev": true,
 					"requires": {
 						"ansi-regex": "3.0.0"
 					}
@@ -5048,6 +4756,7 @@
 			"version": "4.1.1",
 			"resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-4.1.1.tgz",
 			"integrity": "sha512-35+Asrsk3XHJDBgf/VRFexPgh3UyETv8IAn/LRTiZjVy6rjPVqdEk8dJcJYBzl1w0XCJM48lvTy8SfEsCWS4nA==",
+			"dev": true,
 			"requires": {
 				"arrify": "1.0.1",
 				"micromatch": "2.3.11",
@@ -5060,6 +4769,7 @@
 					"version": "1.1.0",
 					"resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
 					"integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
+					"dev": true,
 					"requires": {
 						"graceful-fs": "4.1.11",
 						"parse-json": "2.2.0",
@@ -5072,6 +4782,7 @@
 					"version": "1.1.0",
 					"resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
 					"integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
+					"dev": true,
 					"requires": {
 						"graceful-fs": "4.1.11",
 						"pify": "2.3.0",
@@ -5082,6 +4793,7 @@
 					"version": "1.1.0",
 					"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
 					"integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
+					"dev": true,
 					"requires": {
 						"load-json-file": "1.1.0",
 						"normalize-package-data": "2.4.0",
@@ -5092,6 +4804,7 @@
 					"version": "1.0.1",
 					"resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
 					"integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
+					"dev": true,
 					"requires": {
 						"find-up": "1.1.2",
 						"read-pkg": "1.1.0"
@@ -5101,6 +4814,7 @@
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
 					"integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
+					"dev": true,
 					"requires": {
 						"is-utf8": "0.2.1"
 					}
@@ -5110,32 +4824,38 @@
 		"text-table": {
 			"version": "0.2.0",
 			"resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
-			"integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ="
+			"integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
+			"dev": true
 		},
 		"throat": {
 			"version": "3.2.0",
 			"resolved": "https://registry.npmjs.org/throat/-/throat-3.2.0.tgz",
-			"integrity": "sha512-/EY8VpvlqJ+sFtLPeOgc8Pl7kQVOWv0woD87KTXVHPIAE842FGT+rokxIhe8xIUP1cfgrkt0as0vDLjDiMtr8w=="
+			"integrity": "sha512-/EY8VpvlqJ+sFtLPeOgc8Pl7kQVOWv0woD87KTXVHPIAE842FGT+rokxIhe8xIUP1cfgrkt0as0vDLjDiMtr8w==",
+			"dev": true
 		},
 		"through": {
 			"version": "2.3.8",
 			"resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
-			"integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
+			"integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
+			"dev": true
 		},
 		"tmpl": {
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.4.tgz",
-			"integrity": "sha1-I2QN17QtAEM5ERQIIOXPRA5SHdE="
+			"integrity": "sha1-I2QN17QtAEM5ERQIIOXPRA5SHdE=",
+			"dev": true
 		},
 		"to-fast-properties": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz",
-			"integrity": "sha1-uDVx+k2MJbguIxsG46MFXeTKGkc="
+			"integrity": "sha1-uDVx+k2MJbguIxsG46MFXeTKGkc=",
+			"dev": true
 		},
 		"tough-cookie": {
 			"version": "2.3.2",
 			"resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.2.tgz",
 			"integrity": "sha1-8IH3bkyFcg5sN6X6ztc3FQ2EByo=",
+			"dev": true,
 			"requires": {
 				"punycode": "1.4.1"
 			}
@@ -5143,22 +4863,26 @@
 		"tr46": {
 			"version": "0.0.3",
 			"resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-			"integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o="
+			"integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o=",
+			"dev": true
 		},
 		"trim-right": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz",
-			"integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM="
+			"integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM=",
+			"dev": true
 		},
 		"tryit": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/tryit/-/tryit-1.0.3.tgz",
-			"integrity": "sha1-OTvnMKlEb9Hq1tpZoBQwjzbCics="
+			"integrity": "sha1-OTvnMKlEb9Hq1tpZoBQwjzbCics=",
+			"dev": true
 		},
 		"tunnel-agent": {
 			"version": "0.6.0",
 			"resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
 			"integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
+			"dev": true,
 			"requires": {
 				"safe-buffer": "5.1.1"
 			}
@@ -5167,12 +4891,14 @@
 			"version": "0.14.5",
 			"resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
 			"integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
+			"dev": true,
 			"optional": true
 		},
 		"type-check": {
 			"version": "0.3.2",
 			"resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
 			"integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
+			"dev": true,
 			"requires": {
 				"prelude-ls": "1.1.2"
 			}
@@ -5180,7 +4906,8 @@
 		"typedarray": {
 			"version": "0.0.6",
 			"resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
-			"integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
+			"integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
+			"dev": true
 		},
 		"ua-parser-js": {
 			"version": "0.7.14",
@@ -5191,6 +4918,7 @@
 			"version": "2.8.29",
 			"resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.29.tgz",
 			"integrity": "sha1-KcVzMUgFe7Th913zW3qcty5qWd0=",
+			"dev": true,
 			"optional": true,
 			"requires": {
 				"source-map": "0.5.6",
@@ -5202,6 +4930,7 @@
 					"version": "3.10.0",
 					"resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
 					"integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"camelcase": "1.2.1",
@@ -5216,27 +4945,32 @@
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
 			"integrity": "sha1-bgkk1r2mta/jSeOabWMoUKD4grc=",
+			"dev": true,
 			"optional": true
 		},
 		"user-home": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/user-home/-/user-home-1.1.1.tgz",
-			"integrity": "sha1-K1viOjK2Onyd640PKNSFcko98ZA="
+			"integrity": "sha1-K1viOjK2Onyd640PKNSFcko98ZA=",
+			"dev": true
 		},
 		"util-deprecate": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-			"integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
+			"integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+			"dev": true
 		},
 		"uuid": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/uuid/-/uuid-3.1.0.tgz",
-			"integrity": "sha512-DIWtzUkw04M4k3bf1IcpS2tngXEL26YUD2M0tMDUpnUrz2hgzUBlD55a4FjdLGPvfHxS6uluGWvaVEqgBcVa+g=="
+			"integrity": "sha512-DIWtzUkw04M4k3bf1IcpS2tngXEL26YUD2M0tMDUpnUrz2hgzUBlD55a4FjdLGPvfHxS6uluGWvaVEqgBcVa+g==",
+			"dev": true
 		},
 		"v8flags": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/v8flags/-/v8flags-2.1.1.tgz",
 			"integrity": "sha1-qrGh+jDUX4jdMhFIh1rALAtV5bQ=",
+			"dev": true,
 			"requires": {
 				"user-home": "1.1.1"
 			}
@@ -5245,6 +4979,7 @@
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz",
 			"integrity": "sha1-KAS6vnEq0zeUWaz74kdGqywwP7w=",
+			"dev": true,
 			"requires": {
 				"spdx-correct": "1.0.2",
 				"spdx-expression-parse": "1.0.4"
@@ -5259,6 +4994,7 @@
 			"version": "1.10.0",
 			"resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
 			"integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
+			"dev": true,
 			"requires": {
 				"assert-plus": "1.0.0",
 				"core-util-is": "1.0.2",
@@ -5268,19 +5004,22 @@
 				"assert-plus": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-					"integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
+					"integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+					"dev": true
 				}
 			}
 		},
 		"vlq": {
 			"version": "0.2.2",
 			"resolved": "https://registry.npmjs.org/vlq/-/vlq-0.2.2.tgz",
-			"integrity": "sha1-4xbVJXtAuGu0PLjV/qXX9U1rDKE="
+			"integrity": "sha1-4xbVJXtAuGu0PLjV/qXX9U1rDKE=",
+			"dev": true
 		},
 		"walker": {
 			"version": "1.0.7",
 			"resolved": "https://registry.npmjs.org/walker/-/walker-1.0.7.tgz",
 			"integrity": "sha1-L3+bj9ENZ3JisYqITijRlhjgKPs=",
+			"dev": true,
 			"requires": {
 				"makeerror": "1.0.11"
 			}
@@ -5296,17 +5035,20 @@
 		"watch": {
 			"version": "0.10.0",
 			"resolved": "https://registry.npmjs.org/watch/-/watch-0.10.0.tgz",
-			"integrity": "sha1-d3mLLaD5kQ1ZXxrOWwwiWFIfIdw="
+			"integrity": "sha1-d3mLLaD5kQ1ZXxrOWwwiWFIfIdw=",
+			"dev": true
 		},
 		"webidl-conversions": {
 			"version": "4.0.1",
 			"resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-4.0.1.tgz",
-			"integrity": "sha1-gBWherg+fhsxFjhIas6B2mziBqA="
+			"integrity": "sha1-gBWherg+fhsxFjhIas6B2mziBqA=",
+			"dev": true
 		},
 		"whatwg-encoding": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-1.0.1.tgz",
 			"integrity": "sha1-PGxFGhmO567FWx7GHQkgxngBpfQ=",
+			"dev": true,
 			"requires": {
 				"iconv-lite": "0.4.13"
 			}
@@ -5320,6 +5062,7 @@
 			"version": "4.8.0",
 			"resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-4.8.0.tgz",
 			"integrity": "sha1-0pgaqRSMHgCkHFphMRZqtGg7vMA=",
+			"dev": true,
 			"requires": {
 				"tr46": "0.0.3",
 				"webidl-conversions": "3.0.1"
@@ -5328,7 +5071,8 @@
 				"webidl-conversions": {
 					"version": "3.0.1",
 					"resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-					"integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE="
+					"integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE=",
+					"dev": true
 				}
 			}
 		},
@@ -5336,6 +5080,7 @@
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/which/-/which-1.3.0.tgz",
 			"integrity": "sha512-xcJpopdamTuY5duC/KnTTNBraPK54YwpenP4lzxU8H91GudWpFv38u0CKjclE1Wi2EH2EDz5LRcHcKbCIzqGyg==",
+			"dev": true,
 			"requires": {
 				"isexe": "2.0.0"
 			}
@@ -5343,23 +5088,27 @@
 		"which-module": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/which-module/-/which-module-1.0.0.tgz",
-			"integrity": "sha1-u6Y8qGGUiZT/MHc2CJ47lgJsKk8="
+			"integrity": "sha1-u6Y8qGGUiZT/MHc2CJ47lgJsKk8=",
+			"dev": true
 		},
 		"window-size": {
 			"version": "0.1.0",
 			"resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz",
 			"integrity": "sha1-VDjNLqk7IC76Ohn+iIeu58lPnJ0=",
+			"dev": true,
 			"optional": true
 		},
 		"wordwrap": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
-			"integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus="
+			"integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
+			"dev": true
 		},
 		"worker-farm": {
 			"version": "1.4.1",
 			"resolved": "https://registry.npmjs.org/worker-farm/-/worker-farm-1.4.1.tgz",
 			"integrity": "sha512-tgFAtgOYLPutkAyzgpS6VJFL5HY+0ui1Tvua+fITgz8ByaJTMFGtazR6xxQfwfiAcbwE+2fLG/K49wc2TfwCNw==",
+			"dev": true,
 			"requires": {
 				"errno": "0.1.4",
 				"xtend": "4.0.1"
@@ -5369,6 +5118,7 @@
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
 			"integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
+			"dev": true,
 			"requires": {
 				"string-width": "1.0.2",
 				"strip-ansi": "3.0.1"
@@ -5377,12 +5127,14 @@
 		"wrappy": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-			"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+			"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+			"dev": true
 		},
 		"write": {
 			"version": "0.2.1",
 			"resolved": "https://registry.npmjs.org/write/-/write-0.2.1.tgz",
 			"integrity": "sha1-X8A4KOJkzqP+kUVUdvejxWbLB1c=",
+			"dev": true,
 			"requires": {
 				"mkdirp": "0.5.1"
 			}
@@ -5390,22 +5142,26 @@
 		"xml-name-validator": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-2.0.1.tgz",
-			"integrity": "sha1-TYuPHszTQZqjYgYb7O9RXh5VljU="
+			"integrity": "sha1-TYuPHszTQZqjYgYb7O9RXh5VljU=",
+			"dev": true
 		},
 		"xtend": {
 			"version": "4.0.1",
 			"resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
-			"integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68="
+			"integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
+			"dev": true
 		},
 		"y18n": {
 			"version": "3.2.1",
 			"resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
-			"integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE="
+			"integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE=",
+			"dev": true
 		},
 		"yargs": {
 			"version": "7.1.0",
 			"resolved": "https://registry.npmjs.org/yargs/-/yargs-7.1.0.tgz",
 			"integrity": "sha1-a6MY6xaWFyf10oT46gA+jWFU0Mg=",
+			"dev": true,
 			"requires": {
 				"camelcase": "3.0.0",
 				"cliui": "3.2.0",
@@ -5425,12 +5181,14 @@
 				"camelcase": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
-					"integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo="
+					"integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo=",
+					"dev": true
 				},
 				"cliui": {
 					"version": "3.2.0",
 					"resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
 					"integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
+					"dev": true,
 					"requires": {
 						"string-width": "1.0.2",
 						"strip-ansi": "3.0.1",
@@ -5441,6 +5199,7 @@
 					"version": "1.1.0",
 					"resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
 					"integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
+					"dev": true,
 					"requires": {
 						"graceful-fs": "4.1.11",
 						"parse-json": "2.2.0",
@@ -5453,6 +5212,7 @@
 					"version": "1.1.0",
 					"resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
 					"integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
+					"dev": true,
 					"requires": {
 						"graceful-fs": "4.1.11",
 						"pify": "2.3.0",
@@ -5463,6 +5223,7 @@
 					"version": "1.1.0",
 					"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
 					"integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
+					"dev": true,
 					"requires": {
 						"load-json-file": "1.1.0",
 						"normalize-package-data": "2.4.0",
@@ -5473,6 +5234,7 @@
 					"version": "1.0.1",
 					"resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
 					"integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
+					"dev": true,
 					"requires": {
 						"find-up": "1.1.2",
 						"read-pkg": "1.1.0"
@@ -5482,6 +5244,7 @@
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
 					"integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
+					"dev": true,
 					"requires": {
 						"is-utf8": "0.2.1"
 					}
@@ -5492,6 +5255,7 @@
 			"version": "5.0.0",
 			"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-5.0.0.tgz",
 			"integrity": "sha1-J17PDX/+Bcd+ZOfIbkzZS/DhIoo=",
+			"dev": true,
 			"requires": {
 				"camelcase": "3.0.0"
 			},
@@ -5499,7 +5263,8 @@
 				"camelcase": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
-					"integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo="
+					"integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo=",
+					"dev": true
 				}
 			}
 		}

--- a/packages/react-router/package.json
+++ b/packages/react-router/package.json
@@ -62,9 +62,9 @@
     "react": "^15.4.2",
     "react-addons-test-utils": "^15.4.2",
     "react-dom": "^15.3.0",
-    "rollup": "^0.45.2",
-    "rollup-plugin-babel": "^2.7.1",
-    "rollup-plugin-commonjs": "^8.0.2",
+    "rollup": "^0.48.2",
+    "rollup-plugin-babel": "^3.0.2",
+    "rollup-plugin-commonjs": "^8.2.0",
     "rollup-plugin-node-resolve": "^3.0.0",
     "rollup-plugin-replace": "^1.1.1",
     "rollup-plugin-uglify": "^2.0.1"

--- a/packages/react-router/rollup.config.js
+++ b/packages/react-router/rollup.config.js
@@ -5,8 +5,8 @@ import commonjs from 'rollup-plugin-commonjs'
 import resolve from 'rollup-plugin-node-resolve'
 
 const config = {
-  entry: 'modules/index.js',
-  moduleName: 'ReactRouter',
+  input: 'modules/index.js',
+  name: 'ReactRouter',
   globals: {
     react: 'React'
   },


### PR DESCRIPTION
I went ahead and updated all of the outdated Rollup dependencies, although my main reason for doing this is that [my PR to `rollup-plugin-commonjs`](https://github.com/rollup/rollup-plugin-commonjs/pull/208) was just merged and it makes the UMD builds a lot more readable. Instead of there being lots of `index$1`, `index$2`, etc. variable names (because they come from` index.js` files), those variables are now named using their parent directory.

Previous:
```js
var index$6 = Array.isArray || function (arr) {
  return Object.prototype.toString.call(arr) == '[object Array]';
};

if (!index$6(keys)) {
  options = /** @type {!Object} */ (keys || options);
  keys = [];
}
```
Now:
```js
var isarray = Array.isArray || function (arr) {
  return Object.prototype.toString.call(arr) == '[object Array]';
};

if (!isarray(keys)) {
  options = /** @type {!Object} */ (keys || options);
  keys = [];
}
```