### PR TITLE
Allow customising the render of a Switch component

### DIFF
--- a/packages/react-router/modules/Switch.js
+++ b/packages/react-router/modules/Switch.js
@@ -16,7 +16,8 @@ class Switch extends React.Component {
 
   static propTypes = {
     children: PropTypes.node,
-    location: PropTypes.object
+    location: PropTypes.object,
+    render: PropTypes.func
   }
 
   componentWillMount() {
@@ -40,21 +41,25 @@ class Switch extends React.Component {
 
   render() {
     const { route } = this.context.router
-    const { children } = this.props
+    const { children, render } = this.props
     const location = this.props.location || route.location
 
-    let match, child
-    React.Children.forEach(children, element => {
+    let match, child, index = -1
+    React.Children.forEach(children, (element, i) => {
       if (match == null && React.isValidElement(element)) {
         const { path: pathProp, exact, strict, sensitive, from } = element.props
         const path = pathProp || from
 
         child = element
         match = path ? matchPath(location.pathname, { path, exact, strict, sensitive }) : route.match
+        if (match != null) {
+          index = i
+        }
       }
     })
 
-    return match ? React.cloneElement(child, { location, computedMatch: match }) : null
+    const result = match ? React.cloneElement(child, { location, computedMatch: match }) : null
+    return render ? render(result, index, children) : result
   }
 }
 


### PR DESCRIPTION
I wanted to re-create the animation I'd seen in the Facebook iOS app for swapping between tabs, where they get shunted left or right as if you're tabs are all on one flat plane and you're simply panning left/right across it.  To do this, I needed a way to intercept the switch component right before it renders the resulting element, and render something slightly different.  I also needed to know the index of the matched item, so I knew whether we were going left or right.

This render prop provides the hook I needed, and I imagine would also enable lots of alternative page transitions as well.

You can see it being used in [react-router-animated-switch](https://github.com/mopedjs/moped/tree/master/packages/react-router-animated-switch) and there's a live demo at https://adoring-austin-f8272b.netlify.com