### PR TITLE
Store the last history action

### DIFF
--- a/packages/react-router-redux/modules/ConnectedRouter.js
+++ b/packages/react-router-redux/modules/ConnectedRouter.js
@@ -15,17 +15,20 @@ class ConnectedRouter extends Component {
     store: PropTypes.object
   }
 
-  handleLocationChange = location => {
+  handleLocationChange = (location, action) => {
     this.store.dispatch({
       type: LOCATION_CHANGE,
-      payload: location
+      payload: {
+        ...location,
+        action
+      }
     })
   }
 
   componentWillMount() {
     const { store:propsStore, history } = this.props
     this.store = propsStore || this.context.store
-    this.handleLocationChange(history.location)
+    this.handleLocationChange(history.location, history.action)
   }
 
   componentDidMount() {

--- a/packages/react-router-redux/modules/__tests__/ConnectedRouter-test.js
+++ b/packages/react-router-redux/modules/__tests__/ConnectedRouter-test.js
@@ -30,6 +30,7 @@ describe('A <ConnectedRouter>', () => {
     )
 
     expect(store.getState()).toHaveProperty('router.location.pathname')
+    expect(store.getState()).toHaveProperty('router.location.action', 'POP')
   })
 
   it('connects to a store via props', () => {
@@ -42,6 +43,7 @@ describe('A <ConnectedRouter>', () => {
     )
 
     expect(store.getState()).toHaveProperty('router.location.pathname')
+    expect(store.getState()).toHaveProperty('router.location.action', 'POP')
   })
 
   it('updates the store with location changes', () => {
@@ -56,6 +58,8 @@ describe('A <ConnectedRouter>', () => {
     history.push('/foo')
 
     expect(store.getState()).toHaveProperty('router.location.pathname', '/foo')
+    expect(store.getState()).toHaveProperty('router.location.action', 'PUSH')
+
   })
 
   describe('with children', () => {


### PR DESCRIPTION
In order to customize and trace history in app, I suggest synchronizing the location and the last history action given by the `history.listen ` callback.

See https://github.com/ReactTraining/history/blob/master/modules/createBrowserHistory.js#L86

