### PR TITLE
Warn of possible tooling loss on upgrade

### DIFF
--- a/packages/react-router/docs/guides/migrating.md
+++ b/packages/react-router/docs/guides/migrating.md
@@ -4,7 +4,7 @@ React Router v4 is a complete rewrite, so there is not a simple migration path. 
 
 **Note:** This migration guide is for both React Router v2 and v3, but for brevity, references to previous versions will only mention v3.
 
-**Caution for react-router-redux users:** Not all packages are redux-router v4 compatible. In particular, time travel in Redux DevTools will be disabled on upgrading, as this feature is [not yet available](https://github.com/ReactTraining/react-router/pull/4717) in the latest react-router-redux (currently in beta).
+**Caution for react-router-redux users:** Not all packages are compatible with React Router v4 or are feature complete. In particular, time travel in Redux DevTools is [not yet available](https://github.com/ReactTraining/react-router/pull/4717) in the latest react-router-redux (currently in alpha).
 
 * [The Router](#the-router)
 * [Routes](#routes)

--- a/packages/react-router/docs/guides/migrating.md
+++ b/packages/react-router/docs/guides/migrating.md
@@ -4,6 +4,8 @@ React Router v4 is a complete rewrite, so there is not a simple migration path. 
 
 **Note:** This migration guide is for both React Router v2 and v3, but for brevity, references to previous versions will only mention v3.
 
+**Caution for react-router-redux users:** Not all packages are redux-router v4 compatible. In particular, time travel in Redux DevTools will be disabled on upgrading, as this feature is [not yet available](https://github.com/ReactTraining/react-router/pull/4717) in the latest react-router-redux (currently in beta).
+
 * [The Router](#the-router)
 * [Routes](#routes)
   * [Nesting Routes](#nesting-routes)


### PR DESCRIPTION
Hiya, thanks for all the fab work on these packages. So it wasn't until I was pretty far through the upgrade to react-router v4 that I found [these issues](https://github.com/ReactTraining/react-router/pull/4717) with react-router-redux and React DevTools. Obviously it will take time for the tooling etc to catch up with new releases of popular packages, but would it be possible to publicise this issue a little more? 