### PR TITLE
Use named import of 'history' module to fix #5576.

### DIFF
--- a/packages/react-router-dom/modules/BrowserRouter.js
+++ b/packages/react-router-dom/modules/BrowserRouter.js
@@ -1,7 +1,7 @@
 import warning from 'warning'
 import React from 'react'
 import PropTypes from 'prop-types'
-import createHistory from 'history/createBrowserHistory'
+import {createBrowserHistory as createHistory} from 'history'
 import Router from './Router'
 
 /**

--- a/packages/react-router-dom/modules/BrowserRouter.js
+++ b/packages/react-router-dom/modules/BrowserRouter.js
@@ -1,7 +1,7 @@
 import warning from 'warning'
 import React from 'react'
 import PropTypes from 'prop-types'
-import {createBrowserHistory as createHistory} from 'history'
+import { createBrowserHistory as createHistory } from 'history'
 import Router from './Router'
 
 /**

--- a/packages/react-router-dom/modules/HashRouter.js
+++ b/packages/react-router-dom/modules/HashRouter.js
@@ -1,7 +1,7 @@
 import warning from 'warning'
 import React from 'react'
 import PropTypes from 'prop-types'
-import {createHashHistory as createHistory} from 'history'
+import { createHashHistory as createHistory } from 'history'
 import Router from './Router'
 
 /**

--- a/packages/react-router-dom/modules/HashRouter.js
+++ b/packages/react-router-dom/modules/HashRouter.js
@@ -1,7 +1,7 @@
 import warning from 'warning'
 import React from 'react'
 import PropTypes from 'prop-types'
-import createHistory from 'history/createHashHistory'
+import {createHashHistory as createHistory} from 'history'
 import Router from './Router'
 
 /**

--- a/packages/react-router/modules/MemoryRouter.js
+++ b/packages/react-router/modules/MemoryRouter.js
@@ -1,7 +1,7 @@
 import warning from 'warning'
 import React from 'react'
 import PropTypes from 'prop-types'
-import createHistory from 'history/createMemoryHistory'
+import {createMemoryHistory as createHistory} from 'history'
 import Router from './Router'
 
 /**

--- a/packages/react-router/modules/StaticRouter.js
+++ b/packages/react-router/modules/StaticRouter.js
@@ -2,7 +2,7 @@ import warning from 'warning'
 import invariant from 'invariant'
 import React from 'react'
 import PropTypes from 'prop-types'
-import { addLeadingSlash, createPath, parsePath } from 'history/PathUtils'
+import { createPath, parsePath } from 'history'
 import Router from './Router'
 
 const normalizeLocation = (object) => {
@@ -13,6 +13,10 @@ const normalizeLocation = (object) => {
     search: search === '?' ? '' : search,
     hash: hash === '#' ? '' : hash
   }
+}
+
+const addLeadingSlash = (path) => {
+  return path.charAt(0) === '/' ? path : '/' + path;
 }
 
 const addBasename = (basename, location) => {

--- a/packages/react-router/modules/__tests__/Route-test.js
+++ b/packages/react-router/modules/__tests__/Route-test.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import ReactDOM from 'react-dom'
-import createMemoryHistory from 'history/createMemoryHistory'
+import {createMemoryHistory} from 'history'
 import MemoryRouter from '../MemoryRouter'
 import Router from '../Router'
 import Route from '../Route'

--- a/packages/react-router/modules/__tests__/Route-test.js
+++ b/packages/react-router/modules/__tests__/Route-test.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import ReactDOM from 'react-dom'
-import {createMemoryHistory} from 'history'
+import { createMemoryHistory } from 'history'
 import MemoryRouter from '../MemoryRouter'
 import Router from '../Router'
 import Route from '../Route'

--- a/packages/react-router/modules/__tests__/Router-test.js
+++ b/packages/react-router/modules/__tests__/Router-test.js
@@ -2,7 +2,7 @@ import React from 'react'
 import ReactDOM from 'react-dom'
 import PropTypes from 'prop-types'
 import Router from '../Router'
-import createHistory from 'history/createMemoryHistory'
+import {createMemoryHistory as createHistory} from 'history'
 
 describe('A <Router>', () => {
   const node = document.createElement('div')

--- a/packages/react-router/modules/__tests__/Router-test.js
+++ b/packages/react-router/modules/__tests__/Router-test.js
@@ -2,7 +2,7 @@ import React from 'react'
 import ReactDOM from 'react-dom'
 import PropTypes from 'prop-types'
 import Router from '../Router'
-import {createMemoryHistory as createHistory} from 'history'
+import { createMemoryHistory as createHistory } from 'history'
 
 describe('A <Router>', () => {
   const node = document.createElement('div')

--- a/packages/react-router/modules/__tests__/SwitchMount-test.js
+++ b/packages/react-router/modules/__tests__/SwitchMount-test.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import ReactDOM from 'react-dom'
-import {createMemoryHistory as createHistory } from 'history'
+import { createMemoryHistory as createHistory } from 'history'
 import Router from '../Router'
 import Switch from '../Switch'
 import Route from '../Route'

--- a/packages/react-router/modules/__tests__/SwitchMount-test.js
+++ b/packages/react-router/modules/__tests__/SwitchMount-test.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import ReactDOM from 'react-dom'
-import createHistory from 'history/createMemoryHistory'
+import {createMemoryHistory as createHistory } from 'history'
 import Router from '../Router'
 import Switch from '../Switch'
 import Route from '../Route'


### PR DESCRIPTION
Fixes https://github.com/ReactTraining/react-router/issues/5576
The issue is when we have something like 
`import createBrowserHistory from  'history/createBrowserHistory'`
you get file included into the result dist:
` node_modules/history/createBrowserHistory.js`
And then when you import something like
`import {smth} from 'history'`
and your webpack or other build tool is configured to read packages.json>module property then it includes node_modules/history/es/index.js and then node_modules/history/es/createBrowserHistory.js
So both files are included:
```
node_modules/history/createBrowserHistory.js
node_modules/history/es/createBrowserHistory.js
```