### PR TITLE
Listen history in componentWillMount

### DIFF
--- a/packages/react-router-redux/modules/ConnectedRouter.js
+++ b/packages/react-router-redux/modules/ConnectedRouter.js
@@ -26,10 +26,6 @@ class ConnectedRouter extends Component {
     const { store:propsStore, history } = this.props
     this.store = propsStore || this.context.store
     this.handleLocationChange(history.location)
-  }
-
-  componentDidMount() {
-    const { history } = this.props
     this.unsubscribeFromHistory = history.listen(this.handleLocationChange)
   }
 


### PR DESCRIPTION
When I rendered page which have to redirect, my child component push to history new route but `ConnectedRouter` did't dispatch action `LOCATION_CHANGE` a second time, because subscription occurs after render `Redirect` component .

``` 
<Provider store={ store }>
  <ConnectedRouter history={history}>
     <Route exact path="/" render={() => (<Redirect to="/test" />)} />    
  </ConnectedRouter>
</Provider>
```
So, I think to fix this case needs move `history.listen` from componentDidMount to componentWillMount