### PR TITLE
Updated react-transition-group and changed Animation.js example

### DIFF
--- a/website/modules/examples/Animation.js
+++ b/website/modules/examples/Animation.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import { CSSTransitionGroup } from 'react-transition-group'
+import { CSSTransition, TransitionGroup } from 'react-transition-group'
 import {
   BrowserRouter as Router,
   Route,
@@ -35,24 +35,26 @@ const AnimationExample = () => (
         </ul>
 
         <div style={styles.content}>
-          <CSSTransitionGroup
-            transitionName="fade"
-            transitionEnterTimeout={300}
-            transitionLeaveTimeout={300}
-          >
-            {/* no different than other usage of
+          <TransitionGroup>
+            <CSSTransition
+              classNames="fade"
+              timeout = {300}
+              key={location.key}
+            >
+              {/* no different than other usage of
                 CSSTransitionGroup, just make
                 sure to pass `location` to `Route`
                 so it can match the old location
                 as it animates out
-            */}
-            <Route
-              location={location}
-              key={location.key}
-              path="/:h/:s/:l"
-              component={HSL}
-            />
-          </CSSTransitionGroup>
+              */}
+              <Route
+                location={location}
+                key={location.key}
+                path="/:h/:s/:l"
+                component={HSL}
+              />
+            </CSSTransition>
+          </TransitionGroup>
         </div>
       </div>
     )}/>

--- a/website/package.json
+++ b/website/package.json
@@ -47,7 +47,7 @@
     "cheerio": "^0.22.0",
     "react-icons": "^2.2.3",
     "react-media": "^1.5.1",
-    "react-transition-group": "^1.1.2",
+    "react-transition-group": "^2.2.1",
     "resolve-pathname": "^2.0.2",
     "slug": "^0.9.1"
   }


### PR DESCRIPTION
For beginners like me it would be nice if you would use the latest version from react-transition-group in your Animations example. In v2 of react-transition-group the implementation for CSS Transitions changed slightly.