### PR TITLE
add namespaces to react-router-redux

### DIFF
--- a/packages/react-router-redux/modules/ConnectedRouter.js
+++ b/packages/react-router-redux/modules/ConnectedRouter.js
@@ -8,7 +8,8 @@ class ConnectedRouter extends Component {
   static propTypes = {
     store: PropTypes.object,
     history: PropTypes.object,
-    children: PropTypes.node
+    children: PropTypes.node,
+    namespace: PropTypes.string
   }
 
   static contextTypes = {
@@ -16,9 +17,13 @@ class ConnectedRouter extends Component {
   }
 
   handleLocationChange = location => {
+    const { namespace } = this.props
     this.store.dispatch({
       type: LOCATION_CHANGE,
-      payload: location
+      payload: {
+        location,
+        namespace
+      }
     })
   }
 

--- a/packages/react-router-redux/modules/__tests__/ConnectedRouter-test.js
+++ b/packages/react-router-redux/modules/__tests__/ConnectedRouter-test.js
@@ -19,7 +19,7 @@ describe('A <ConnectedRouter>', () => {
   })
 
   it('connects to a store via Provider', () => {
-    expect(store.getState()).toHaveProperty('router.location', null)
+    expect(store.getState()).toHaveProperty('router.location.default', null)
 
     renderer.create(
       <Provider store={store}>
@@ -29,11 +29,11 @@ describe('A <ConnectedRouter>', () => {
       </Provider>
     )
 
-    expect(store.getState()).toHaveProperty('router.location.pathname')
+    expect(store.getState()).toHaveProperty('router.location.default.pathname')
   })
 
   it('connects to a store via props', () => {
-    expect(store.getState()).toHaveProperty('router.location', null)
+    expect(store.getState()).toHaveProperty('router.location.default', null)
 
     renderer.create(
       <ConnectedRouter store={store} history={history}>
@@ -41,41 +41,58 @@ describe('A <ConnectedRouter>', () => {
       </ConnectedRouter>
     )
 
-    expect(store.getState()).toHaveProperty('router.location.pathname')
+    expect(store.getState()).toHaveProperty('router.location.default.pathname')
+  })
+  describe('with no namespace', () => {
+    it('updates the store with location changes, setting to default namespace', () => {
+      renderer.create(
+        <ConnectedRouter store={store} history={history}>
+          <div>Test</div>
+        </ConnectedRouter>
+      )
+
+      expect(store.getState()).toHaveProperty('router.location.default.pathname', '/')
+
+      history.push('/foo')
+
+      expect(store.getState()).toHaveProperty('router.location.default.pathname', '/foo')
+    })
   })
 
-  it('updates the store with location changes', () => {
-    renderer.create(
-      <ConnectedRouter store={store} history={history}>
-        <div>Test</div>
-      </ConnectedRouter>
-    )
+  describe('with namespace set', () => {
+    it('updates the store with location changes, setting to the specified namespace', () => {
+      renderer.create(
+        <ConnectedRouter store={store} history={history} namespace={'inMemory'}>
+          <div>Test</div>
+        </ConnectedRouter>
+      )
 
-    expect(store.getState()).toHaveProperty('router.location.pathname', '/')
+      expect(store.getState()).toHaveProperty('router.location.inMemory.pathname', '/')
 
-    history.push('/foo')
+      history.push('/foo')
 
-    expect(store.getState()).toHaveProperty('router.location.pathname', '/foo')
+      expect(store.getState()).toHaveProperty('router.location.inMemory.pathname', '/foo')
+    })
   })
 
   describe('with children', () => {
-    it('to render', () => {      
+    it('to render', () => {
       const tree = renderer.create(
         <ConnectedRouter store={store} history={history}>
           <div>Test</div>
         </ConnectedRouter>
       ).toJSON()
-      
+
       expect(tree).toMatchSnapshot()
     })
   })
 
   describe('with no children', () => {
-    it('to render', () => {      
+    it('to render', () => {
       const tree = renderer.create(
         <ConnectedRouter store={store} history={history} />
       ).toJSON()
-      
+
       expect(tree).toMatchSnapshot()
     })
   })

--- a/packages/react-router-redux/modules/__tests__/actions-test.js
+++ b/packages/react-router-redux/modules/__tests__/actions-test.js
@@ -1,10 +1,10 @@
 import {
   CALL_HISTORY_METHOD,
-  push, replace, go, goBack, goForward
+  push, replace, go, goBack, goForward,
+  namespacedPush, namespacedReplace, namespacedGo, namespacedGoBack, namespacedGoForward
 } from '../actions'
 
 describe('routerActions', () => {
-
   describe('push', () => {
     it('creates actions', () => {
       expect(push('/foo')).toEqual({
@@ -95,4 +95,112 @@ describe('routerActions', () => {
     })
   })
 
+  describe('namespaced actions', () => {
+    describe('namespacedPush', () => {
+      it('returns a function which creates actions with namespace', () => {
+        const action = namespacedPush('bar')
+        expect(action('/foo')).toEqual({
+          type: CALL_HISTORY_METHOD,
+          payload: {
+            method: 'push',
+            args: [ '/foo' ],
+            namespace: 'bar'
+          }
+        })
+
+        expect(action({ pathname: '/foo', state: { the: 'state' } })).toEqual({
+          type: CALL_HISTORY_METHOD,
+          payload: {
+            method: 'push',
+            args: [ {
+              pathname: '/foo',
+              state: { the: 'state' }
+            } ],
+            namespace: 'bar'
+          }
+        })
+
+        expect(action('/foo', 'baz', 123)).toEqual({
+          type: CALL_HISTORY_METHOD,
+          payload: {
+            method: 'push',
+            args: [ '/foo' , 'baz', 123 ],
+            namespace: 'bar'
+          }
+        })
+      })
+    })
+
+    describe('namespacedReplace', () => {
+      it('returns a function which creates actions with namespace', () => {
+        const action = namespacedReplace('bar-replace')
+
+        expect(action('/foo')).toEqual({
+          type: CALL_HISTORY_METHOD,
+          payload: {
+            method: 'replace',
+            args: [ '/foo' ],
+            namespace: 'bar-replace'
+          }
+        })
+
+        expect(action({ pathname: '/foo', state: { the: 'state' } })).toEqual({
+          type: CALL_HISTORY_METHOD,
+          payload: {
+            method: 'replace',
+            args: [ {
+              pathname: '/foo',
+              state: { the: 'state' }
+            } ],
+            namespace: 'bar-replace'
+          }
+        })
+      })
+    })
+
+    describe('namespacedGo', () => {
+      it('returns a function which creates actions with namespace', () => {
+        const action = namespacedGo('bar-go')
+
+        expect(action(1)).toEqual({
+          type: CALL_HISTORY_METHOD,
+          payload: {
+            method: 'go',
+            args: [ 1 ],
+            namespace: 'bar-go',
+          }
+        })
+      })
+    })
+
+    describe('namespacedGoBack', () => {
+      it('returns a function which creates actions with namespace', () => {
+        const action = namespacedGoBack('bar-back')
+
+        expect(action()).toEqual({
+          type: CALL_HISTORY_METHOD,
+          payload: {
+            method: 'goBack',
+            args: [],
+            namespace: 'bar-back',
+          }
+        })
+      })
+    })
+
+    describe('namespacedGoForward', () => {
+      it('returns a function which creates actions with namespace', () => {
+        const action = namespacedGoForward('bar-forward')
+
+        expect(action()).toEqual({
+          type: CALL_HISTORY_METHOD,
+          payload: {
+            method: 'goForward',
+            args: [],
+            namespace: 'bar-forward',
+          }
+        })
+      })
+    })
+  })
 })

--- a/packages/react-router-redux/modules/__tests__/middleware-test.js
+++ b/packages/react-router-redux/modules/__tests__/middleware-test.js
@@ -1,32 +1,90 @@
-import { push, replace } from '../actions'
+import { push, namespacedPush, replace, namespacedReplace } from '../actions'
 import routerMiddleware from '../middleware'
 
 describe('routerMiddleware', () => {
   let history, next, dispatch
 
-  beforeEach(() => {
-    history = {
-      push: jest.fn(),
-      replace: jest.fn()
-    }
-    next = jest.fn()
+  describe('without namespace specified', () => {
+    beforeEach(() => {
+      history = {
+        push: jest.fn(),
+        replace: jest.fn()
+      }
+      next = jest.fn()
 
-    dispatch = routerMiddleware(history)()(next)
+      dispatch = routerMiddleware(history)()(next)
+    })
+
+    it('calls the appropriate history method', () => {
+      dispatch(push('/foo'))
+      expect(history.push).toHaveBeenCalled()
+
+      dispatch(replace('/foo'))
+      expect(history.replace).toHaveBeenCalled()
+
+      expect(next).toHaveBeenCalledTimes(0)
+    })
+
+    it('does not call history methods if action is namespaced', () => {
+      dispatch(namespacedPush('namespaced')('/foo'))
+      expect(history.push).toHaveBeenCalledTimes(0)
+
+      dispatch(namespacedReplace('namespaced')('/foo'))
+      expect(history.replace).toHaveBeenCalledTimes(0)
+
+      expect(next).toHaveBeenCalled()
+    })
+
+    it('ignores other actions', () => {
+      dispatch({ type: 'FOO' })
+      expect(next).toHaveBeenCalled()
+    })
   })
 
+  describe('with namespace set', () => {
+    beforeEach(() => {
+      history = {
+        push: jest.fn(),
+        replace: jest.fn()
+      }
+      next = jest.fn()
 
-  it('calls the appropriate history method', () => {
-    dispatch(push('/foo'))
-    expect(history.push).toHaveBeenCalled()
+      dispatch = routerMiddleware(history, 'a-namespace')()(next)
+    })
 
-    dispatch(replace('/foo'))
-    expect(history.replace).toHaveBeenCalled()
+    it('does not call history method if action is not namespaced', () => {
+      dispatch(push('/foo'))
+      expect(history.push).toHaveBeenCalledTimes(0)
 
-    expect(next).toHaveBeenCalledTimes(0)
-  })
+      dispatch(replace('/foo'))
+      expect(history.replace).toHaveBeenCalledTimes(0)
 
-  it('ignores other actions', () => {
-    dispatch({ type: 'FOO' })
-    expect(next).toHaveBeenCalled()
+      expect(next).toHaveBeenCalled()
+    })
+
+    it('does not call history method if action’s namespace does not match middleware’s namespace', () => {
+      dispatch(namespacedPush('anotherNamespace')('/foo'))
+      expect(history.push).toHaveBeenCalledTimes(0)
+
+      dispatch(namespacedReplace('anotherNamespace')('/foo'))
+      expect(history.replace).toHaveBeenCalledTimes(0)
+
+      expect(next).toHaveBeenCalled()
+    })
+
+    it('calls the appropriate history method if action’s namespace matchs middleware’s namespace', () => {
+      dispatch(namespacedPush('a-namespace')('/foo'))
+      expect(history.push).toHaveBeenCalled()
+
+      dispatch(namespacedReplace('a-namespace')('/foo'))
+      expect(history.replace).toHaveBeenCalled()
+
+      expect(next).toHaveBeenCalledTimes(0)
+    })
+
+    it('ignores other actions', () => {
+      dispatch({ type: 'FOO' })
+      expect(next).toHaveBeenCalled()
+    })
   })
 })

--- a/packages/react-router-redux/modules/__tests__/reducer-test.js
+++ b/packages/react-router-redux/modules/__tests__/reducer-test.js
@@ -1,56 +1,72 @@
 import { LOCATION_CHANGE, routerReducer } from '../reducer'
 
 describe('routerReducer', () => {
-  const state = {
-    location: {
-      pathname: '/foo',
-      action: 'POP'
+  describe('with namespace unset', () => {
+    const state = {
+      location: {
+        default: {
+          pathname: '/foo',
+          action: 'POP'
+        }
+      }
     }
-  }
 
-  it('updates the path', () => {
-    expect(routerReducer(state, {
-      type: LOCATION_CHANGE,
-      payload: {
-        path: '/bar',
-        action: 'PUSH'
-      }
-    })).toEqual({
-      location: {
-        path: '/bar',
-        action: 'PUSH'
-      }
+    it('updates the path', () => {
+      expect(routerReducer(state, {
+        type: LOCATION_CHANGE,
+        payload: {
+          location: {
+            path: '/bar',
+            action: 'PUSH'
+          }
+        }
+      })).toEqual({
+        location: {
+          default: {
+            path: '/bar',
+            action: 'PUSH'
+          }
+        }
+      })
     })
-  })
 
-  it('works with initialState', () => {
-    expect(routerReducer(undefined, {
-      type: LOCATION_CHANGE,
-      payload: {
-        path: '/bar',
-        action: 'PUSH'
-      }
-    })).toEqual({
-      location: {
-        path: '/bar',
-        action: 'PUSH'
-      }
+    it('works with initialState', () => {
+      expect(routerReducer(undefined, {
+        type: LOCATION_CHANGE,
+        payload: {
+          location: {
+            path: '/bar',
+            action: 'PUSH'
+          }
+        }
+      })).toEqual({
+        location: {
+          default: {
+            path: '/bar',
+            action: 'PUSH'
+          }
+        }
+      })
     })
-  })
 
 
-  it('respects replace', () => {
-    expect(routerReducer(state, {
-      type: LOCATION_CHANGE,
-      payload: {
-        path: '/bar',
-        action: 'REPLACE'
-      }
-    })).toEqual({
-      location: {
-        path: '/bar',
-        action: 'REPLACE'
-      }
+    it('respects replace', () => {
+      expect(routerReducer(state, {
+        type: LOCATION_CHANGE,
+        payload: {
+          location: {
+            path: '/bar',
+            action: 'REPLACE'
+          }
+        }
+      })).toEqual({
+        location: {
+          default: {
+            path: '/bar',
+            action: 'REPLACE'
+          }
+        }
+      })
     })
   })
 })

--- a/packages/react-router-redux/modules/__tests__/selectors-test.js
+++ b/packages/react-router-redux/modules/__tests__/selectors-test.js
@@ -17,7 +17,7 @@ describe('selectors', () => {
       const location = { pathname: '/' }
       store.dispatch({
         type: LOCATION_CHANGE,
-        payload: location
+        payload: { location }
       })
       const state = store.getState()
       expect(getLocation(state)).toBe(location)
@@ -29,7 +29,9 @@ describe('selectors', () => {
       const matchSelector = createMatchSelector('/')
       store.dispatch({
         type: LOCATION_CHANGE,
-        payload: { pathname: '/test' }
+        payload: {
+          location: { pathname: '/test' }
+        }
       })
       const state = store.getState()
       expect(matchSelector(state)).toEqual({
@@ -39,7 +41,7 @@ describe('selectors', () => {
         url: '/'
       })
     })
-    
+
     it('does not throw error if router has not yet initialized', () => {
       const matchSelector = createMatchSelector('/')
       const state = store.getState()
@@ -50,12 +52,16 @@ describe('selectors', () => {
       const matchSelector = createMatchSelector('/')
       store.dispatch({
         type: LOCATION_CHANGE,
-        payload: { pathname: '/test1' }
+        payload: {
+          location: { pathname: '/test1' }
+        }
       })
       const match1 = matchSelector(store.getState())
       store.dispatch({
         type: LOCATION_CHANGE,
-        payload: { pathname: '/test2' }
+        payload: {
+          location: { pathname: '/test2' }
+        }
       })
       const match2 = matchSelector(store.getState())
       expect(match1).toBe(match2)
@@ -65,12 +71,16 @@ describe('selectors', () => {
       const matchSelector = createMatchSelector('/sushi/:type')
       store.dispatch({
         type: LOCATION_CHANGE,
-        payload: { pathname: '/sushi/california' }
+        payload: {
+          location: { pathname: '/sushi/california' }
+        }
       })
       const match1 = matchSelector(store.getState())
       store.dispatch({
         type: LOCATION_CHANGE,
-        payload: { pathname: '/sushi/dynamite' }
+        payload: {
+          location: { pathname: '/sushi/dynamite' }
+        }
       })
       const match2 = matchSelector(store.getState())
       expect(match1).not.toBe(match2)

--- a/packages/react-router-redux/modules/actions.js
+++ b/packages/react-router-redux/modules/actions.js
@@ -7,9 +7,9 @@
 export const CALL_HISTORY_METHOD = '@@router/CALL_HISTORY_METHOD'
 
 function updateLocation(method) {
-  return (...args) => ({
+  return (namespace) => (...args) => ({
     type: CALL_HISTORY_METHOD,
-    payload: { method, args }
+    payload: { method, args, namespace }
   })
 }
 
@@ -18,10 +18,23 @@ function updateLocation(method) {
  * The associated routerMiddleware will capture these events before they get to
  * your reducer and reissue them as the matching function on your history.
  */
-export const push = updateLocation('push')
-export const replace = updateLocation('replace')
-export const go = updateLocation('go')
-export const goBack = updateLocation('goBack')
-export const goForward = updateLocation('goForward')
+export const namespacedPush = updateLocation('push')
+export const namespacedReplace = updateLocation('replace')
+export const namespacedGo = updateLocation('go')
+export const namespacedGoBack = updateLocation('goBack')
+export const namespacedGoForward = updateLocation('goForward')
+
+export const push = namespacedPush()
+export const replace = namespacedReplace()
+export const go = namespacedGo()
+export const goBack = namespacedGoBack()
+export const goForward = namespacedGoForward()
 
 export const routerActions = { push, replace, go, goBack, goForward }
+export const namespacedRouterActions = (namespace) => ({
+  push: namespacedPush(namespace),
+  replace: namespacedReplace(namespace),
+  go: namespacedGo(namespace),
+  goBack: namespacedGoBack(namespace),
+  goForward: namespacedGoForward(namespace),
+})

--- a/packages/react-router-redux/modules/index.js
+++ b/packages/react-router-redux/modules/index.js
@@ -4,6 +4,7 @@ export { LOCATION_CHANGE, routerReducer } from './reducer'
 export {
   CALL_HISTORY_METHOD,
   push, replace, go, goBack, goForward,
-  routerActions
+  namespacedPush, namespacedReplace, namespacedGo, namespacedGoBack, namespacedGoForward,
+  routerActions, namespacedRouterActions,
 } from './actions'
 export routerMiddleware from './middleware'

--- a/packages/react-router-redux/modules/middleware.js
+++ b/packages/react-router-redux/modules/middleware.js
@@ -5,13 +5,15 @@ import { CALL_HISTORY_METHOD } from './actions'
  * provided history object. This will prevent these actions from reaching your
  * reducer or any middleware that comes after this one.
  */
-export default function routerMiddleware(history) {
+export default function routerMiddleware(history, key) {
   return () => next => action => {
     if (action.type !== CALL_HISTORY_METHOD) {
       return next(action)
     }
-
-    const { payload: { method, args } } = action
+    const { payload: { method, args, namespace } } = action
+    if (key !== namespace) {
+      return next(action)
+    }
     history[method](...args)
   }
 }

--- a/packages/react-router-redux/modules/reducer.js
+++ b/packages/react-router-redux/modules/reducer.js
@@ -5,7 +5,7 @@
 export const LOCATION_CHANGE = '@@router/LOCATION_CHANGE'
 
 const initialState = {
-  location: null
+  location: { default: null },
 }
 
 /**
@@ -16,7 +16,11 @@ const initialState = {
  */
 export function routerReducer(state = initialState, { type, payload } = {}) {
   if (type === LOCATION_CHANGE) {
-    return { ...state, location: payload }
+    const { location, namespace } = payload
+    return { ...state, location: {
+      ...state.location,
+      [namespace || 'default']: location,
+    }}
   }
 
   return state

--- a/packages/react-router-redux/modules/selectors.js
+++ b/packages/react-router-redux/modules/selectors.js
@@ -1,6 +1,6 @@
 import { matchPath } from 'react-router'
 
-export const getLocation = state => state.router.location
+export const getLocation = (state, namespace='default') => state.router.location[namespace]
 
 export const createMatchSelector = (path) => {
   let lastPathname = null


### PR DESCRIPTION
This is a PR demonstrating one possible implementation of name-spacing react-router-redux to allow the management of multiple routers via redux. Please see this feature request - https://github.com/ReactTraining/react-router/issues/5663.

It adds the abstractions that we currently need to dispatch router actions to multiple routers, while remaining backward compatible with the simple interface of react-router-redux.
