### PR TITLE
Add basic working examples to react-router-redux

### DIFF
--- a/packages/react-router-redux/examples/AuthExample.js
+++ b/packages/react-router-redux/examples/AuthExample.js
@@ -1,0 +1,111 @@
+import React from 'react';
+import { render } from 'react-dom';
+import { Provider } from 'react-redux';
+import { ConnectedRouter } from 'react-router-redux';
+
+import { createStore, applyMiddleware, combineReducers } from 'redux';
+import createHistory from 'history/createBrowserHistory';
+import { routerReducer, routerMiddleware, push } from 'react-router-redux';
+
+import { connect } from 'react-redux';
+import { Route, Switch } from 'react-router';
+
+const history = createHistory();
+
+const authSuccess = () => ({
+    type: 'AUTH_SUCCESS'
+})
+
+const authFail = () => ({
+    type: 'AUTH_FAIL'
+})
+
+const initialState = {
+    isAuthenticated: false
+}
+
+const authReducer = (state = initialState , action) => {
+    switch (action.type) {
+        case 'AUTH_SUCCESS':
+            return Object.assign({}, ...state, {
+                isAuthenticated: true
+            });
+        case 'AUTH_FAIL':
+            return Object.assign({}, ...state, {
+                isAuthenticated: false
+            });
+        default: 
+            return { ...state };
+    }
+}
+
+const store = createStore(
+    combineReducers({ routerReducer, authReducer }),
+    applyMiddleware(routerMiddleware(history)),
+);
+
+const ConnectedSwitch = connect(state => ({
+	location: state.location
+}))(Switch);
+
+class LoginContainer extends React.Component {
+    render() {
+        return <button onClick={() => this.props.login()}>Login Here!</button>
+    }
+}
+
+class HomeContainer extends React.Component {
+    componentWillMount() {
+        alert('Private home is at: ' + this.props.location.pathname)
+    }
+
+    render() {
+        return <button onClick={() => this.props.logout()}>Logout Here!</button>
+    }
+}
+
+const AppContainer = ({ location }) => (
+    <ConnectedSwitch>
+        <PrivateRoute component={Home} />
+    </ConnectedSwitch>
+);
+
+class PrivateRouteContainer extends React.Component {
+    render() {
+        return this.props.isAuthenticated ?
+            <Route exact path="/" component={this.props.component} />
+        :   <Route exact path="/" component={Login} />
+    }
+}
+
+const PrivateRoute = connect(state => ({
+    isAuthenticated: state.authReducer.isAuthenticated
+}))(PrivateRouteContainer)
+
+const Login = connect(null, dispatch => ({
+    login: () => { 
+        dispatch(authSuccess())
+        dispatch(push('/'))
+    }
+}))(LoginContainer)
+
+const Home = connect(null, dispatch => ({
+    logout: () => { 
+        dispatch(authFail())
+        dispatch(push('/'))
+    }
+}))(HomeContainer)
+
+const App = connect(state => ({
+    location: state.location,
+}))(AppContainer)
+
+render(
+    <Provider store={store}>
+        <ConnectedRouter history={history}>
+            <App />
+        </ConnectedRouter>
+    </Provider>,
+    document.getElementById('root'),
+);
+  

--- a/packages/react-router-redux/examples/BasicExample.js
+++ b/packages/react-router-redux/examples/BasicExample.js
@@ -1,0 +1,44 @@
+import React from 'react';
+import { render } from 'react-dom';
+import { Provider } from 'react-redux';
+import { ConnectedRouter } from 'react-router-redux';
+
+import { createStore, applyMiddleware } from 'redux';
+import createHistory from 'history/createBrowserHistory';
+import { routerReducer, routerMiddleware } from 'react-router-redux';
+
+import { connect } from 'react-redux';
+import { Link } from 'react-router-dom';
+import { Route, Switch } from 'react-router';
+
+const history = createHistory();
+
+const store = createStore(
+    routerReducer,
+    applyMiddleware(routerMiddleware(history)),
+);
+
+const ConnectedSwitch = connect(state => ({
+	location: state.location
+}))(Switch);
+
+const AppContainer = ({ location }) => (
+    <ConnectedSwitch>
+        <Route exact path="/" component={(props) => (<h1>Home <Link to="/about">About</Link></h1>)} />
+        <Route path="/about" component={(props) => (<h1>About <Link to="/">Home</Link></h1>)} />
+    </ConnectedSwitch>
+);
+
+const App = connect(state => ({
+    location: state.location,
+}))(AppContainer)
+
+render(
+    <Provider store={store}>
+        <ConnectedRouter history={history}>
+            <App />
+        </ConnectedRouter>
+    </Provider>,
+    document.getElementById('root'),
+);
+  


### PR DESCRIPTION
I'm adding these examples in order to improve our docs and help to understand the API's usage, just like it's currently done on <a href="https://github.com/ReactTraining/react-router/tree/master/packages/react-router-native/examples">React Router Native</a> .
I would like some help to improve these docs in the future as **React Router Redux** is being developed because right now it's quite simple.