### PR TITLE
Version 3: Added peerDependency support for React 16.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "warning": "^3.0.0"
   },
   "peerDependencies": {
-    "react": "^0.14.0 || ^15.0.0 || ^16.0.0-rc"
+    "react": "^0.14.0 || ^15.0.0 || ^16.0.0"
   },
   "devDependencies": {
     "babel-cli": "^6.11.4",


### PR DESCRIPTION
After upgrading to React 16 the react-router v3 throws a peerDependency warning.

This fix it to stop this warning and allow downstream modules to build without peerDependency failures.