### PR TITLE
[README] remove install instruction for history

### DIFF
--- a/packages/react-router-redux/README.md
+++ b/packages/react-router-redux/README.md
@@ -20,7 +20,6 @@ Users of react-router 2.x and 3.x want to use react-router-redux found at [the l
 
 ```
 npm install --save react-router-redux@next
-npm install --save history
 ```
 
 ## Usage


### PR DESCRIPTION
`history` is is listed as dependency in project's package.json, so there should be no need for explicit install by user