### PR TITLE
Remove history methods from render of Link

### DIFF
--- a/packages/react-router-dom/modules/Link.js
+++ b/packages/react-router-dom/modules/Link.js
@@ -38,6 +38,20 @@ class Link extends React.Component {
     }).isRequired
   }
 
+  getHref = () => {
+    const { replace, to } = this.props // eslint-disable-line no-unused-vars
+    
+    invariant(
+      this.context.router,
+      'You should not use <Link> outside a <Router>'
+    )
+
+    const { history } = this.context.router
+    const location = typeof to === 'string' ? createLocation(to, null, null, history.location) : to
+
+    return history.createHref(location)
+  }
+
   handleClick = (event) => {
     if (this.props.onClick)
       this.props.onClick(event)
@@ -62,17 +76,9 @@ class Link extends React.Component {
   }
 
   render() {
-    const { replace, to, innerRef, ...props } = this.props // eslint-disable-line no-unused-vars
-
-    invariant(
-      this.context.router,
-      'You should not use <Link> outside a <Router>'
-    )
-
-    const { history } = this.context.router
-    const location = typeof to === 'string' ? createLocation(to, null, null, history.location) : to
-
-    const href = history.createHref(location)
+    const { innerRef, ...props } = this.props // eslint-disable-line no-unused-vars
+    const href = this.getHref()
+    
     return <a {...props} onClick={this.handleClick} href={href} ref={innerRef}/>
   }
 }


### PR DESCRIPTION
The render method computes what `href` should be. This causes challenges when developers want to extend the `Link` component to render a link that is not an anchor tag. For example, developers want to use their own design-language-system component. Now they can:

```javascript
import { Link as RouterLink } from 'react-router-dom';
import DLSLink from 'path/to/DLSLink';

class ReactRouterDlsLink extends RouterLink {
  render() {
    const { innerRef, ...props } = this.props;
    const href = this.getHref();

    return (
      <DLSLink {...props} onPress={this.handleClick} href={href} ref={innerRef} />
    );
  }
}
```