### PR TITLE
Change `history.location.state` to `object`

### DIFF
--- a/packages/react-router/docs/api/history.md
+++ b/packages/react-router/docs/api/history.md
@@ -16,7 +16,7 @@ The following terms are also used:
   - `pathname` - (string) The path of the URL
   - `search` - (string) The URL query string
   - `hash` - (string) The URL hash fragment
-  - `state` - (string) location-specific state that was provided to e.g. `push(path, state)` when this location was pushed onto the stack. Only available in browser and memory history.
+  - `state` - (object) location-specific state that was provided to e.g. `push(path, state)` when this location was pushed onto the stack. Only available in browser and memory history.
 - `push(path, [state])` - (function) Pushes a new entry onto the history stack
 - `replace(path, [state])` - (function) Replaces the current entry on the history stack
 - `go(n)` - (function) Moves the pointer in the history stack by `n` entries


### PR DESCRIPTION
Correct me if I'm wrong, but I believe `history.location.state` is an `object` and not a `string`?