### PR TITLE
[BUG-FIX]: createMatchSelector isExact

### DIFF
--- a/packages/react-router-redux/modules/__tests__/selectors-test.js
+++ b/packages/react-router-redux/modules/__tests__/selectors-test.js
@@ -75,6 +75,21 @@ describe('selectors', () => {
       const match2 = matchSelector(store.getState())
       expect(match1).not.toBe(match2)
     })
+
+    it('updates if the exact match is different', () => {
+      const matchSelector = createMatchSelector('/sushi')
+      store.dispatch({
+        type: LOCATION_CHANGE,
+        payload: { pathname: '/sushi' }
+      })
+      const match1 = matchSelector(store.getState())
+      store.dispatch({
+        type: LOCATION_CHANGE,
+        payload: { pathname: '/sushi/dynamite' }
+      })
+      const match2 = matchSelector(store.getState())
+      expect(match1).not.toBe(match2)
+    })
   })
 
 })

--- a/packages/react-router-redux/modules/selectors.js
+++ b/packages/react-router-redux/modules/selectors.js
@@ -12,7 +12,10 @@ export const createMatchSelector = (path) => {
     }
     lastPathname = pathname
     const match = matchPath(pathname, path)
-    if (!match || !lastMatch || match.url !== lastMatch.url) {
+    if (
+      !match || !lastMatch || match.url !== lastMatch.url
+      || match.isExact !== lastMatch.isExact
+    ) {
       lastMatch = match
     }
     return lastMatch


### PR DESCRIPTION
Hi and thanks a lot for this package,

I've notice a pretty annoying bug with the `createMatchSelector`. In this PR I've added a test to reproduce the bug and a fix.

Basically what happens is that the selector doesn't update the `match` object if what have change is the `isExact` property.

For instance, if I have a "matchSelector" for the path "/sushi" and the user navigates from "/sushi" to "/sushi/dynamite", despite of the fact that the `match` object is different (before it was an exact match and now it it's not) the previously memoized match is the one that is returned.

It's an easy fix.

Thanks,

Josep