### PR TITLE
Support for Routing with Access Restriction

### DIFF
--- a/packages/react-router-config/modules/renderRoutes.js
+++ b/packages/react-router-config/modules/renderRoutes.js
@@ -1,8 +1,7 @@
 import React from 'react'
-import Switch from 'react-router/Switch'
-import Route from 'react-router/Route'
+import { Route, Redirect, Switch } from 'react-router'
 
-const renderRoutes = (routes, extraProps = {}, switchProps = {}) => routes ? (
+const renderRoutes = (routes, authed, authPath, extraProps = {}, switchProps = {}) => routes ? (
   <Switch {...switchProps}>
     {routes.map((route, i) => (
       <Route
@@ -10,9 +9,14 @@ const renderRoutes = (routes, extraProps = {}, switchProps = {}) => routes ? (
         path={route.path}
         exact={route.exact}
         strict={route.strict}
-        render={(props) => (
-          <route.component {...props} {...extraProps} route={route}/>
-        )}
+        render={(props) => {
+          
+          if( !route.restricted || authed || route.path == authPath) {
+            return <route.component {...props} {...extraProps} route={route}/>
+          }
+          const redirPath = authPath ? authPath : '/login'
+          return <Redirect to={{pathname: redirPath, state: {from: props.location}}}/>
+        }}
       />
     ))}
   </Switch>


### PR DESCRIPTION
This was a response to [Issue 4962](https://github.com/ReactTraining/react-router/issues/4962). I posted a solution on there which I've copied below:

I modified the `react-router-config`/[renderRoutes.js](https://github.com/ReactTraining/react-router/blob/master/packages/react-router-config/modules/renderRoutes.js) file to this:

```javascript
// renderRoutes.js

import React from 'react'
import Switch from 'react-router/Switch'
import { Route, Redirect } from 'react-router-dom'

const renderRoutes = (routes, authed, authPath, extraProps = {}, switchProps = {}) => routes ? (
  <Switch {...switchProps}>
    {routes.map((route, i) => (
      <Route
        key={route.key || i}
        path={route.path}
        exact={route.exact}
        strict={route.strict}
        render={(props) => {
          
          if( !route.restricted || authed || route.path == authPath) {
            return <route.component {...props} {...extraProps} route={route}/>
          }
          const redirPath = authPath ? authPath : '/login'
          return <Redirect to={{pathname: redirPath, state: {from: props.location}}}/>
        }}
      />
    ))}
  </Switch>
) : null

export default renderRoutes
```

I added `authed` and `authPath` as two new arguments to `renderRoutes` function.
* `authed` is true if user is logged in and false otherwise.
* `authPath` is the path you want to redirect to (e.g., /login) if `authed` is false. 

Here is how you call the `renderRoutes` function:
```javascript
// caller of renderRoutes

import React from 'react'
import { Switch } from 'react-router-dom'
//import { renderRoutes } from 'react-router-config'
import renderRoutes from '../renderRoutes'
import routes from '../routes3'

const authed = false // <-- You can change this
const authPath = '/login' // <-- You can change this

const Main = () => (
   <main>
      <Switch>
         {renderRoutes(routes, authed, authPath)}
      </Switch>
   </main>
)

export default Main
```

Having `authed` and `authPath` configurable from the caller of renderRoutes is desirable because it gives you more control over these parameters from `redux` / server side. I have not tried trying this solution out with `redux` or the server side logic for logging users in but that's what I'm going to be doing next.

Lastly, an important change need to be added to the routes object as part of this solution. Specifically, for each route, you need to specify a `restricted` field, which can be true if you want the page to be accessible only when `authed` is true, or false if the page is a public page that anyone can access. For example:

```javascript
// routes.js
import Home from './components/Home'
import Login from './components/User/Login'
import User from './components/User/User'

const routes = [
	{ path: '/',
		exact: true,
		restricted: false,  // <-- NEW
		component: Home,
	},
	{
		path: '/login',
		restricted: false, // <-- NEW
		component: Login,
	},
	{
		path: '/user',
		restricted: true, // <-- NEW
		component: User,
	},
	{
		path: '*',
		restricted: false, // <-- NEW
		component: NotFound
	}
]

```

For completeness, this is what the `Login` component looks like:

```javascript
// Login.js

import React from 'react'

class Login extends React.Component {
   render() {
      const { from } = this.props.location.state || { from: {pathname: '/' } }
         return (
	    <div>
	       <p>You must log in to view this page at {from.pathname} </p>
	          <button onClick={this.login}>Log in </button>
	     </div>
	 )
   }
}

export default Login
```

`this.props.location.state` tells you where you last were before you got directed to `/login`. The idea for this feature came out of the `PrivateRoute` [tutorial](https://reacttraining.com/react-router/web/example/auth-workflow).