### PR TITLE
Add action to payload of LOCATION_CHANGE

### DIFF
--- a/packages/react-router-redux/modules/ConnectedRouter.js
+++ b/packages/react-router-redux/modules/ConnectedRouter.js
@@ -15,10 +15,10 @@ class ConnectedRouter extends Component {
     store: PropTypes.object
   }
 
-  handleLocationChange = location => {
+  handleLocationChange = (location, action) => {
     this.store.dispatch({
       type: LOCATION_CHANGE,
-      payload: location
+      payload: Object.assign(location, { action })
     })
   }
 


### PR DESCRIPTION
The action property in the payload of LOCATION_CHANGE went missing in the latest react-router-redux. This change adds it back. I need this to synchronise a stack data structure in a reducer with the history entries data structure.