### PR TITLE
Bring back documentation on Link DOM props

### DIFF
--- a/packages/react-router-dom/docs/api/Link.md
+++ b/packages/react-router-dom/docs/api/Link.md
@@ -53,3 +53,8 @@ const refCallback = node => {
 
 <Link to="/" innerRef={refCallback} />
 ```
+
+## others
+
+You can also pass props you'd like to be on the `<a>` such as a `title`, `id`, `className`, etc.
+


### PR DESCRIPTION
In v3 the docs [clearly indicated](https://github.com/ReactTraining/react-router/blob/07d6b50ab9a9b6d1940d67abe530044be7f7dc99/docs/API.md#others) that `<Link>` takes DOM props to be put on `<a>`.
In v4 docs this information [is missing](https://reacttraining.com/react-router/web/api/Link).

Nevertheless, the functionality [is still here](https://github.com/ReactTraining/react-router/blob/96410c69be1ca32e294bf83e7d1321c39ecd286b/packages/react-router-dom/modules/Link.js#L76).
The contributors [refer to it](https://github.com/ReactTraining/react-router/issues/5760#issuecomment-347979291) as expected, public functionality.
The [`activeClassName` prop on `NavLink`](https://reacttraining.com/react-router/web/api/NavLink/activeClassName-string) clearly suggests that a regular `className` is also accepted.