### PR TITLE
Update `req.url` to be `req.path`

### DIFF
--- a/packages/react-router/docs/api/matchPath.md
+++ b/packages/react-router/docs/api/matchPath.md
@@ -15,7 +15,7 @@ const match = matchPath('/users/123', {
 ## pathname
 
 The first argument is the pathname you want to match. If you're using
-this on the server with Node.js, it would be `req.url`.
+this on the server with Node.js, it would be `req.path`.
 
 ## props
 


### PR DESCRIPTION
URL's with query strings don't get matched correctly when using `req.url`. `req.path` is required instead. This PR simply updates the documentation.

https://github.com/ReactTraining/react-router/issues/5285