### PR TITLE
Changed prop type of Route component

### DIFF
--- a/packages/react-router/modules/Route.js
+++ b/packages/react-router/modules/Route.js
@@ -13,7 +13,10 @@ const isEmptyChildren = (children) =>
 class Route extends React.Component {
   static propTypes = {
     computedMatch: PropTypes.object, // private, from <Switch>
-    path: PropTypes.string,
+    path: PropTypes.oneOfType([
+      PropTypes.string,
+      PropTypes.object
+    ]),
     exact: PropTypes.bool,
     strict: PropTypes.bool,
     sensitive: PropTypes.bool,


### PR DESCRIPTION
Change prop type of Route component's 'path' prop to be either string or object (in order there would not be a  warning on regexp passed).