### PR TITLE
Add precondition function & onPreconditionFailed callback on route co…

### DIFF
--- a/packages/react-router-config/modules/__tests__/renderRoutes-test.js
+++ b/packages/react-router-config/modules/__tests__/renderRoutes-test.js
@@ -433,4 +433,47 @@ describe("renderRoutes", () => {
       expect(renderedRoutes[1]).toEqual(routes[1].routes[1]);
     });
   });
+
+  describe("routes with precondition + onPreconditionFailed", () => {
+    it("renders the matched route if given precondition & precondition is satisfied", () => {
+      const precondition = jest.fn().mockReturnValue(true);
+      const onPreconditionFailed = jest.fn();
+      const routeToMatch = {
+        component: Comp,
+        path: "/foo/bar",
+        precondition,
+        onPreconditionFailed
+      };
+      const routes = [routeToMatch]
+      ReactDOMServer.renderToString(
+        <StaticRouter location="/foo/bar" context={{}}>
+          {renderRoutes(routes)}
+        </StaticRouter>
+      )
+      expect(precondition).toHaveBeenCalled();
+      expect(renderedRoutes.length).toBe(1);
+      expect(renderedRoutes[0]).toEqual(routeToMatch);
+      // onPreconditionFailed should not be called if precondition is satisfied
+      expect(onPreconditionFailed.mock.calls.length).toBe(0);
+    });
+
+    it("renders the onPreconditionFailed if precondition is not satisfied", () => {
+      const onPreconditionFailed = jest.fn().mockImplementation(Comp);
+      const routeToMatch = {
+        component: () => null,
+        path: "/foo/bar",
+        precondition: () => false,
+        onPreconditionFailed,
+      };
+      const routes = [routeToMatch]
+      ReactDOMServer.renderToString(
+        <StaticRouter location="/foo/bar" context={{}}>
+          {renderRoutes(routes)}
+        </StaticRouter>
+      )
+      expect(onPreconditionFailed).toHaveBeenCalled();
+      expect(onPreconditionFailed.mock.calls[0][0].route).toEqual(routeToMatch);
+      expect(renderedRoutes.length).toBe(1);
+    });
+  });
 });

--- a/packages/react-router-config/modules/renderRoutes.js
+++ b/packages/react-router-config/modules/renderRoutes.js
@@ -11,9 +11,16 @@ const renderRoutes = (routes, extraProps = {}, switchProps = {}) =>
           path={route.path}
           exact={route.exact}
           strict={route.strict}
-          render={props => (
-            <route.component {...props} {...extraProps} route={route} />
-          )}
+          render={props => {
+            const precondition = typeof route.precondition === 'function' ? route.precondition : () => true
+            if (precondition(props)) {
+              return <route.component {...props} {...extraProps} route={route} />
+            }
+            if (typeof route.onPreconditionFailed === 'function') {
+              return <route.onPreconditionFailed {...props} {...extraProps} route={route} />
+            }
+            return null
+          }}
         />
       ))}
     </Switch>


### PR DESCRIPTION
Should (hopefully) resolve #4962

Context: react-router-config

Introduced two new route properties:
1. precondition: `(RouteProps) => boolean`
2. onPreconditionFailed: `(RouteProps && ExtraProps && Route) => React.Node`

### Example: Authentication
```jsx
const shouldAuth = ({ match }) => checkAuth(match.params.userId);
const routes = [
  {
    path: '/foo/bar/:userId',
    component: MyComponent,
    precondition: shouldAuth,
    onPreconditionFailed: ({ location }) => 
        <Redirect to={{ pathname: '/login', state: { location.state } }} from={location.pathname} />
  },
  {
    path: '/login',
    component: MyLoginComponent,
  }
]
```
Other use cases including, but not limited to:
- IP filtering
- Feature control
- AB testing