### PR TITLE
Pass propeties from `Route` to children

### DIFF
--- a/packages/react-router/modules/Route.js
+++ b/packages/react-router/modules/Route.js
@@ -104,10 +104,10 @@ class Route extends React.Component {
 
   render() {
     const { match } = this.state
-    const { children, component, render } = this.props
+    const { children, component, render, ...rest } = this.props
     const { history, route, staticContext } = this.context.router
     const location = this.props.location || route.location
-    const props = { match, location, history, staticContext }
+    const props = { match, location, history, staticContext, ...rest }
 
     if (component)
       return match ? React.createElement(component, props) : null


### PR DESCRIPTION
In older versions of the router the default behavior had been to pass all properties from a parent component to its children. e.g as can be seen in https://scotch.io/tutorials/react-on-the-server-for-beginners-build-a-universal-react-and-node-app

```
const routes = (
  <Route path="/" component={Layout}>
    <IndexRoute component={IndexPage}/>
    <Route path="athlete/:id" component={AthletePage}/>
    <Route path="*" component={NotFoundPage}/>
  </Route>
);
```

What happened here is that in the `Layout` component,  we could create helper method via HOC components and those helper were injected into the child component e.g. IndexPage

The change I propose is to bring back that default behavior.