### PR TITLE
Use history.createLocation in <StaticRouter>

### DIFF
--- a/packages/react-router/modules/StaticRouter.js
+++ b/packages/react-router/modules/StaticRouter.js
@@ -2,18 +2,8 @@ import warning from "warning";
 import invariant from "invariant";
 import React from "react";
 import PropTypes from "prop-types";
-import { createPath, parsePath } from "history";
+import { createLocation, createPath } from "history";
 import Router from "./Router";
-
-const normalizeLocation = object => {
-  const { pathname = "/", search = "", hash = "" } = object;
-
-  return {
-    pathname,
-    search: search === "?" ? "" : search,
-    hash: hash === "#" ? "" : hash
-  };
-};
 
 const addLeadingSlash = path => {
   return path.charAt(0) === "/" ? path : "/" + path;
@@ -40,11 +30,6 @@ const stripBasename = (basename, location) => {
     pathname: location.pathname.substr(base.length)
   };
 };
-
-const createLocation = location =>
-  typeof location === "string"
-    ? parsePath(location)
-    : normalizeLocation(location);
 
 const createURL = location =>
   typeof location === "string" ? location : createPath(location);


### PR DESCRIPTION
Currently, there is an inconsistency between the pseudo-history used by the `<StaticRouter>` and the histories created by the `history` package because the `history` package creates locations with decoded pathnames, while the pseudo-history does not. This PR updates the `<StaticRouter>` to use the `createLocation` function from the `history` package to ensure consistent decoding between `<StaticRouter>` and the other routers.

Fixes #5296. #5359 is also partially fixed by this, but that also includes `matchPath` tests which are outside the scope of this PR.