### PR TITLE
Update history dependencies to match with react-router

### DIFF
--- a/packages/react-router-redux/package.json
+++ b/packages/react-router-redux/package.json
@@ -30,7 +30,7 @@
     "react": ">=15"
   },
   "dependencies": {
-    "history": "^4.5.1",
+    "history": "^4.7.2",
     "prop-types": "^15.5.4",
     "react-router": "^4.2.0"
   },


### PR DESCRIPTION
Use 4.7.2 since react-router use 4.7.2 as well: https://github.com/ReactTraining/react-router/blob/master/packages/react-router/package.json#L39