### PR TITLE
pretty-quick v1.2.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1616,9 +1616,9 @@
       "dev": true
     },
     "pretty-quick": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/pretty-quick/-/pretty-quick-1.2.0.tgz",
-      "integrity": "sha512-fgn3rP0mGOs73zdyuT6bCDavx3oXbXJvoIm+NhrRRW3cW5jnR4g2xFL32iccPvktgGE8ak9lMI2hn3uVplp40w==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/pretty-quick/-/pretty-quick-1.2.2.tgz",
+      "integrity": "sha512-8GYqYVcb2dJLuna3sALsCLIUi075+HHgiwwYrF89z2I6ERWI6VIEsaWgft9i/tG2FZWk143pjFLjZCfbUuYrww==",
       "dev": true,
       "requires": {
         "chalk": "2.3.0",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,6 @@
     "husky": "^0.14.3",
     "lerna": "2.2.0",
     "prettier": "^1.10.2",
-    "pretty-quick": "^1.2.0"
+    "pretty-quick": "^1.2.2"
   }
 }


### PR DESCRIPTION
There was an issue with the previous `pretty-quick` release that added all edited files (not just staged ones) when committing, which is fixed in this release.