### PR TITLE
Remove single child restriction for <Router>

### DIFF
--- a/packages/react-router/modules/Router.js
+++ b/packages/react-router/modules/Router.js
@@ -3,6 +3,11 @@ import invariant from "invariant";
 import React from "react";
 import PropTypes from "prop-types";
 
+function is16Plus() {
+  const [major] = React.version.split('.');
+  return parseInt(major) >= 16;
+}
+
 /**
  * The public API for putting history on context.
  */
@@ -50,9 +55,9 @@ class Router extends React.Component {
     const { children, history } = this.props;
 
     invariant(
-      children == null || React.Children.count(children) === 1,
-      "A <Router> may have only one child element"
-    );
+      is16Plus() || children == null || React.Children.count(children) === 1,
+      'A <Router> may have only one child element'
+    )
 
     // Do this here so we can setState when a <Redirect> changes the
     // location in componentWillMount. This happens e.g. when doing
@@ -76,8 +81,7 @@ class Router extends React.Component {
   }
 
   render() {
-    const { children } = this.props;
-    return children ? React.Children.only(children) : null;
+    return this.props.children || null
   }
 }
 

--- a/packages/react-router/modules/Router.js
+++ b/packages/react-router/modules/Router.js
@@ -3,11 +3,6 @@ import invariant from "invariant";
 import React from "react";
 import PropTypes from "prop-types";
 
-function is16Plus() {
-  const [major] = React.version.split('.');
-  return parseInt(major) >= 16;
-}
-
 /**
  * The public API for putting history on context.
  */
@@ -55,9 +50,11 @@ class Router extends React.Component {
     const { children, history } = this.props;
 
     invariant(
-      is16Plus() || children == null || React.Children.count(children) === 1,
-      'A <Router> may have only one child element'
-    )
+      React.Fragment !== undefined ||
+        children == null ||
+        React.Children.count(children) === 1,
+      "A <Router> may have only one child element"
+    );
 
     // Do this here so we can setState when a <Redirect> changes the
     // location in componentWillMount. This happens e.g. when doing
@@ -81,7 +78,7 @@ class Router extends React.Component {
   }
 
   render() {
-    return this.props.children || null
+    return this.props.children || null;
   }
 }
 

--- a/packages/react-router/modules/__tests__/Router-test.js
+++ b/packages/react-router/modules/__tests__/Router-test.js
@@ -11,10 +11,8 @@ describe("A <Router>", () => {
     ReactDOM.unmountComponentAtNode(node);
   });
 
-  describe("when it has more than one child", () => {
-    it("throws an error explaining a Router may have only one child", () => {
-      spyOn(console, "error");
-
+  describe('when it has more than one child', () => {
+    it('renders all children', () => {
       expect(() => {
         ReactDOM.render(
           <Router history={createHistory()}>
@@ -22,10 +20,11 @@ describe("A <Router>", () => {
             <p>Bar</p>
           </Router>,
           node
-        );
-      }).toThrow(/A <Router> may have only one child element/);
-    });
-  });
+        )
+      }).not.toThrow()
+      expect(node.textContent).toBe('FooBar')
+    })
+  })
 
   describe("with exactly one child", () => {
     it("does not throw an error", () => {

--- a/packages/react-router/modules/__tests__/Router-test.js
+++ b/packages/react-router/modules/__tests__/Router-test.js
@@ -11,8 +11,8 @@ describe("A <Router>", () => {
     ReactDOM.unmountComponentAtNode(node);
   });
 
-  describe('when it has more than one child', () => {
-    it('renders all children', () => {
+  describe("when it has more than one child", () => {
+    it("renders all children", () => {
       expect(() => {
         ReactDOM.render(
           <Router history={createHistory()}>
@@ -20,11 +20,11 @@ describe("A <Router>", () => {
             <p>Bar</p>
           </Router>,
           node
-        )
-      }).not.toThrow()
-      expect(node.textContent).toBe('FooBar')
-    })
-  })
+        );
+      }).not.toThrow();
+      expect(node.textContent).toBe("FooBar");
+    });
+  });
 
   describe("with exactly one child", () => {
     it("does not throw an error", () => {


### PR DESCRIPTION
This PR takes advantage of the fact that with React 16, a component can return multiple elements.

```js
// 15
ReactDOM.render((
  <BrowserRouter>
    <div>
      <One />
      <Two />
    </div>
  </BrowserRouter>
), holder);

// 16
ReactDOM.render((
  <BrowserRouter>
    <One />
    <Two />
  </BrowserRouter>
), holder);
```

The `invariant` call will still throw in React 15 if the user passes multiple children to a `<Router>`. I'm not actually sure if there is a convenient way to test this. If someone is using React 15 and attempts to pass multiple children, the `invariant` will throw before the `render` function is called, so the changes to the `render` function should have no effect