### PR TITLE
Switch: wrap matched route with `render` or `component` passed to `Switch` if any

### DIFF
--- a/packages/react-router/modules/Switch.js
+++ b/packages/react-router/modules/Switch.js
@@ -16,7 +16,9 @@ class Switch extends React.Component {
 
   static propTypes = {
     children: PropTypes.node,
-    location: PropTypes.object
+    location: PropTypes.object,
+    render: PropTypes.func,
+    component: PropTypes.func
   }
 
   componentWillMount() {

--- a/packages/react-router/modules/Switch.js
+++ b/packages/react-router/modules/Switch.js
@@ -57,12 +57,7 @@ class Switch extends React.Component {
     })
     
     const routeElement = match 
-      ? React.cloneElement(child, {
-        location,
-        computedMatch: match,
-        key: child.key != null ? child.key : child.props.path
-      })
-      : null
+      ? React.cloneElement(child, { location, computedMatch: match }) : null
     
     const props = { location, match, children: routeElement }
     if (component) return React.createElement(component, props)

--- a/packages/react-router/modules/Switch.js
+++ b/packages/react-router/modules/Switch.js
@@ -60,7 +60,7 @@ class Switch extends React.Component {
       ? React.cloneElement(child, {
         location,
         computedMatch: match,
-        key: child.key != null ? child.key : child.path
+        key: child.key != null ? child.key : child.props.path
       })
       : null
     

--- a/packages/react-router/modules/Switch.js
+++ b/packages/react-router/modules/Switch.js
@@ -40,7 +40,7 @@ class Switch extends React.Component {
 
   render() {
     const { route } = this.context.router
-    const { children } = this.props
+    const { children, render, component } = this.props
     const location = this.props.location || route.location
 
     let match, child
@@ -55,8 +55,19 @@ class Switch extends React.Component {
         match = path ? matchPath(location.pathname, { path, exact, strict, sensitive }) : route.match
       }
     })
-
-    return match ? React.cloneElement(child, { location, computedMatch: match }) : null
+    
+    const routeElement = match 
+      ? React.cloneElement(child, {
+        location,
+        computedMatch: match,
+        key: child.key != null ? child.key : child.path
+      })
+      : null
+    
+    const props = { location, match, children: routeElement }
+    if (component) return React.createElement(component, props)
+    if (render) return render(props)
+    return routeElement
   }
 }
 


### PR DESCRIPTION
This very simple, non-breaking change makes it significantly easier to wrap routes in animated transition components.

It also solves a problem with the recommended method of using `<Switch key={location.key} location={location}>`: if there are nested route transitions, when the user navigates from one subroute to another, all parent routes will needlessly retransition to themselves (since the `location.key` changes for everything) when only the subroutes need to transition.

Consider this example:

```js
const Account = ({match, location}) => (
  <div>
    <h1>Account</h1>
    <Fader>
      <Switch key={location.key} location={location}>
        <Route path={`${match.url}/profile`} component={Profile} />
        <Route path={`${match.url}/changePassword`} component={ChangePassword} />
      </Switch>
    </Fader>
  </div>
)

<Route render={({location}) => (
  <Fader>
    <Switch key={location.key} location={location}>
      <Route exact path="/" component={Home} />
      <Route path="/about" component={About} />
      <Route path="/account" component={Account} />
    </Switch>
  </Fader>
)}/>
```

For the path `/account/profile`, it renders the following component hierarchy:

```js
<Router>
  <Fader>
    <Switch key="key1">
      <Route>
        <Account>
          <div>
            <h1>Account</h1>
            <Fader>
              <Switch key="key1">
                <Route>
                  <Profile>
```
If the user navigates to `/account/changePassword`, it causes both `<Fader>s` to transition, when only the inner one needs to, because both receive a new child key:
```js
<Router>
  <Fader>
    <Switch key="key2">
      <Route>
        <Account>
          <div>
            <h1>Account</h1>
            <Fader>
              <Switch key="key2">
                <Route>
                  <ChangePassword>
```

This solution solves that problem by wrapping the matched `<Route>` with any `component` or `render` prop provided to `<Switch>` (new API).  So if user gives each `<Route>` an appropriate `key` then transitions will work exactly as desired.

Note that it's also no longer necessary to manually pass `location` to each `<Switch>`, which means less developer mistakes and confusion.

```js
const Account = ({match}) => (
  <div>
    <h1>Account</h1>
    <Switch component={Fader}>
      <Route key="profile" path={`${match.url}/profile`} component={Profile} />
      <Route key="changePassword" path={`${match.url}/changePassword`} component={ChangePassword} />
    </Switch>
  </div>
)

<Router>
  <Switch component={Fader}>
    <Route key="home" exact path="/" component={Home} />
    <Route key="about" path="/about" component={About} />
    <Route key="account" path="/account" component={Account} />
  </Switch>
</Router>
```

With the above setup, `/account/profile` will render the following component hierarchy.
```js
<Router>
  <Switch>
    <Fader>
      <Route key="account">
        <Account>
          <div>
            <h1>Account</h1>
            <Switch>
              <Fader>
                <Route key="profile">
                  <Profile />
```
If the user navigates to `/account/changePassword`, only the inner `<Fader>` will transition, because the child key for the outer `<Fader>` remains the same:
```js
<Router>
  <Switch>
    <Fader>
      <Route key="account">
        <Account>
          <div>
            <h1>Account</h1>
            <Switch>
              <Fader>
                <Route key="changePassword">
                  <ChangePassword />
```