### PR TITLE
fix: Route propTypes, path like array of strings

### DIFF
--- a/packages/react-router/modules/Route.js
+++ b/packages/react-router/modules/Route.js
@@ -12,7 +12,7 @@ const isEmptyChildren = children => React.Children.count(children) === 0;
 class Route extends React.Component {
   static propTypes = {
     computedMatch: PropTypes.object, // private, from <Switch>
-    path: PropTypes.string,
+    path: PropTypes.oneOfType([PropTypes.string, PropTypes.arrayOf(PropTypes.string)]),
     exact: PropTypes.bool,
     strict: PropTypes.bool,
     sensitive: PropTypes.bool,


### PR DESCRIPTION
According `path-to-regexp` path can be an array but react-router has wrong propTypes for path prop