### PR TITLE
Improvements to react-router-redux examples

### DIFF
--- a/packages/react-router-redux/examples/AuthExample.js
+++ b/packages/react-router-redux/examples/AuthExample.js
@@ -55,7 +55,7 @@ const ConnectedSwitch = connect(state => ({
 
 class LoginContainer extends React.Component {
   render() {
-    return <button onClick={() => this.props.login()}>Login Here!</button>
+    return <button onClick={this.props.login}>Login Here!</button>
   }
 }
 
@@ -65,7 +65,7 @@ class HomeContainer extends React.Component {
   }
 
   render() {
-    return <button onClick={() => this.props.logout()}>Logout Here!</button>
+    return <button onClick={this.props.logout}>Logout Here!</button>
   }
 }
 
@@ -73,7 +73,7 @@ const AppContainer = ({ location }) => (
   <ConnectedSwitch>
     <PrivateRoute component={Home} />
   </ConnectedSwitch>
-);
+)
 
 class PrivateRouteContainer extends React.Component {
   render() {

--- a/packages/react-router-redux/examples/AuthExample.js
+++ b/packages/react-router-redux/examples/AuthExample.js
@@ -12,6 +12,7 @@ import { createStore, applyMiddleware, combineReducers } from 'redux'
 import createHistory from 'history/createBrowserHistory'
 
 import { Route, Switch } from 'react-router'
+import { Redirect } from 'react-router-dom'
 
 const history = createHistory()
 
@@ -49,10 +50,6 @@ const store = createStore(
   applyMiddleware(routerMiddleware(history)),
 )
 
-const ConnectedSwitch = connect(state => ({
-	location: state.location
-}))(Switch)
-
 class LoginContainer extends React.Component {
   render() {
     return <button onClick={this.props.login}>Login Here!</button>
@@ -69,17 +66,29 @@ class HomeContainer extends React.Component {
   }
 }
 
-const AppContainer = ({ location }) => (
-  <ConnectedSwitch>
-    <PrivateRoute component={Home} />
-  </ConnectedSwitch>
-)
-
 class PrivateRouteContainer extends React.Component {
   render() {
-    return this.props.isAuthenticated ?
-        <Route exact path="/" component={this.props.component} />
-    :   <Route exact path="/" component={Login} />
+    const {
+      isAuthenticated,
+      component: Component,
+      ...props
+    } = this.props
+
+    return (
+      <Route
+        {...props}
+        render={props =>
+          isAuthenticated
+            ? <Component {...props} />
+            : (
+            <Redirect to={{
+              pathname: '/login',
+              state: { from: props.location }
+            }} />
+          )
+        }
+      />
+    )
   }
 }
 
@@ -97,18 +106,17 @@ const Login = connect(null, dispatch => ({
 const Home = connect(null, dispatch => ({
   logout: () => {
     dispatch(authFail())
-    dispatch(push('/'))
+    dispatch(push('/login'))
   }
 }))(HomeContainer)
-
-const App = connect(state => ({
-  location: state.location,
-}))(AppContainer)
 
 render(
   <Provider store={store}>
     <ConnectedRouter history={history}>
-      <App />
+      <Switch>
+        <Route path="/login" component={Login} />
+        <PrivateRoute exact path="/" component={Home} />
+      </Switch>
     </ConnectedRouter>
   </Provider>,
   document.getElementById('root'),

--- a/packages/react-router-redux/examples/AuthExample.js
+++ b/packages/react-router-redux/examples/AuthExample.js
@@ -1,111 +1,115 @@
-import React from 'react';
-import { render } from 'react-dom';
-import { Provider } from 'react-redux';
-import { ConnectedRouter } from 'react-router-redux';
+import React from 'react'
+import { render } from 'react-dom'
+import { connect, Provider } from 'react-redux'
+import {
+  ConnectedRouter,
+  routerReducer,
+  routerMiddleware,
+  push
+} from 'react-router-redux'
 
-import { createStore, applyMiddleware, combineReducers } from 'redux';
-import createHistory from 'history/createBrowserHistory';
-import { routerReducer, routerMiddleware, push } from 'react-router-redux';
+import { createStore, applyMiddleware, combineReducers } from 'redux'
+import createHistory from 'history/createBrowserHistory'
 
-import { connect } from 'react-redux';
-import { Route, Switch } from 'react-router';
+import { Route, Switch } from 'react-router'
 
-const history = createHistory();
+const history = createHistory()
 
 const authSuccess = () => ({
-    type: 'AUTH_SUCCESS'
+  type: 'AUTH_SUCCESS'
 })
 
 const authFail = () => ({
-    type: 'AUTH_FAIL'
+  type: 'AUTH_FAIL'
 })
 
 const initialState = {
-    isAuthenticated: false
+  isAuthenticated: false
 }
 
 const authReducer = (state = initialState , action) => {
-    switch (action.type) {
-        case 'AUTH_SUCCESS':
-            return Object.assign({}, ...state, {
-                isAuthenticated: true
-            });
-        case 'AUTH_FAIL':
-            return Object.assign({}, ...state, {
-                isAuthenticated: false
-            });
-        default: 
-            return { ...state };
-    }
+  switch (action.type) {
+    case 'AUTH_SUCCESS':
+      return {
+        ...state,
+        isAuthenticated: true
+      }
+    case 'AUTH_FAIL':
+      return {
+        ...state,
+        isAuthenticated: false
+      }
+    default:
+      return state
+  }
 }
 
 const store = createStore(
-    combineReducers({ routerReducer, authReducer }),
-    applyMiddleware(routerMiddleware(history)),
-);
+  combineReducers({ routerReducer, authReducer }),
+  applyMiddleware(routerMiddleware(history)),
+)
 
 const ConnectedSwitch = connect(state => ({
 	location: state.location
-}))(Switch);
+}))(Switch)
 
 class LoginContainer extends React.Component {
-    render() {
-        return <button onClick={() => this.props.login()}>Login Here!</button>
-    }
+  render() {
+    return <button onClick={() => this.props.login()}>Login Here!</button>
+  }
 }
 
 class HomeContainer extends React.Component {
-    componentWillMount() {
-        alert('Private home is at: ' + this.props.location.pathname)
-    }
+  componentWillMount() {
+    alert('Private home is at: ' + this.props.location.pathname)
+  }
 
-    render() {
-        return <button onClick={() => this.props.logout()}>Logout Here!</button>
-    }
+  render() {
+    return <button onClick={() => this.props.logout()}>Logout Here!</button>
+  }
 }
 
 const AppContainer = ({ location }) => (
-    <ConnectedSwitch>
-        <PrivateRoute component={Home} />
-    </ConnectedSwitch>
+  <ConnectedSwitch>
+    <PrivateRoute component={Home} />
+  </ConnectedSwitch>
 );
 
 class PrivateRouteContainer extends React.Component {
-    render() {
-        return this.props.isAuthenticated ?
-            <Route exact path="/" component={this.props.component} />
-        :   <Route exact path="/" component={Login} />
-    }
+  render() {
+    return this.props.isAuthenticated ?
+        <Route exact path="/" component={this.props.component} />
+    :   <Route exact path="/" component={Login} />
+  }
 }
 
 const PrivateRoute = connect(state => ({
-    isAuthenticated: state.authReducer.isAuthenticated
+  isAuthenticated: state.authReducer.isAuthenticated
 }))(PrivateRouteContainer)
 
 const Login = connect(null, dispatch => ({
-    login: () => { 
-        dispatch(authSuccess())
-        dispatch(push('/'))
-    }
+  login: () => {
+    dispatch(authSuccess())
+    dispatch(push('/'))
+  }
 }))(LoginContainer)
 
 const Home = connect(null, dispatch => ({
-    logout: () => { 
-        dispatch(authFail())
-        dispatch(push('/'))
-    }
+  logout: () => {
+    dispatch(authFail())
+    dispatch(push('/'))
+  }
 }))(HomeContainer)
 
 const App = connect(state => ({
-    location: state.location,
+  location: state.location,
 }))(AppContainer)
 
 render(
-    <Provider store={store}>
-        <ConnectedRouter history={history}>
-            <App />
-        </ConnectedRouter>
-    </Provider>,
-    document.getElementById('root'),
-);
-  
+  <Provider store={store}>
+    <ConnectedRouter history={history}>
+      <App />
+    </ConnectedRouter>
+  </Provider>,
+  document.getElementById('root'),
+)

--- a/packages/react-router-redux/examples/BasicExample.js
+++ b/packages/react-router-redux/examples/BasicExample.js
@@ -1,44 +1,41 @@
-import React from 'react';
-import { render } from 'react-dom';
-import { Provider } from 'react-redux';
-import { ConnectedRouter } from 'react-router-redux';
+import React from 'react'
+import { render } from 'react-dom'
+import { connect, Provider } from 'react-redux'
+import { ConnectedRouter, routerReducer, routerMiddleware } from 'react-router-redux'
 
-import { createStore, applyMiddleware } from 'redux';
-import createHistory from 'history/createBrowserHistory';
-import { routerReducer, routerMiddleware } from 'react-router-redux';
+import { createStore, applyMiddleware } from 'redux'
+import createHistory from 'history/createBrowserHistory'
 
-import { connect } from 'react-redux';
-import { Link } from 'react-router-dom';
-import { Route, Switch } from 'react-router';
+import { Link } from 'react-router-dom'
+import { Route, Switch } from 'react-router'
 
-const history = createHistory();
+const history = createHistory()
 
 const store = createStore(
-    routerReducer,
-    applyMiddleware(routerMiddleware(history)),
-);
+  routerReducer,
+  applyMiddleware(routerMiddleware(history)),
+)
 
 const ConnectedSwitch = connect(state => ({
-	location: state.location
-}))(Switch);
+  location: state.location
+}))(Switch)
 
-const AppContainer = ({ location }) => (
-    <ConnectedSwitch>
-        <Route exact path="/" component={(props) => (<h1>Home <Link to="/about">About</Link></h1>)} />
-        <Route path="/about" component={(props) => (<h1>About <Link to="/">Home</Link></h1>)} />
-    </ConnectedSwitch>
-);
+const AppContainer = () => (
+  <ConnectedSwitch>
+    <Route exact path="/" component={() => (<h1>Home <Link to="/about">About</Link></h1>)} />
+    <Route path="/about" component={() => (<h1>About <Link to="/">Home</Link></h1>)} />
+  </ConnectedSwitch>
+)
 
 const App = connect(state => ({
-    location: state.location,
+  location: state.location,
 }))(AppContainer)
 
 render(
-    <Provider store={store}>
-        <ConnectedRouter history={history}>
-            <App />
-        </ConnectedRouter>
-    </Provider>,
-    document.getElementById('root'),
-);
-  
+  <Provider store={store}>
+    <ConnectedRouter history={history}>
+      <App />
+    </ConnectedRouter>
+  </Provider>,
+  document.getElementById('root'),
+)


### PR DESCRIPTION
I made some general improvements to things I noticed in the examples:

- Removed duplicated imports;
- Removed semicolons; 
- Changed indentation style;
- Fixed `authReducer` which was removing any props other than `isAuthenticated` because of the spread operator and also triggering an update on default case;