### PR TITLE
Fix link to location.md in <Switch> documentation

### DIFF
--- a/packages/react-router/docs/api/Switch.md
+++ b/packages/react-router/docs/api/Switch.md
@@ -51,7 +51,7 @@ This is also useful for animated transitions since the matched `<Route>` is rend
 
 ## location: object
 
-A [`location`](location.md) object to be used for matching children elements instead of the current history location (usually the current browser URL).
+A [`location`](./location.md) object to be used for matching children elements instead of the current history location (usually the current browser URL).
 
 ## children: node
 


### PR DESCRIPTION
The `./` there is important to give the correct link when rendered.

Note that this is not related to #5259

Also note that this breaks not the link when browsing github repo, but for the [website](https://reacttraining.com/react-router/web/api/Switch/Switch-props) - the hyperlink points to `/react-router/location.md` instead of `/react-router/web/api/location.md`