### PR TITLE
add history action to LOCATION_CHANGE payload

### DIFF
--- a/packages/react-router-redux/modules/ConnectedRouter.js
+++ b/packages/react-router-redux/modules/ConnectedRouter.js
@@ -15,10 +15,10 @@ class ConnectedRouter extends Component {
     store: PropTypes.object
   }
 
-  handleLocationChange = location => {
+  handleLocationChange = (location, action) => {
     this.store.dispatch({
       type: LOCATION_CHANGE,
-      payload: location
+      payload: { ...location, action }
     })
   }
 


### PR DESCRIPTION
I'm using the event LOCATION_CHANGE to load resources based on his location, rather than based on a component loading, there's a case where I want to know if the user is navigating or replacing the current url