### PR TITLE
Add selectors to files

### DIFF
--- a/packages/react-router-redux/package.json
+++ b/packages/react-router-redux/package.json
@@ -12,6 +12,7 @@
     "actions.js",
     "es",
     "index.js",
+    "selectors.js",
     "middleware.js",
     "reducer.js",
     "umd"


### PR DESCRIPTION
fixes #5637 where requireing index.js would fail.

Reproduction steps:

```
> require('react-router-redux');
Error: Cannot find module './selectors'
    at Function.Module._resolveFilename (module.js:527:15)
    at Function.Module._load (module.js:476:23)
    at Module.require (module.js:568:17)
    at require (internal/module.js:11:18)
    at Object.<anonymous> (/home/halkeye/git/sauce/billing/node_modules/react-router-redux/index.js:6:18)
    at Module._compile (module.js:624:30)
    at Object.Module._extensions..js (module.js:635:10)
    at Module.load (module.js:545:32)
    at tryModuleLoad (module.js:508:12)
    at Function.Module._load (module.js:500:3)
```