### PR TITLE
Enable flag in Switch children

### DIFF
--- a/packages/react-router/docs/api/Redirect.md
+++ b/packages/react-router/docs/api/Redirect.md
@@ -20,7 +20,7 @@ The URL to redirect to. Any valid URL path that [`path-to-regexp`](https://www.n
 All URL parameters that are used in `to` must be covered by `from`.
 
 ```jsx
-<Redirect to="/somewhere/else"/>
+<Redirect to="/somewhere/else" />
 ```
 
 ## to: object
@@ -28,11 +28,13 @@ All URL parameters that are used in `to` must be covered by `from`.
 A location to redirect to. `pathname` can be any valid URL path that [`path-to-regexp`](https://www.npmjs.com/package/path-to-regexp) understands.
 
 ```jsx
-<Redirect to={{
-  pathname: '/login',
-  search: '?utm=your+face',
-  state: { referrer: currentLocation }
-}}/>
+<Redirect
+  to={{
+    pathname: "/login",
+    search: "?utm=your+face",
+    state: { referrer: currentLocation }
+  }}
+/>
 ```
 
 ## push: bool
@@ -40,28 +42,28 @@ A location to redirect to. `pathname` can be any valid URL path that [`path-to-r
 When `true`, redirecting will push a new entry onto the history instead of replacing the current one.
 
 ```jsx
-<Redirect push to="/somewhere/else"/>
+<Redirect push to="/somewhere/else" />
 ```
 
 ## from: string
 
 A pathname to redirect from. Any valid URL path that [`path-to-regexp`](https://www.npmjs.com/package/path-to-regexp) understands.
-All matched URL parameters are provided to the pattern in `to`. Must contain all parameters that are used in `to`. Additional parameters not used by `to` are ignored. 
+All matched URL parameters are provided to the pattern in `to`. Must contain all parameters that are used in `to`. Additional parameters not used by `to` are ignored.
 
 This can only be used to match a location when rendering a `<Redirect>` inside of a `<Switch>`. See [`<Switch children>`](./Switch.md#children-node) for more details.
 
 ```jsx
 <Switch>
-  <Redirect from='/old-path' to='/new-path'/>
-  <Route path='/new-path' component={Place}/>
+  <Redirect from="/old-path" to="/new-path" />
+  <Route path="/new-path" component={Place} />
 </Switch>
 ```
 
 ```jsx
 // Redirect with matched parameters
 <Switch>
-  <Redirect from='/users/:id' to='/users/profile/:id'/>
-  <Route path='/users/profile/:id' component={Profile}/>
+  <Redirect from="/users/:id" to="/users/profile/:id" />
+  <Route path="/users/profile/:id" component={Profile} />
 </Switch>
 ```
 
@@ -72,3 +74,15 @@ Match `from` exactly; equivalent to [Route.exact](./Route.md#exact-bool).
 ## strict: bool
 
 Match `from` strictly; equivalent to [Route.strict](./Route.md#strict-bool).
+
+## strict: bool
+
+When `false` ignore this redirect.
+
+```jsx
+<Switch>
+  <Redirect enabled={false} from="/users/:id" to="/do/not/route/here" />
+  <Redirect from="/users/:id" to="/users/profile/:id" />
+  <Route path="/users/profile/:id" component={Profile} />
+</Switch>
+```

--- a/packages/react-router/docs/api/Route.md
+++ b/packages/react-router/docs/api/Route.md
@@ -42,9 +42,9 @@ The "react-empty" comments are just implementation details of React's `null` ren
 
 There are 3 ways to render something with a `<Route>`:
 
-- [`<Route component>`](#component)
-- [`<Route render>`](#render-func)
-- [`<Route children>`](#children-func)
+* [`<Route component>`](#component)
+* [`<Route render>`](#render-func)
+* [`<Route children>`](#children-func)
 
 Each is useful in different circumstances. You should use only one of these props on a given `<Route>`. See their explanations below to understand why you have 3 options. Most of the time you'll use `component`.
 
@@ -52,9 +52,9 @@ Each is useful in different circumstances. You should use only one of these prop
 
 All three [render methods](#route-render-methods) will be passed the same three route props
 
-- [match](./match.md)
-- [location](./location.md)
-- [history](./history.md)
+* [match](./match.md)
+* [location](./location.md)
+* [history](./history.md)
 
 ## component
 
@@ -62,11 +62,11 @@ A React component to render only when the location matches. It will be
 rendered with [route props](#route-props).
 
 ```jsx
-<Route path="/user/:username" component={User}/>
+<Route path="/user/:username" component={User} />;
 
 const User = ({ match }) => {
-  return <h1>Hello {match.params.username}!</h1>
-}
+  return <h1>Hello {match.params.username}!</h1>;
+};
 ```
 
 When you use `component` (instead of `render` or `children`, below) the router uses [`React.createElement`](https://facebook.github.io/react/docs/react-api.html#createelement) to create a new [React element](https://facebook.github.io/react/docs/rendering-elements.html) from the given component. That means if you provide an inline function to the `component` prop, you would create a new component every render. This results in the existing component unmounting and the new component mounting instead of just updating the existing component. When using an inline function for inline rendering, use the `render` or the `children` prop (below).
@@ -103,17 +103,20 @@ The `children` render prop receives all the same [route props](#route-props) as 
 
 ```jsx
 <ul>
-  <ListItemLink to="/somewhere"/>
-  <ListItemLink to="/somewhere-else"/>
-</ul>
+  <ListItemLink to="/somewhere" />
+  <ListItemLink to="/somewhere-else" />
+</ul>;
 
 const ListItemLink = ({ to, ...rest }) => (
-  <Route path={to} children={({ match }) => (
-    <li className={match ? 'active' : ''}>
-      <Link to={to} {...rest}/>
-    </li>
-  )}/>
-)
+  <Route
+    path={to}
+    children={({ match }) => (
+      <li className={match ? "active" : ""}>
+        <Link to={to} {...rest} />
+      </li>
+    )}
+  />
+);
 ```
 
 This could also be useful for animations:
@@ -135,7 +138,7 @@ This could also be useful for animations:
 Any valid URL path that [`path-to-regexp`](https://www.npmjs.com/package/path-to-regexp) understands.
 
 ```jsx
-<Route path="/users/:id" component={User}/>
+<Route path="/users/:id" component={User} />
 ```
 
 Routes without a `path` _always_ match.
@@ -145,39 +148,39 @@ Routes without a `path` _always_ match.
 When `true`, will only match if the path matches the `location.pathname` _exactly_.
 
 ```jsx
-<Route exact path="/one" component={About}/>
+<Route exact path="/one" component={About} />
 ```
 
-| path | location.pathname | exact | matches? |
-| --- | --- | --- | --- |
-| `/one`  | `/one/two`  | `true` | no |
-| `/one`  | `/one/two`  | `false` | yes |
+| path   | location.pathname | exact   | matches? |
+| ------ | ----------------- | ------- | -------- |
+| `/one` | `/one/two`        | `true`  | no       |
+| `/one` | `/one/two`        | `false` | yes      |
 
 ## strict: bool
 
 When `true`, a `path` that has a trailing slash will only match a `location.pathname` with a trailing slash. This has no effect when there are additional URL segments in the `location.pathname`.
 
 ```jsx
-<Route strict path="/one/" component={About}/>
+<Route strict path="/one/" component={About} />
 ```
 
-| path | location.pathname | matches? |
-| --- | --- | --- |
-| `/one/` | `/one` | no |
-| `/one/` | `/one/` | yes |
-| `/one/` | `/one/two` | yes |
+| path    | location.pathname | matches? |
+| ------- | ----------------- | -------- |
+| `/one/` | `/one`            | no       |
+| `/one/` | `/one/`           | yes      |
+| `/one/` | `/one/two`        | yes      |
 
 **Warning:** `strict` can be used to enforce that a `location.pathname` has no trailing slash, but in order to do this both `strict` and `exact` must be `true`.
 
 ```jsx
-<Route exact strict path="/one" component={About}/>
+<Route exact strict path="/one" component={About} />
 ```
 
-| path | location.pathname | matches? |
-| --- | --- | --- |
-| `/one` | `/one` | yes |
-| `/one` | `/one/` | no |
-| `/one` | `/one/two` | no |
+| path   | location.pathname | matches? |
+| ------ | ----------------- | -------- |
+| `/one` | `/one`            | yes      |
+| `/one` | `/one/`           | no       |
+| `/one` | `/one/two`        | no       |
 
 ## location: object
 
@@ -190,14 +193,24 @@ If a `<Route>` element is wrapped in a `<Switch>` and matches the location passe
 
 ## sensitive: bool
 
-When `true`, will match if the path is __case sensitive__.
+When `true`, will match if the path is **case sensitive**.
 
 ```jsx
-<Route sensitive path="/one" component={About}/>
+<Route sensitive path="/one" component={About} />
 ```
 
-| path | location.pathname | sensitive | matches? |
-| --- | --- | --- | --- |
-| `/one`  | `/one`  | `true` | yes |
-| `/One`  | `/one`  | `false` | no |
+| path   | location.pathname | sensitive | matches? |
+| ------ | ----------------- | --------- | -------- |
+| `/one` | `/one`            | `true`    | yes      |
+| `/One` | `/one`            | `false`   | no       |
 
+## enabled: bool
+
+When `false` ignore this route.
+
+```jsx
+<Switch>
+  <Route enabled={props.isSuperUser} path="/one" component={SuperUserOnly} />
+  <Route path="/one" component={EveryoneElse} />
+</Switch>
+```

--- a/packages/react-router/docs/api/Switch.md
+++ b/packages/react-router/docs/api/Switch.md
@@ -1,10 +1,10 @@
 # &lt;Switch>
 
-Renders the first child [`<Route>`](Route.md) or [`<Redirect>`](Redirect.md) that matches the location.
+Renders the first enabled child [`<Route>`](Route.md) or [`<Redirect>`](Redirect.md) that matches the location.
 
 **How is this different than just using a bunch of `<Route>`s?**
 
-`<Switch>` is unique in that it renders a route *exclusively*. In contrast, every `<Route>` that matches the location renders *inclusively*. Consider this code:
+`<Switch>` is unique in that it renders a route _exclusively_. In contrast, every `<Route>` that matches the location renders _inclusively_. Consider this code:
 
 ```jsx
 <Route path="/about" component={About}/>
@@ -49,6 +49,21 @@ This is also useful for animated transitions since the matched `<Route>` is rend
 </Fade>
 ```
 
+In order to programatically ignore a [`<Route>`](Route.md) or [`<Redirect>`](Redirect.md) use the `enabled` flag on the children of the Switch.
+
+```jsx
+import { Switch, Route } from 'react-router'
+
+<Switch>
+  <Route exact path="/" component={Home}/>
+  <Route path="/about" component={About}/>
+  <Route enabled={props.user.isLoggedIn} path="/edit" component={User}/>
+  <Route component={NoMatch}/>
+</Switch>
+```
+
+Would only allow logged in users to route to /edit, all others will see NoMatch.
+
 ## location: object
 
 A [`location`](./location.md) object to be used for matching children elements instead of the current history location (usually the current browser URL).
@@ -65,11 +80,11 @@ If a `location` prop is given to the `<Switch>`, it will override the `location`
 
 ```jsx
 <Switch>
-  <Route exact path="/" component={Home}/>
+  <Route exact path="/" component={Home} />
 
-  <Route path="/users" component={Users}/>
-  <Redirect from="/accounts" to="/users"/>
+  <Route path="/users" component={Users} />
+  <Redirect from="/accounts" to="/users" />
 
-  <Route component={NoMatch}/>
+  <Route component={NoMatch} />
 </Switch>
 ```

--- a/packages/react-router/docs/api/Switch.md
+++ b/packages/react-router/docs/api/Switch.md
@@ -1,6 +1,6 @@
 # &lt;Switch>
 
-Renders the first enabled child [`<Route>`](Route.md) or [`<Redirect>`](Redirect.md) that matches the location.
+Renders the first child [`<Route>`](Route.md) or [`<Redirect>`](Redirect.md) that matches the location.
 
 **How is this different than just using a bunch of `<Route>`s?**
 

--- a/packages/react-router/modules/Redirect.js
+++ b/packages/react-router/modules/Redirect.js
@@ -81,7 +81,10 @@ class Redirect extends React.Component {
 
   perform() {
     const { history } = this.context.router;
-    const { push } = this.props;
+    const { enabled = true, push } = this.props;
+
+    if (!enabled) return;
+
     const to = this.computeTo(this.props);
 
     if (push) {

--- a/packages/react-router/modules/Route.js
+++ b/packages/react-router/modules/Route.js
@@ -51,9 +51,10 @@ class Route extends React.Component {
   };
 
   computeMatch(
-    { computedMatch, location, path, strict, exact, sensitive },
+    { computedMatch, location, path, strict, exact, sensitive, enabled = true },
     router
   ) {
+    if (!enabled) return null;
     if (computedMatch) return computedMatch; // <Switch> already computed the match for us
 
     invariant(

--- a/packages/react-router/modules/Switch.js
+++ b/packages/react-router/modules/Switch.js
@@ -48,6 +48,7 @@ class Switch extends React.Component {
       if (match == null && React.isValidElement(element)) {
         const {
           path: pathProp,
+          enabled = true,
           exact,
           strict,
           sensitive,
@@ -55,10 +56,12 @@ class Switch extends React.Component {
         } = element.props;
         const path = pathProp || from;
 
-        child = element;
-        match = path
-          ? matchPath(location.pathname, { path, exact, strict, sensitive })
-          : route.match;
+        if (enabled) {
+          child = element;
+          match = path
+            ? matchPath(location.pathname, { path, exact, strict, sensitive })
+            : route.match;
+        }
       }
     });
 

--- a/packages/react-router/modules/__tests__/Redirect-test.js
+++ b/packages/react-router/modules/__tests__/Redirect-test.js
@@ -44,10 +44,12 @@ describe("A <Redirect>", () => {
 
       ReactDOM.render(
         <MemoryRouter initialEntries={["/initialroute"]}>
-          <div>
+          <Switch>
             <Route path="/redirectto" render={() => <h1>one</h1>} />
-            <Redirect enabled={true} from="/initialroute" to="/redirectto" />
-          </div>
+            <Route>
+              <Redirect enabled={true} from="/initialroute" to="/redirectto" />
+            </Route>
+          </Switch>
         </MemoryRouter>,
         node
       );
@@ -59,10 +61,12 @@ describe("A <Redirect>", () => {
 
       ReactDOM.render(
         <MemoryRouter initialEntries={["/initialroute"]}>
-          <div>
+          <Switch>
             <Route path="/redirectto" render={() => <h1>one</h1>} />
-            <Redirect from="/initialroute" to="/redirectto" />
-          </div>
+            <Route>
+              <Redirect from="/initialroute" to="/redirectto" />
+            </Route>
+          </Switch>
         </MemoryRouter>,
         node
       );
@@ -73,10 +77,12 @@ describe("A <Redirect>", () => {
       const node = document.createElement("div");
       ReactDOM.render(
         <MemoryRouter initialEntries={["/initialroute"]}>
-          <div>
+          <Switch>
             <Route path="/redirectto" render={() => <h1>one</h1>} />
-            <Redirect enabled={false} from="/initialroute" to="/redirectto" />
-          </div>
+            <Route>
+              <Redirect enabled={false} from="/initialroute" to="/redirectto" />
+            </Route>
+          </Switch>
         </MemoryRouter>,
         node
       );

--- a/packages/react-router/modules/__tests__/Redirect-test.js
+++ b/packages/react-router/modules/__tests__/Redirect-test.js
@@ -37,4 +37,50 @@ describe("A <Redirect>", () => {
       });
     });
   });
+
+  describe("A <Redirect enabled>", () => {
+    it("follow redirect if enabled", () => {
+      const node = document.createElement("div");
+
+      ReactDOM.render(
+        <MemoryRouter initialEntries={["/initialroute"]}>
+          <div>
+            <Route path="/redirectto" render={() => <h1>one</h1>} />
+            <Redirect enabled={true} from="/initialroute" to="/redirectto" />
+          </div>
+        </MemoryRouter>,
+        node
+      );
+      expect(node.innerHTML).toMatch(/one/);
+    });
+
+    it("default is to be enabled", () => {
+      const node = document.createElement("div");
+
+      ReactDOM.render(
+        <MemoryRouter initialEntries={["/initialroute"]}>
+          <div>
+            <Route path="/redirectto" render={() => <h1>one</h1>} />
+            <Redirect from="/initialroute" to="/redirectto" />
+          </div>
+        </MemoryRouter>,
+        node
+      );
+      expect(node.innerHTML).toMatch(/one/);
+    });
+
+    it("not follow redirect if not enabled", () => {
+      const node = document.createElement("div");
+      ReactDOM.render(
+        <MemoryRouter initialEntries={["/initialroute"]}>
+          <div>
+            <Route path="/redirectto" render={() => <h1>one</h1>} />
+            <Redirect enabled={false} from="/initialroute" to="/redirectto" />
+          </div>
+        </MemoryRouter>,
+        node
+      );
+      expect(node.innerHTML).not.toMatch(/one/);
+    });
+  });
 });

--- a/packages/react-router/modules/__tests__/Route-test.js
+++ b/packages/react-router/modules/__tests__/Route-test.js
@@ -388,3 +388,51 @@ describe("A <Route location>", () => {
     });
   });
 });
+
+describe("A <Route enabled>", () => {
+  it("does render when the route is not enabled", () => {
+    const TEXT = "bubblegum";
+    const node = document.createElement("div");
+
+    ReactDOM.render(
+      <MemoryRouter initialEntries={["/somepath"]}>
+        <Route enabled={true} path="/somepath" render={() => <h1>{TEXT}</h1>} />
+      </MemoryRouter>,
+      node
+    );
+
+    expect(node.innerHTML).toContain(TEXT);
+  });
+
+  it("defaults to enabled", () => {
+    const TEXT = "bubblegum";
+    const node = document.createElement("div");
+
+    ReactDOM.render(
+      <MemoryRouter initialEntries={["/somepath"]}>
+        <Route path="/somepath" render={() => <h1>{TEXT}</h1>} />
+      </MemoryRouter>,
+      node
+    );
+
+    expect(node.innerHTML).toContain(TEXT);
+  });
+
+  it("does not render when the route is not enabled", () => {
+    const TEXT = "bubblegum";
+    const node = document.createElement("div");
+
+    ReactDOM.render(
+      <MemoryRouter initialEntries={["/somepath"]}>
+        <Route
+          enabled={false}
+          path="/somepath"
+          render={() => <h1>{TEXT}</h1>}
+        />
+      </MemoryRouter>,
+      node
+    );
+
+    expect(node.innerHTML).not.toContain(TEXT);
+  });
+});

--- a/packages/react-router/modules/__tests__/Switch-test.js
+++ b/packages/react-router/modules/__tests__/Switch-test.js
@@ -282,6 +282,38 @@ describe("A <Switch>", () => {
     expect(node.innerHTML).toMatch(/one/);
   });
 
+  it("skip children with enabled={false}", () => {
+    const node = document.createElement("div");
+
+    ReactDOM.render(
+      <MemoryRouter initialEntries={["/one"]}>
+        <Switch>
+          <Route path="/one" enabled={false} render={() => <h1>one</h1>} />
+          <Route path="/one" render={() => <h1>two</h1>} />
+        </Switch>
+      </MemoryRouter>,
+      node
+    );
+
+    expect(node.innerHTML).toMatch(/two/);
+  });
+
+  it("not skip children with enabled={true}", () => {
+    const node = document.createElement("div");
+
+    ReactDOM.render(
+      <MemoryRouter initialEntries={["/one"]}>
+        <Switch>
+          <Route path="/one" enabled={true} render={() => <h1>one</h1>} />
+          <Route path="/one" render={() => <h1>two</h1>} />
+        </Switch>
+      </MemoryRouter>,
+      node
+    );
+
+    expect(node.innerHTML).toMatch(/one/);
+  });
+
   it("throws with no <Router>", () => {
     const node = document.createElement("div");
 


### PR DESCRIPTION
Having Switch use an `enabled` flag on each of it's children would simplify routing.

For example, I want to put some of my routes behind an auth check, redirecting to a login screen. I also want to enable some routes for admins while regular users should see a 404 screen.

```jsx
export default (routeProps) => (
  <Layout>
    <Switch>
      <Route path="/login" component={Login} />
      <Route path="/reset_password" component={ResetPassword} />
      {!routeProps.user.is_authenticated && <Redirect to="/login" />}
      <Route path="/list" component={List} />
      <Route path="/:id/edit" render={renderProps => 
        routeProps.user.is_admin ? <Edit {...renderProps}  />  : <FourOhFour />
      } />
      <Route path="/:id" component={Details} />
      <Route component={FourOhFour} />
    </Switch>
  </Layout>
);
```
Which works OK, but gets tedious and hard to read when it's all over the place.
It would also be nice to be able to fall through the `/:id/edit` route instead of putting the alternative inside the Routes render.

Adding an `enabled` flag that is used by Switch would let me do this instead:
```jsx
export default (routeProps) => (
  <Layout>
    <Switch>
      <Route path="/login" component={Login} />
      <Route path="/reset_password" component={ResetPassword} />
      <Redirect enabled={!routeProps.user.is_authenticated} to="/login" />
      <Route path="/list" component={List} />
      <Route path="/:id/edit" enabled={routeProps.user.is_admin} component={Edit} /> 
      <Route path="/:id" component={Details} />
      <Route component={FourOhFour} />
    </Switch>
  </Layout>
);
```

The main thing I want out of the PR is to enable Switch's to check it's children for the `enabled` flag.
I felt that it would be confusing to have a flag on Route and Redirect that is used by Switch but not used by the components themselves, so also added handling of `enabled` to Route and Redirect themselves.

This means Route's not in a Switch could also be enabled/disabled.
For example in this routing only `<Two />` would be rendered, instead of One and Two.

```jsx
function OurRouter(routeProps) {
  return (
    <ConnectedRouter history={props.history}>
      <div>
        <Route enabled={false} path="/theroute" component={One} />
        <Route enabled={true} path="/theroute" component={Two} />
      </div>
    </ConnectedRouter>
  );
}

```

A bunch of the edits in the .md files seem to be from the pretty-quick run in the precommit hook...
Sorry about that. Please let me know if I should try to get that reverted.
