### PR TITLE
react-router-redux/createMatchSelector: handle null case when router state is not yet initialized

### DIFF
--- a/packages/react-router-redux/modules/__tests__/selectors-test.js
+++ b/packages/react-router-redux/modules/__tests__/selectors-test.js
@@ -25,7 +25,7 @@ describe('selectors', () => {
   })
 
   describe('createMatchSelector', () => {
-    it('matches correctly', () => {
+    it('matches correctly if the router is initialized', () => {
       const matchSelector = createMatchSelector('/')
       store.dispatch({
         type: LOCATION_CHANGE,
@@ -38,6 +38,12 @@ describe('selectors', () => {
         path: '/',
         url: '/'
       })
+    })
+    
+    it('does not throw error if router has not yet initialized', () => {
+      const matchSelector = createMatchSelector('/')
+      const state = store.getState()
+      expect(matchSelector(state)).toEqual({})
     })
 
     it('does not update if the match is the same', () => {

--- a/packages/react-router-redux/modules/__tests__/selectors-test.js
+++ b/packages/react-router-redux/modules/__tests__/selectors-test.js
@@ -43,7 +43,7 @@ describe('selectors', () => {
     it('does not throw error if router has not yet initialized', () => {
       const matchSelector = createMatchSelector('/')
       const state = store.getState()
-      expect(matchSelector(state))
+      expect(() => matchSelector(state)).not.toThrow()
     })
 
     it('does not update if the match is the same', () => {

--- a/packages/react-router-redux/modules/__tests__/selectors-test.js
+++ b/packages/react-router-redux/modules/__tests__/selectors-test.js
@@ -43,7 +43,7 @@ describe('selectors', () => {
     it('does not throw error if router has not yet initialized', () => {
       const matchSelector = createMatchSelector('/')
       const state = store.getState()
-      expect(matchSelector(state)).toEqual({})
+      expect(matchSelector(state))
     })
 
     it('does not update if the match is the same', () => {

--- a/packages/react-router-redux/modules/selectors.js
+++ b/packages/react-router-redux/modules/selectors.js
@@ -6,7 +6,7 @@ export const createMatchSelector = (path) => {
   let lastPathname = null
   let lastMatch = null
   return (state) => {
-    const { pathname } = getLocation(state)
+    const { pathname } = getLocation(state) || {}
     if (pathname === lastPathname) {
       return lastMatch
     }


### PR DESCRIPTION
If one uses the `createMatchSelector` selector function provided by this library (presumbly using `connect`) in a component that could potentially be in an uninitialized state where the `router` property has not yet been initialized by redux (i.e. the root `<Router>` component of your route hierarchy), the line at https://github.com/ReactTraining/react-router/blob/master/packages/react-router-redux/modules/selectors.js#L9 causes the selector to throw an error by destructuring on the `undefined` return value of `getLocation(state)`.