### PR TITLE
Ignore the website in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,3 +16,4 @@ branches:
   only:
     - master
     - next
+    - ignore-website-in-ci

--- a/package.json
+++ b/package.json
@@ -2,8 +2,8 @@
   "private": true,
   "name": "react-router-packages",
   "scripts": {
-    "postinstall": "lerna bootstrap --stream",
-    "build": "lerna run build --stream",
+    "postinstall": "node ./scripts/postinstall.js",
+    "build": "node ./scripts/build.js",
     "clean": "lerna run clean",
     "start": "cd website && npm start",
     "test": "lerna run test --stream"

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -1,0 +1,13 @@
+const execSync = require('child_process').execSync
+
+const exec = (cmd, env) =>
+  execSync(cmd, {
+    stdio: 'inherit',
+    env: Object.assign({}, process.env, env)
+  })
+
+if (process.env.CI) {
+  exec('lerna run build --stream --ignore react-router-website')
+} else {
+  exec('lerna run build --stream')
+}

--- a/scripts/postinstall.js
+++ b/scripts/postinstall.js
@@ -1,0 +1,13 @@
+const execSync = require('child_process').execSync
+
+const exec = (cmd, env) =>
+  execSync(cmd, {
+    stdio: 'inherit',
+    env: Object.assign({}, process.env, env)
+  })
+
+if (process.env.CI) {
+  exec('lerna bootstrap --stream --ignore react-router-website')
+} else {
+  exec('lerna bootstrap --stream')
+}


### PR DESCRIPTION
Don't build the website in CI or install any of its dependencies. This was suggested by both @timdorr in https://github.com/ReactTraining/react-router/pull/5527#issuecomment-329872051 and @pshrmn in https://github.com/ReactTraining/react-router/issues/4362#issuecomment-328163751. But @ryanflorence seems opposed to the idea (see https://github.com/ReactTraining/react-router/pull/5527#issuecomment-329874880).

Anyway, just wanted to put up this PR real quick so we have a place to discuss. I personally don't think it's a huge deal either way. It doesn't take a terrible amount of time to build the website in CI, but it is annoying. I also don't think building the site is a very valuable test of what's working and what's not. ¯\_(ツ)_/¯