### PR TITLE
react-router-redux useful selectors

### DIFF
--- a/packages/react-router-redux/modules/__tests__/selectors-test.js
+++ b/packages/react-router-redux/modules/__tests__/selectors-test.js
@@ -26,21 +26,6 @@ describe('selectors', () => {
 
   describe('createMatchSelector', () => {
     it('matches correctly', () => {
-      store.dispatch({
-        type: LOCATION_CHANGE,
-        payload: { pathname: '/' }
-      })
-      const state = store.getState()
-      const matchSelector = createMatchSelector('/')
-      expect(matchSelector(state)).toEqual({
-        isExact: true,
-        params: {},
-        path: '/',
-        url: '/'
-      })
-    })
-
-    it('matches correctly', () => {
       const matchSelector = createMatchSelector('/')
       store.dispatch({
         type: LOCATION_CHANGE,

--- a/packages/react-router-redux/modules/__tests__/selectors-test.js
+++ b/packages/react-router-redux/modules/__tests__/selectors-test.js
@@ -20,7 +20,7 @@ describe('selectors', () => {
         payload: location
       })
       const state = store.getState()
-      expect(getLocation(state)).toEqual(location)
+      expect(getLocation(state)).toBe(location)
     })
   })
 

--- a/packages/react-router-redux/modules/__tests__/selectors-test.js
+++ b/packages/react-router-redux/modules/__tests__/selectors-test.js
@@ -1,0 +1,89 @@
+import { getLocation, createMatchSelector } from '../selectors'
+import { createStore, combineReducers } from 'redux'
+import { routerReducer, LOCATION_CHANGE } from '../reducer'
+
+describe('selectors', () => {
+
+  let store, history
+
+  beforeEach(() => {
+    store = createStore(combineReducers({
+      router: routerReducer
+    }))
+  })
+
+  describe('getLocation', () => {
+    it('gets the location from the state', () => {
+      const location = { pathname: '/' }
+      store.dispatch({
+        type: LOCATION_CHANGE,
+        payload: location
+      })
+      const state = store.getState()
+      expect(getLocation(state)).toEqual(location)
+    })
+  })
+
+  describe('createMatchSelector', () => {
+    it('matches correctly', () => {
+      store.dispatch({
+        type: LOCATION_CHANGE,
+        payload: { pathname: '/' }
+      })
+      const state = store.getState()
+      const matchSelector = createMatchSelector('/')
+      expect(matchSelector(state)).toEqual({
+        isExact: true,
+        params: {},
+        path: '/',
+        url: '/'
+      })
+    })
+
+    it('matches correctly', () => {
+      const matchSelector = createMatchSelector('/')
+      store.dispatch({
+        type: LOCATION_CHANGE,
+        payload: { pathname: '/test' }
+      })
+      const state = store.getState()
+      expect(matchSelector(state)).toEqual({
+        isExact: false,
+        params: {},
+        path: '/',
+        url: '/'
+      })
+    })
+
+    it('does not update if the match is the same', () => {
+      const matchSelector = createMatchSelector('/')
+      store.dispatch({
+        type: LOCATION_CHANGE,
+        payload: { pathname: '/test1' }
+      })
+      const match1 = matchSelector(store.getState())
+      store.dispatch({
+        type: LOCATION_CHANGE,
+        payload: { pathname: '/test2' }
+      })
+      const match2 = matchSelector(store.getState())
+      expect(match1).toBe(match2)
+    })
+
+    it('updates if the match is different', () => {
+      const matchSelector = createMatchSelector('/sushi/:type')
+      store.dispatch({
+        type: LOCATION_CHANGE,
+        payload: { pathname: '/sushi/california' }
+      })
+      const match1 = matchSelector(store.getState())
+      store.dispatch({
+        type: LOCATION_CHANGE,
+        payload: { pathname: '/sushi/dynamite' }
+      })
+      const match2 = matchSelector(store.getState())
+      expect(match1).not.toBe(match2)
+    })
+  })
+
+})

--- a/packages/react-router-redux/modules/__tests__/selectors-test.js
+++ b/packages/react-router-redux/modules/__tests__/selectors-test.js
@@ -4,7 +4,7 @@ import { routerReducer, LOCATION_CHANGE } from '../reducer'
 
 describe('selectors', () => {
 
-  let store, history
+  let store
 
   beforeEach(() => {
     store = createStore(combineReducers({

--- a/packages/react-router-redux/modules/index.js
+++ b/packages/react-router-redux/modules/index.js
@@ -1,4 +1,5 @@
 export ConnectedRouter from './ConnectedRouter'
+export { getLocation, createMatchSelector } from './selectors';
 export { LOCATION_CHANGE, routerReducer } from './reducer'
 export {
   CALL_HISTORY_METHOD,

--- a/packages/react-router-redux/modules/selectors.js
+++ b/packages/react-router-redux/modules/selectors.js
@@ -1,6 +1,5 @@
 import { matchPath } from 'react-router'
 
-
 export const getLocation = state => state.router.location
 
 export const createMatchSelector = (path) => {

--- a/packages/react-router-redux/modules/selectors.js
+++ b/packages/react-router-redux/modules/selectors.js
@@ -1,0 +1,21 @@
+import { matchPath } from 'react-router'
+
+
+export const getLocation = state => state.router.location
+
+export const createMatchSelector = (path) => {
+  let lastPathname = null
+  let lastMatch = null
+  return (state) => {
+    const { pathname } = getLocation(state)
+    if (pathname === lastPathname) {
+      return lastMatch
+    }
+    lastPathname = pathname
+    const match = matchPath(pathname, path)
+    if (!match || !lastMatch || match.url !== lastMatch.url) {
+      lastMatch = match
+    }
+    return lastMatch
+  }
+}


### PR DESCRIPTION
Add a couple functions to the react-router-redux API

#### getLocation(state) -> location

Simply retrieve the location object stored in the store

#### createMatchSelector(path) -> matchSelector(state) -> match|null

This function will create a memoized selector that will match the current location to the given path, if the match turns out to be different than before it will return the new match, otherwise it will keep returning the previous one.

Usage:

```js
import { createMatchSelector } from 'react-router-redux';

const usersMatchSelector = createMatchSelector({ path: '/users' });

// this will effectively update your component when the user enters or leaves the /users route.
// it wont update the component if the users goes from /users/one to /users/two because
// the pattern doesn't have the `exact: true` flag.
const mapStateToProps = (state) => ({
  match: usersMatchSelector(state);
});
```