### PR TITLE
Added component property to NavLink

### DIFF
--- a/packages/react-router-dom/docs/api/NavLink.md
+++ b/packages/react-router-dom/docs/api/NavLink.md
@@ -79,3 +79,34 @@ const oddEvent = (match, location) => {
 
 The [`isActive`](#isactive-func) compares the current history location (usually the current browser URL).
 To compare to a different location, a [`location`](../../../react-router/docs/api/location.md) can be passed.
+
+## component
+
+The React component which gets rendered by `NavLink`. Defaults to [`Link`](Link.md). This should be used if you want to change the rendered component, for example when you want to apply a higher order component
+function to `Link` or render something completely different.
+
+```js
+import { Link, NavLink } from 'react-router-dom'
+// Custom Link component
+const AbsoluteLink = ({to, ...rest}) => {
+  // Always pass an absolute link, but don't touch links which are already absolute
+  const absolute = to.startsWith('/') ? to : `/${to}`
+  return <Link to={absolute} {...rest} />
+}
+
+// Wrapping Link using a higher order component
+const makeAbsolute = Component => {
+  const Wrapped = ({to, ...rest}) => {
+    // Always pass an absolute link, but don't touch links which are already absolute
+    const absolute = to.startsWith('/') ? to : `/${to}`
+    return <Component to={absolute} {...rest} />
+  }
+  return Wrapped
+}
+const AbsoluteWrappedLink = makeAbsolute(Link)
+
+// All three of these will have the same effect and link to "/about"
+<NavLink to="/about">About</NavLink>
+<NavLink to="about" component={AbsoluteLink}>About</NavLink>
+<NavLink to="about" component={AbsoluteWrappedLink}>About</NavLink>
+```

--- a/packages/react-router-dom/modules/NavLink.js
+++ b/packages/react-router-dom/modules/NavLink.js
@@ -10,6 +10,7 @@ const NavLink = ({
   to,
   exact,
   strict,
+  component: RenderComponent,
   location,
   activeClassName,
   className,
@@ -28,7 +29,7 @@ const NavLink = ({
       const isActive = !!(getIsActive ? getIsActive(match, location) : match)
 
       return (
-        <Link
+        <RenderComponent
           to={to}
           className={isActive ? [ className, activeClassName ].filter(i => i).join(' ') : className}
           style={isActive ? { ...style, ...activeStyle } : style}
@@ -44,6 +45,7 @@ NavLink.propTypes = {
   to: Link.propTypes.to,
   exact: PropTypes.bool,
   strict: PropTypes.bool,
+  component: PropTypes.func,
   location: PropTypes.object,
   activeClassName: PropTypes.string,
   className: PropTypes.string,
@@ -55,7 +57,8 @@ NavLink.propTypes = {
 
 NavLink.defaultProps = {
   activeClassName: 'active',
-  ariaCurrent: 'true'
+  ariaCurrent: 'true',
+  component: Link
 }
 
 export default NavLink

--- a/packages/react-router-dom/modules/__tests__/NavLink-test.js
+++ b/packages/react-router-dom/modules/__tests__/NavLink-test.js
@@ -292,4 +292,21 @@ describe('NavLink', () => {
       expect(a.className).not.toContain('selected')
     })
   })
+
+  describe('component property', () => {
+    it('renders a custom component instead of Link if supplied as prop', () => {
+      const AbsoluteLink = ({to}) => {
+        const href = to.startsWith('/') ? to : `/${to}`
+        return <a href={href}/>
+      }
+
+      ReactDOM.render((
+        <MemoryRouter initialEntries={['/pizza']}>
+          <NavLink to='pizza' component={AbsoluteLink}>Pizza!</NavLink>
+        </MemoryRouter>
+      ), node)
+      const href = node.querySelector('a').getAttribute('href')
+      expect(href).toEqual('/pizza')
+    })
+  })
 })


### PR DESCRIPTION
The new component property determines which React component a NavLink
will render. It defaults to Link, to retain current behavior when omitted.
The property can be used if the user wants to change the rendered
component, for example when they want to apply a higher order component
to Link, or to render something completely different.

Updated docs and added a new test case.

Fixes #5496 