### PR TITLE
Add invariant for missing "to" property

### DIFF
--- a/packages/react-router-dom/modules/Link.js
+++ b/packages/react-router-dom/modules/Link.js
@@ -69,6 +69,11 @@ class Link extends React.Component {
       'You should not use <Link> outside a <Router>'
     )
 
+    invariant(
+      to !== undefined,
+      'You must specify the "to" property'
+    )
+
     const { history } = this.context.router
     const location = typeof to === 'string' ? createLocation(to, null, null, history.location) : to
 

--- a/packages/react-router-dom/modules/__tests__/Link-test.js
+++ b/packages/react-router-dom/modules/__tests__/Link-test.js
@@ -27,15 +27,15 @@ describe('A <Link>', () => {
   describe('to as a string', () => {
     it('resolves to with no pathname using current location', () => {
       const node = document.createElement('div')
-      
+
       ReactDOM.render((
         <MemoryRouter initialEntries={[ '/somewhere' ]}>
           <Link to='?rendersWithPathname=true'>link</Link>
         </MemoryRouter>
       ), node)
-  
+
       const href = node.querySelector('a').getAttribute('href')
-  
+
       expect(href).toEqual('/somewhere?rendersWithPathname=true')
     })
   })
@@ -54,6 +54,25 @@ describe('A <Link>', () => {
     expect(console.error.calls.count()).toBe(2)
     expect(console.error.calls.argsFor(0)[0]).toContain(
       'The context `router` is marked as required in `Link`'
+    )
+  })
+
+  it('throws with no "to" prop', () => {
+    const node = document.createElement('div')
+
+    spyOn(console, 'error')
+
+    expect(() => {
+      ReactDOM.render((
+        <MemoryRouter>
+          <Link>link</Link>
+        </MemoryRouter>
+      ), node)
+    }).toThrow(/You must specify the "to" property/)
+
+    expect(console.error.calls.count()).toBe(2)
+    expect(console.error.calls.argsFor(0)[0]).toContain(
+      'The prop `to` is marked as required in `Link`'
     )
   })
 


### PR DESCRIPTION
First off - thanks for creating this. Me, myself and my team - and thousands of other developers across the world - are building incredibly successful apps thanks to your hard work and sexy brains. I hugely appreciate your efforts.

Now, to business.

Whenever you forget to set the `to` property on a `<Link />` component, You get the following error message:

![image](https://user-images.githubusercontent.com/1307267/34016039-b5bc8d4c-e120-11e7-953d-f675019320ed.png)

If I scroll long enough up the error log, you'll see the error from prop types telling me I forgot to set the required `to` prop - but it usually takes me a minute to figure it out. With the rising of `create-react-app` - many people will probably not find it for a bit, because they are busy looking through the stack traces in the error overlay (like I was in my screen shot above).

**This PR adds an invariant check** (I'm very open to suggestions about the error message) to ensure it's sent in. If not, the code will throw before it crashes and burns deep down in the `history` package.

Thoughts? It's my first time contributing to your code base, so if I screwed up some formatting way of thinking, please accept my apologies.