### PR TITLE
Escape NavLink path to allow special characters in path.  Fixes #5584

### DIFF
--- a/packages/react-router-dom/modules/NavLink.js
+++ b/packages/react-router-dom/modules/NavLink.js
@@ -19,20 +19,14 @@ const NavLink = ({
   ariaCurrent,
   ...rest
 }) => {
-  // Escape special Route path matching characters since `to` is expected to be an exact url.
-  let unescapedPath;
-  if (typeof to === 'object') {
-    unescapedPath = to.pathname;
-  } else {
-    unescapedPath = to;
-  }
+  const path = typeof to === 'object' ? to.pathname : to
 
   // Regex taken from: https://github.com/pillarjs/path-to-regexp/blob/master/index.js#L202
-  const path = unescapedPath.replace(/([.+*?=^!:${}()[\]|/\\])/g, '\\$1');
+  const escapedPath = path.replace(/([.+*?=^!:${}()[\]|/\\])/g, '\\$1')
 
   return (
     <Route
-      path={path}
+      path={escapedPath}
       exact={exact}
       strict={strict}
       location={location}

--- a/packages/react-router-dom/modules/NavLink.js
+++ b/packages/react-router-dom/modules/NavLink.js
@@ -18,27 +18,40 @@ const NavLink = ({
   isActive: getIsActive,
   ariaCurrent,
   ...rest
-}) => (
-  <Route
-    path={typeof to === 'object' ? to.pathname : to}
-    exact={exact}
-    strict={strict}
-    location={location}
-    children={({ location, match }) => {
-      const isActive = !!(getIsActive ? getIsActive(match, location) : match)
+}) => {
+  // Escape special Route path matching characters since `to` is expected to be an exact url.
+  let unescapedPath;
+  if (typeof to === 'object') {
+    unescapedPath = to.pathname;
+  } else {
+    unescapedPath = to;
+  }
 
-      return (
-        <Link
-          to={to}
-          className={isActive ? [ className, activeClassName ].filter(i => i).join(' ') : className}
-          style={isActive ? { ...style, ...activeStyle } : style}
-          aria-current={isActive && ariaCurrent}
-          {...rest}
-        />
-      )
-    }}
-  />
-)
+  // Regex taken from: https://github.com/pillarjs/path-to-regexp/blob/master/index.js#L202
+  const path = unescapedPath.replace(/([.+*?=^!:${}()[\]|/\\])/g, '\\$1');
+
+  return (
+    <Route
+      path={path}
+      exact={exact}
+      strict={strict}
+      location={location}
+      children={({ location, match }) => {
+        const isActive = !!(getIsActive ? getIsActive(match, location) : match)
+
+        return (
+          <Link
+            to={to}
+            className={isActive ? [ className, activeClassName ].filter(i => i).join(' ') : className}
+            style={isActive ? { ...style, ...activeStyle } : style}
+            aria-current={isActive && ariaCurrent}
+            {...rest}
+          />
+        )
+      }}
+    />
+  );
+}
 
 NavLink.propTypes = {
   to: Link.propTypes.to,

--- a/packages/react-router-dom/modules/__tests__/NavLink-test.js
+++ b/packages/react-router-dom/modules/__tests__/NavLink-test.js
@@ -50,6 +50,19 @@ describe('NavLink', () => {
       const a = node.getElementsByTagName('a')[0]
       expect(a.style.color).toBe(activeStyle.color)
     })
+
+    it('it properly escapes path-to-regexp special characters', () => {
+      ReactDOM.render((
+        <MemoryRouter initialEntries={['/pizza (1)']}>
+          <NavLink to='/pizza (1)'>Pizza!</NavLink>
+        </MemoryRouter>
+      ), node)
+
+      const href = node.querySelector('a').getAttribute('href')
+      expect(href).toEqual('/pizza (1)')
+      const a = node.getElementsByTagName('a')[0]
+      expect(a.className).toEqual('active')
+    })
   })
 
   describe('When a <NavLink> is not active', () => {


### PR DESCRIPTION
The `to` prop passed to NavLink needs to have special characters escaped when passed to the Route component.  This change allows NavLink to be used for urls with any characters.

Example routes that will be taken literally:
- /pizza (1)
- /:pizza*
- /(.*) 