### PR TITLE
Allow onClick interpret as a bool type

### DIFF
--- a/packages/react-router-dom/modules/Link.js
+++ b/packages/react-router-dom/modules/Link.js
@@ -10,7 +10,10 @@ const isModifiedEvent = (event) =>
  */
 class Link extends React.Component {
   static propTypes = {
-    onClick: PropTypes.func,
+    onClick: PropTypes.oneOfType([
+      PropTypes.bool,
+      PropTypes.func
+    ]),
     target: PropTypes.string,
     replace: PropTypes.bool,
     to: PropTypes.oneOfType([


### PR DESCRIPTION
Fixed warning "Warning: Expected `onClick` listener to be a function, instead got a value of `boolean` type."