### PR TITLE
[FIX]: Allow other middlewares to dispatch routerActions on init

### DIFF
--- a/packages/react-router-redux/modules/ConnectedRouter.js
+++ b/packages/react-router-redux/modules/ConnectedRouter.js
@@ -26,10 +26,11 @@ class ConnectedRouter extends Component {
   componentWillMount() {
     const { store:propsStore, history, isSSR } = this.props
     this.store = propsStore || this.context.store
-    this.handleLocationChange(history.location)
 
     if (!isSSR)
       this.unsubscribeFromHistory = history.listen(this.handleLocationChange)
+
+    this.handleLocationChange(history.location)
   }
 
   componentWillUnmount() {


### PR DESCRIPTION
A followup PR of [this discussion](https://github.com/ReactTraining/react-router/pull/5786#issuecomment-351220936).

cc @ericp96