### PR TITLE
Install the package by yarn.

### DIFF
--- a/packages/react-router-redux/README.md
+++ b/packages/react-router-redux/README.md
@@ -22,6 +22,11 @@ Users of react-router 2.x and 3.x want to use react-router-redux found at [the l
 npm install --save react-router-redux@next
 npm install --save history
 ```
+or
+```
+yarn upgrade react-router-redux@next
+yarn add history
+```
 
 ## Usage
 


### PR DESCRIPTION
Our project is managed by `yarn`.
I install the react-router-redux@next by `npm`.
It caused some issues. 
It is better to add yarn install command to README.

