### PR TITLE
Updated import statement for mathPath and withRouter in -dom and -native

### DIFF
--- a/packages/react-router-dom/docs/api/matchPath.md
+++ b/packages/react-router-dom/docs/api/matchPath.md
@@ -1,3 +1,31 @@
 # matchPath
 
-Re-exported from core [`matchPath`](../../../react-router/docs/api/matchPath.md)
+This lets you use the same matching code that `<Route>` uses except outside of the normal render cycle, like gathering up data dependencies before rendering on the server.
+
+```js
+import { matchPath } from 'react-router-dom'
+
+const match = matchPath('/users/123', {
+  path: '/users/:id',
+  exact: true,
+  strict: false
+})
+```
+
+## pathname
+
+The first argument is the pathname you want to match. If you're using
+this on the server with Node.js, it would be `req.url`.
+
+## props
+
+The second argument are the props to match against, they are identical
+to the matching props `Route` accepts:
+
+```js
+{
+  path, // like /users/:id
+  strict, // optional, defaults to false
+  exact // optional, defaults to false
+}
+```

--- a/packages/react-router-dom/docs/api/withRouter.md
+++ b/packages/react-router-dom/docs/api/withRouter.md
@@ -1,3 +1,91 @@
 # withRouter
 
-Re-exported from core [`withRouter`](../../../react-router/docs/api/withRouter.md)
+You can get access to the [`history`](./history.md) object's properties and the closest [`<Route>`](./Route.md)'s [`match`](./match.md) via the `withRouter` higher-order component. `withRouter` will pass updated `match`, `location`, and `history` props to the wrapped component whenever it renders.
+
+```js
+import React from 'react'
+import PropTypes from 'prop-types'
+import { withRouter } from 'react-router-dom'
+
+// A simple component that shows the pathname of the current location
+class ShowTheLocation extends React.Component {
+  static propTypes = {
+    match: PropTypes.object.isRequired,
+    location: PropTypes.object.isRequired,
+    history: PropTypes.object.isRequired
+  }
+
+  render() {
+    const { match, location, history } = this.props
+
+    return (
+      <div>You are now at {location.pathname}</div>
+    )
+  }
+}
+
+// Create a new component that is "connected" (to borrow redux
+// terminology) to the router.
+const ShowTheLocationWithRouter = withRouter(ShowTheLocation)
+```
+
+#### Important Note
+
+`withRouter` does not subscribe to location changes like React Redux's `connect` does for state changes.  Instead, re-renders after location changes propagate out from the `<Router>` component.  This means that `withRouter` does _not_ re-render on route transitions unless its parent component re-renders. If you are using `withRouter` to prevent updates from being blocked by `shouldComponentUpdate`, it is important that `withRouter` wraps the component that implements `shouldComponentUpdate`. For example, when using Redux:
+
+```js
+// This gets around shouldComponentUpdate
+withRouter(connect(...)(MyComponent))
+// or
+compose(
+  withRouter,
+  connect(...)
+)(MyComponent)
+
+// This does not
+connect(...)(withRouter(MyComponent))
+// nor
+compose(
+  connect(...),
+  withRouter
+)(MyComponent)
+```
+
+See [this guide](https://github.com/ReactTraining/react-router/blob/master/packages/react-router/docs/guides/blocked-updates.md) for more information.
+
+#### Static Methods and Properties
+
+All non-react specific static methods and properties of the wrapped component are automatically copied to the
+"connected" component.
+
+## Component.WrappedComponent
+
+The wrapped component is exposed as the static property `WrappedComponent` on the returned component, which can be used
+for testing the component in isolation, among other things.
+
+```js
+// MyComponent.js
+export default withRouter(MyComponent)
+
+// MyComponent.test.js
+import MyComponent from './MyComponent'
+render(<MyComponent.WrappedComponent location={{...}} ... />)
+```
+
+## wrappedComponentRef: func
+
+A function that will be passed as the `ref` prop to the wrapped component.
+
+```js
+class Container extends React.Component {
+  componentDidMount() {
+    this.component.doSomething()
+  }
+
+  render() {
+    return (
+      <MyComponent wrappedComponentRef={c => this.component = c}/>
+    )
+  }
+}
+```

--- a/packages/react-router-native/docs/api/matchPath.md
+++ b/packages/react-router-native/docs/api/matchPath.md
@@ -1,3 +1,31 @@
 # matchPath
 
-Re-exported from core [`matchPath`](../../../react-router/docs/api/matchPath.md)
+This lets you use the same matching code that `<Route>` uses except outside of the normal render cycle, like gathering up data dependencies before rendering on the server.
+
+```js
+import { matchPath } from 'react-router-native'
+
+const match = matchPath('/users/123', {
+  path: '/users/:id',
+  exact: true,
+  strict: false
+})
+```
+
+## pathname
+
+The first argument is the pathname you want to match. If you're using
+this on the server with Node.js, it would be `req.url`.
+
+## props
+
+The second argument are the props to match against, they are identical
+to the matching props `Route` accepts:
+
+```js
+{
+  path, // like /users/:id
+  strict, // optional, defaults to false
+  exact // optional, defaults to false
+}
+```

--- a/packages/react-router-native/docs/api/withRouter.md
+++ b/packages/react-router-native/docs/api/withRouter.md
@@ -1,3 +1,91 @@
 # withRouter
 
-Re-exported from core [`withRouter`](../../../react-router/docs/api/withRouter.md)
+You can get access to the [`history`](./history.md) object's properties and the closest [`<Route>`](./Route.md)'s [`match`](./match.md) via the `withRouter` higher-order component. `withRouter` will pass updated `match`, `location`, and `history` props to the wrapped component whenever it renders.
+
+```js
+import React from 'react'
+import PropTypes from 'prop-types'
+import { withRouter } from 'react-router-native'
+
+// A simple component that shows the pathname of the current location
+class ShowTheLocation extends React.Component {
+  static propTypes = {
+    match: PropTypes.object.isRequired,
+    location: PropTypes.object.isRequired,
+    history: PropTypes.object.isRequired
+  }
+
+  render() {
+    const { match, location, history } = this.props
+
+    return (
+      <div>You are now at {location.pathname}</div>
+    )
+  }
+}
+
+// Create a new component that is "connected" (to borrow redux
+// terminology) to the router.
+const ShowTheLocationWithRouter = withRouter(ShowTheLocation)
+```
+
+#### Important Note
+
+`withRouter` does not subscribe to location changes like React Redux's `connect` does for state changes.  Instead, re-renders after location changes propagate out from the `<Router>` component.  This means that `withRouter` does _not_ re-render on route transitions unless its parent component re-renders. If you are using `withRouter` to prevent updates from being blocked by `shouldComponentUpdate`, it is important that `withRouter` wraps the component that implements `shouldComponentUpdate`. For example, when using Redux:
+
+```js
+// This gets around shouldComponentUpdate
+withRouter(connect(...)(MyComponent))
+// or
+compose(
+  withRouter,
+  connect(...)
+)(MyComponent)
+
+// This does not
+connect(...)(withRouter(MyComponent))
+// nor
+compose(
+  connect(...),
+  withRouter
+)(MyComponent)
+```
+
+See [this guide](https://github.com/ReactTraining/react-router/blob/master/packages/react-router/docs/guides/blocked-updates.md) for more information.
+
+#### Static Methods and Properties
+
+All non-react specific static methods and properties of the wrapped component are automatically copied to the
+"connected" component.
+
+## Component.WrappedComponent
+
+The wrapped component is exposed as the static property `WrappedComponent` on the returned component, which can be used
+for testing the component in isolation, among other things.
+
+```js
+// MyComponent.js
+export default withRouter(MyComponent)
+
+// MyComponent.test.js
+import MyComponent from './MyComponent'
+render(<MyComponent.WrappedComponent location={{...}} ... />)
+```
+
+## wrappedComponentRef: func
+
+A function that will be passed as the `ref` prop to the wrapped component.
+
+```js
+class Container extends React.Component {
+  componentDidMount() {
+    this.component.doSomething()
+  }
+
+  render() {
+    return (
+      <MyComponent wrappedComponentRef={c => this.component = c}/>
+    )
+  }
+}
+```


### PR DESCRIPTION
The import statement in the modules -dom and -native was 'react-router', and that could be misleading.

I thought I had to import 'react-router' in addition to 'react-router-native' to use `mathPath` or `withRouter`.

This same issue was referenced at #5034 