### PR TITLE
Move to PureComponent

### DIFF
--- a/packages/react-router-dom/modules/BrowserRouter.js
+++ b/packages/react-router-dom/modules/BrowserRouter.js
@@ -7,7 +7,7 @@ import Router from './Router'
 /**
  * The public API for a <Router> that uses HTML5 history.
  */
-class BrowserRouter extends React.Component {
+class BrowserRouter extends React.PureComponent {
   static propTypes = {
     basename: PropTypes.string,
     forceRefresh: PropTypes.bool,

--- a/packages/react-router-dom/modules/HashRouter.js
+++ b/packages/react-router-dom/modules/HashRouter.js
@@ -7,7 +7,7 @@ import Router from './Router'
 /**
  * The public API for a <Router> that uses window.location.hash.
  */
-class HashRouter extends React.Component {
+class HashRouter extends React.PureComponent {
   static propTypes = {
     basename: PropTypes.string,
     getUserConfirmation: PropTypes.func,

--- a/packages/react-router-dom/modules/Link.js
+++ b/packages/react-router-dom/modules/Link.js
@@ -9,7 +9,7 @@ const isModifiedEvent = (event) =>
 /**
  * The public API for rendering a history-aware <a>.
  */
-class Link extends React.Component {
+class Link extends React.PureComponent {
   static propTypes = {
     onClick: PropTypes.func,
     target: PropTypes.string,

--- a/packages/react-router-native/Link.js
+++ b/packages/react-router-native/Link.js
@@ -1,8 +1,8 @@
-import React, { Component } from 'react'
+import React from 'react'
 import PropTypes from 'prop-types'
 import { TouchableHighlight } from 'react-native'
 
-class Link extends Component {
+class Link extends React.PureComponent {
   static contextTypes = {
     router: PropTypes.shape({
       history: PropTypes.shape({

--- a/packages/react-router-redux/modules/ConnectedRouter.js
+++ b/packages/react-router-redux/modules/ConnectedRouter.js
@@ -1,10 +1,10 @@
-import React, { Component } from 'react'
+import React from 'react'
 import PropTypes from 'prop-types'
 import { Router } from 'react-router'
 
 import { LOCATION_CHANGE } from './reducer'
 
-class ConnectedRouter extends Component {
+class ConnectedRouter extends React.PureComponent {
   static propTypes = {
     store: PropTypes.object,
     history: PropTypes.object.isRequired,

--- a/packages/react-router/modules/MemoryRouter.js
+++ b/packages/react-router/modules/MemoryRouter.js
@@ -7,7 +7,7 @@ import Router from './Router'
 /**
  * The public API for a <Router> that stores location in memory.
  */
-class MemoryRouter extends React.Component {
+class MemoryRouter extends React.PureComponent {
   static propTypes = {
     initialEntries: PropTypes.array,
     initialIndex: PropTypes.number,

--- a/packages/react-router/modules/Prompt.js
+++ b/packages/react-router/modules/Prompt.js
@@ -6,7 +6,7 @@ import invariant from 'invariant'
  * The public API for prompting the user before navigating away
  * from a screen with a component.
  */
-class Prompt extends React.Component {
+class Prompt extends React.PureComponent {
   static propTypes = {
     when: PropTypes.bool,
     message: PropTypes.oneOfType([

--- a/packages/react-router/modules/Route.js
+++ b/packages/react-router/modules/Route.js
@@ -10,7 +10,7 @@ const isEmptyChildren = (children) =>
 /**
  * The public API for matching a single path and rendering.
  */
-class Route extends React.Component {
+class Route extends React.PureComponent {
   static propTypes = {
     computedMatch: PropTypes.object, // private, from <Switch>
     path: PropTypes.string,

--- a/packages/react-router/modules/Router.js
+++ b/packages/react-router/modules/Router.js
@@ -6,7 +6,7 @@ import PropTypes from 'prop-types'
 /**
  * The public API for putting history on context.
  */
-class Router extends React.Component {
+class Router extends React.PureComponent {
   static propTypes = {
     history: PropTypes.object.isRequired,
     children: PropTypes.node

--- a/packages/react-router/modules/StaticRouter.js
+++ b/packages/react-router/modules/StaticRouter.js
@@ -66,7 +66,7 @@ const noop = () => {}
  * location changes in a context object. Useful mainly in testing and
  * server-rendering scenarios.
  */
-class StaticRouter extends React.Component {
+class StaticRouter extends React.PureComponent {
   static propTypes = {
     basename: PropTypes.string,
     context: PropTypes.object.isRequired,


### PR DESCRIPTION
Avoid re-renders on unneeded components. This is usually for Link (and NavLink), although it can include others like Route.