### PR TITLE
Use `match.path` for nested routes.

### DIFF
--- a/packages/react-router-dom/docs/guides/quick-start.md
+++ b/packages/react-router-dom/docs/guides/quick-start.md
@@ -72,8 +72,8 @@ const Topics = ({ match }) => (
       </li>
     </ul>
 
-    <Route path={`${match.url}/:topicId`} component={Topic}/>
-    <Route exact path={match.url} render={() => (
+    <Route path={`${match.path}/:topicId`} component={Topic}/>
+    <Route exact path={match.path} render={() => (
       <h3>Please select a topic.</h3>
     )}/>
   </div>


### PR DESCRIPTION
### This change seeks to attain uniformity in the docs.

[The API docs for `match`](https://github.com/ReactTraining/react-router/blob/0b9917e02391809f6ef12c10a29c75ee0e20efe5/packages/react-router/docs/api/match.md) distinguishes between `match.url` and `match.path`, recommending that `.url` be used for **building nested `<Link>s`** and `.path` for **building nested `<Route>s.`**

The example code in the _Quick Start_ guide uses `match.url` for links, however, it also uses `match.url` for routes. This change is to use `match.path` for routes, to ensure uniformity.