### PR TITLE
Add 'action' to the react-router-redux LOCATION_CHANGE payload

### DIFF
--- a/packages/react-router-redux/modules/ConnectedRouter.js
+++ b/packages/react-router-redux/modules/ConnectedRouter.js
@@ -15,10 +15,10 @@ class ConnectedRouter extends Component {
     store: PropTypes.object
   }
 
-  handleLocationChange = location => {
+  handleLocationChange = (location, action) => {
     this.store.dispatch({
       type: LOCATION_CHANGE,
-      payload: location
+      payload: { action, ...location }
     })
   }
 


### PR DESCRIPTION
Right now there is no way to actually check what location change event happened through the actions provided by the `react-router-redux`, but [even the tests](https://github.com/ReactTraining/react-router/blob/master/packages/react-router-redux/modules/__tests__/reducer-test.js) are suggesting that `action` should be available in the payload.

This PR tries to fix this by adding action type of the `history` change event to the `LOCATION_CHANGE` action payload.

I'm not sure if I need to add any tests for that change, all the current tests are passing locally for me.