### PR TITLE
enable onUnmatch prop on Router

### DIFF
--- a/modules/Router.js
+++ b/modules/Router.js
@@ -104,7 +104,7 @@ const Router = createReactClass({
         assignRouterState(this.router, state)
         this.setState(state, this.props.onUpdate)
       }
-    })
+    }, this.props.onUnmatch)
   },
 
   /* istanbul ignore next: sanity check */

--- a/modules/__tests__/transitionHooks-test.js
+++ b/modules/__tests__/transitionHooks-test.js
@@ -11,7 +11,7 @@ import match from '../match'
 describe('When a router enters a branch', function () {
   let
     node,
-    newsLeaveHookSpy, removeNewsLeaveHook, userLeaveHookSpy,
+    newsLeaveHookSpy, removeNewsLeaveHook, userLeaveHookSpy, unmatchSpy,
     DashboardRoute, NewsFeedRoute, InboxRoute, RedirectToInboxRoute, MessageRoute, UserRoute, AssignmentRoute,
     routes
 
@@ -19,6 +19,7 @@ describe('When a router enters a branch', function () {
     node = document.createElement('div')
     newsLeaveHookSpy = expect.createSpy()
     userLeaveHookSpy = expect.createSpy()
+    unmatchSpy = expect.createSpy()
 
     class Dashboard extends Component {
       render() {
@@ -199,6 +200,13 @@ describe('When a router enters a branch', function () {
     render(<Router history={createHistory('/news')} routes={routes}/>, node, function () {
       expect(dashboardRouteEnterSpy).toHaveBeenCalled()
       expect(newsFeedRouteEnterSpy).toHaveBeenCalled()
+      done()
+    })
+  })
+
+  it('calls the onUnmatch hooks of Router on /unmatch_url', function (done) {
+    render(<Router history={createHistory('/unmatch_url')} routes={routes} onUnmatch={unmatchSpy}/>, node, function () {
+      expect(unmatchSpy).toHaveBeenCalled()
       done()
     })
   })

--- a/modules/createTransitionManager.js
+++ b/modules/createTransitionManager.js
@@ -211,7 +211,7 @@ export default function createTransitionManager(history, routes) {
    * changes, we update state and call the listener. We can also
    * gracefully handle errors and redirects.
    */
-  function listen(listener) {
+  function listen(listener, unmatchHandler) {
     function historyListener(location) {
       if (state.location === location) {
         listener(null, state)
@@ -224,11 +224,15 @@ export default function createTransitionManager(history, routes) {
           } else if (nextState) {
             listener(null, nextState)
           } else {
-            warning(
-              false,
-              'Location "%s" did not match any routes',
-              location.pathname + location.search + location.hash
-            )
+            if (typeof unmatchHandler === 'function') {
+              unmatchHandler(location)
+            } else {
+              warning(
+                false,
+                'Location "%s" did not match any routes',
+                location.pathname + location.search + location.hash
+              )
+            }
           }
         })
       }


### PR DESCRIPTION
enable Router to be hooked on `onUnmatch` so that application could handle location when the location doesn't match any of the defined routes.

Although we can append a `<Route path="/*" onEnter={}/> in the end of Route definition to match any URL, it make the same code not working well on server side.

Sample use case:

~~~~
import {match, Router, browserHistory} from 'react-router';
import {routes} from './routes';
import {App} from './app';

match({routes, history: browserHistory}, (error, redirectLocation, renderProps) => {
  if (renderProps) {
    renderProps.onUnmatch = function(location) {
        window.location.reload(); //force the page to refresh to hit the server again
    };
  } else {
     alert("should not happen here");
  }

  var el = React.createElement(
      App, { },
      React.createElement(Router, renderProps)
  );

  render(el, document.getElementById('root'));
});

~~~~
For various reason, we need to put the unmatched URL page into another server, and the those servers are managed by load balancer.
