### PR TITLE
Add Switch location argument to renderRoutes

### DIFF
--- a/packages/react-router-config/README.md
+++ b/packages/react-router-config/README.md
@@ -186,7 +186,7 @@ import routes from './routes'
 
 Again, that's all pseudo-code. There are a lot of ways to do server rendering with data and pending navigation and we haven't settled on one. The point here is that `matchRoutes` gives you a chance to match statically outside of the render lifecycle. We'd like to make a demo app of this approach eventually.
 
-### `renderRoutes(routes, extraProps = {})`
+### `renderRoutes(routes, extraProps = {}, switchProps = {})`
 
 In order to ensure that matching outside of render with `matchRoutes` and inside of render result in the same branch, you must use `renderRoutes` instead of `<Route>` inside your components. You can render a `<Route>` still, but know that it will not be accounted for in `matchRoutes` outside of render.
 

--- a/packages/react-router-config/modules/__tests__/renderRoutes-test.js
+++ b/packages/react-router-config/modules/__tests__/renderRoutes-test.js
@@ -174,6 +174,37 @@ describe('renderRoutes', () => {
       history.push('/three')
       expect(mountCount).toBe(2)
     })
+
+    it('passes props to Switch', () => {
+      const App = ({ route: { routes } }) => (
+        renderRoutes(routes)
+      )
+
+      const routeToMatch = {
+        component: Comp,
+        path: '/one'
+      }
+
+      const routes = [
+        { path: '/',
+          component: App,
+          routes: [
+            { path: '/one',
+              component: Comp
+            }
+          ]
+        }
+      ]
+
+      ReactDOMServer.renderToString(
+        <StaticRouter location='/two' context={{}}>
+          {renderRoutes(routes, {}, {location: { pathname: '/one' }})}
+        </StaticRouter>
+      )
+
+      expect(renderedRoutes.length).toEqual(1)
+      expect(renderedRoutes[0]).toEqual(routeToMatch)
+    })
   })
 
   describe('routes with exact', () => {

--- a/packages/react-router-config/modules/renderRoutes.js
+++ b/packages/react-router-config/modules/renderRoutes.js
@@ -1,4 +1,3 @@
-
 import React from 'react'
 import Switch from 'react-router/Switch'
 import Route from 'react-router/Route'

--- a/packages/react-router-config/modules/renderRoutes.js
+++ b/packages/react-router-config/modules/renderRoutes.js
@@ -1,9 +1,10 @@
+
 import React from 'react'
 import Switch from 'react-router/Switch'
 import Route from 'react-router/Route'
 
-const renderRoutes = (routes, extraProps = {}) => routes ? (
-  <Switch>
+const renderRoutes = (routes, extraProps = {}, switchProps = {}) => routes ? (
+  <Switch {...switchProps}>
     {routes.map((route, i) => (
       <Route
         key={route.key || i}


### PR DESCRIPTION
In order to render routes in a `modal` using `renderRoutes` (https://reacttraining.com/react-router/web/example/modal-gallery), `renderRoutes` receives an optional `location` argument to set on the `Switch` component.