### PR TITLE
[WIP] Use new Context API in React 16.3

### DIFF
--- a/packages/react-router/modules/Route.js
+++ b/packages/react-router/modules/Route.js
@@ -2,6 +2,7 @@ import warning from "warning";
 import invariant from "invariant";
 import React from "react";
 import PropTypes from "prop-types";
+import RouterContext from "./RouterContext";
 import matchPath from "./matchPath";
 
 const isEmptyChildren = children => React.Children.count(children) === 0;
@@ -9,7 +10,7 @@ const isEmptyChildren = children => React.Children.count(children) === 0;
 /**
  * The public API for matching a single path and rendering.
  */
-class Route extends React.Component {
+class InnerRoute extends React.Component {
   static propTypes = {
     computedMatch: PropTypes.object, // private, from <Switch>
     path: PropTypes.string,
@@ -19,10 +20,7 @@ class Route extends React.Component {
     component: PropTypes.func,
     render: PropTypes.func,
     children: PropTypes.oneOfType([PropTypes.func, PropTypes.node]),
-    location: PropTypes.object
-  };
-
-  static contextTypes = {
+    location: PropTypes.object,
     router: PropTypes.shape({
       history: PropTypes.object.isRequired,
       route: PropTypes.object.isRequired,
@@ -37,9 +35,9 @@ class Route extends React.Component {
   getChildContext() {
     return {
       router: {
-        ...this.context.router,
+        ...this.props.router,
         route: {
-          location: this.props.location || this.context.router.route.location,
+          location: this.props.location || this.props.router.route.location,
           match: this.state.match
         }
       }
@@ -47,13 +45,18 @@ class Route extends React.Component {
   }
 
   state = {
-    match: this.computeMatch(this.props, this.context.router)
+    match: this.computeMatch(this.props)
   };
 
-  computeMatch(
-    { computedMatch, location, path, strict, exact, sensitive },
-    router
-  ) {
+  computeMatch({
+    computedMatch,
+    router,
+    location,
+    path,
+    strict,
+    exact,
+    sensitive
+  }) {
     if (computedMatch) return computedMatch; // <Switch> already computed the match for us
 
     invariant(
@@ -94,7 +97,7 @@ class Route extends React.Component {
     );
   }
 
-  componentWillReceiveProps(nextProps, nextContext) {
+  componentWillReceiveProps(nextProps) {
     warning(
       !(nextProps.location && !this.props.location),
       '<Route> elements should not change from uncontrolled to controlled (or vice versa). You initially used no "location" prop and then provided one on a subsequent render.'
@@ -106,14 +109,18 @@ class Route extends React.Component {
     );
 
     this.setState({
-      match: this.computeMatch(nextProps, nextContext.router)
+      match: this.computeMatch(nextProps)
     });
   }
 
-  render() {
+  renderChildren() {
     const { match } = this.state;
-    const { children, component, render } = this.props;
-    const { history, route, staticContext } = this.context.router;
+    const {
+      children,
+      component,
+      render,
+      router: { history, route, staticContext }
+    } = this.props;
     const location = this.props.location || route.location;
     const props = { match, location, history, staticContext };
 
@@ -128,6 +135,15 @@ class Route extends React.Component {
 
     return null;
   }
+
+  render() {
+    return RouterContext.provide(this.getChildContext(), this.renderChildren());
+  }
 }
+
+const Route = props =>
+  RouterContext.consume(({ router }) => (
+    <InnerRoute {...props} router={router} />
+  ));
 
 export default Route;

--- a/packages/react-router/modules/Router.js
+++ b/packages/react-router/modules/Router.js
@@ -2,6 +2,7 @@ import warning from "warning";
 import invariant from "invariant";
 import React from "react";
 import PropTypes from "prop-types";
+import RouterContext from "./RouterContext";
 
 /**
  * The public API for putting history on context.
@@ -76,8 +77,7 @@ class Router extends React.Component {
   }
 
   render() {
-    const { children } = this.props;
-    return children ? React.Children.only(children) : null;
+    return RouterContext.provide(this.getChildContext(), this.props.children);
   }
 }
 

--- a/packages/react-router/modules/RouterContext.js
+++ b/packages/react-router/modules/RouterContext.js
@@ -1,0 +1,5 @@
+import React from "react";
+
+const RouterContext = React.unstable_createContext(0);
+
+export default RouterContext;

--- a/packages/react-router/modules/Switch.js
+++ b/packages/react-router/modules/Switch.js
@@ -2,26 +2,24 @@ import React from "react";
 import PropTypes from "prop-types";
 import warning from "warning";
 import invariant from "invariant";
+import RouterContext from "./RouterContext";
 import matchPath from "./matchPath";
 
 /**
  * The public API for rendering the first <Route> that matches.
  */
-class Switch extends React.Component {
-  static contextTypes = {
+class InnerSwitch extends React.Component {
+  static propTypes = {
+    children: PropTypes.node,
+    location: PropTypes.object,
     router: PropTypes.shape({
       route: PropTypes.object.isRequired
     }).isRequired
   };
 
-  static propTypes = {
-    children: PropTypes.node,
-    location: PropTypes.object
-  };
-
   componentWillMount() {
     invariant(
-      this.context.router,
+      this.props.router,
       "You should not use <Switch> outside a <Router>"
     );
   }
@@ -39,7 +37,7 @@ class Switch extends React.Component {
   }
 
   render() {
-    const { route } = this.context.router;
+    const { route } = this.props.router;
     const { children } = this.props;
     const location = this.props.location || route.location;
 
@@ -67,5 +65,10 @@ class Switch extends React.Component {
       : null;
   }
 }
+
+const Switch = props =>
+  RouterContext.consume(({ router }) => (
+    <InnerSwitch {...props} router={router} />
+  ));
 
 export default Switch;

--- a/packages/react-router/modules/__tests__/Router-test.js
+++ b/packages/react-router/modules/__tests__/Router-test.js
@@ -2,6 +2,7 @@ import React from "react";
 import ReactDOM from "react-dom";
 import PropTypes from "prop-types";
 import Router from "../Router";
+import RouterContext from "../RouterContext";
 import { createMemoryHistory as createHistory } from "history";
 
 describe("A <Router>", () => {
@@ -50,17 +51,11 @@ describe("A <Router>", () => {
 
   describe("context", () => {
     let rootContext;
-    const ContextChecker = (props, context) => {
-      rootContext = context;
-      return null;
-    };
-
-    ContextChecker.contextTypes = {
-      router: PropTypes.shape({
-        history: PropTypes.object,
-        route: PropTypes.object
-      })
-    };
+    const ContextChecker = () =>
+      RouterContext.consume(context => {
+        rootContext = context;
+        return null;
+      });
 
     afterEach(() => {
       rootContext = undefined;

--- a/packages/react-router/modules/__tests__/Switch-test.js
+++ b/packages/react-router/modules/__tests__/Switch-test.js
@@ -299,7 +299,7 @@ describe("A <Switch>", () => {
 
     expect(console.error.calls.count()).toBe(3);
     expect(console.error.calls.argsFor(0)[0]).toContain(
-      "The context `router` is marked as required in `Switch`"
+      "The prop `router` is marked as required in `InnerSwitch`"
     );
   });
 });

--- a/packages/react-router/modules/index.js
+++ b/packages/react-router/modules/index.js
@@ -3,6 +3,7 @@ export Prompt from "./Prompt";
 export Redirect from "./Redirect";
 export Route from "./Route";
 export Router from "./Router";
+import RouterContext from "./RouterContext";
 export StaticRouter from "./StaticRouter";
 export Switch from "./Switch";
 export generatePath from "./generatePath";


### PR DESCRIPTION
Closes #5901. WIP.

This will obviously not work on Travis until 16.3.0 is out. But I can confirm it works locally. 

To play along at home, simply clone `react` in a parallel folder, `yarn && yarn run build`, and then copy over the files by hand back to this repo:
```sh
cp -a ../react/build/node_modules/react/* node_modules/react/
cp -a ../react/build/node_modules/react-dom/* node_modules/react-dom/
```
This is mostly a brute force approach. All the tests pass, but I'm doing whatever is necessary to get it to work. There may be some more radical refactors warranted with the new API. The new bitmask stuff is neato.

While not BC yet, I'm least keeping available the old context API hooks. I need to feature sniff `unstable_createContext`. 

Outstanding stuff:
- [ ] Wait for a React release (duh)
- [ ] `<Redirect>`, `<Prompt>`
- [ ] `Router#getChildContext` references `this.context.router`
- [ ] `<Link>`
- [ ] React Router Native stuff