### PR TITLE
Fix non-functional links to routers

### DIFF
--- a/packages/react-router/docs/api/Router.md
+++ b/packages/react-router/docs/api/Router.md
@@ -4,9 +4,9 @@ The common low-level interface for all router components. Typically apps will us
 
 - [`<BrowserRouter>`](../../../react-router-dom/docs/api/BrowserRouter.md)
 - [`<HashRouter>`](../../../react-router-dom/docs/api/HashRouter.md)
-- [`<MemoryRouter>`](./MemoryRouter.md)
+- [`<MemoryRouter>`](../../../react-router-dom/docs/api/MemoryRouter.md)
 - [`<NativeRouter>`](../../../react-router-native/docs/api/NativeRouter.md)
-- [`<StaticRouter>`](./StaticRouter.md)
+- [`<StaticRouter>`](../../../react-router-dom/docs/api/StaticRouter.md)
 
 The most common use-case for using the low-level `<Router>` is to
 synchronize a custom history with a state management lib like Redux or Mobx. Note that this is not required to use state management libs alongside React Router, it's only for deep integration.


### PR DESCRIPTION
The previous relative links introduced in #5441 only works in the repo-view in GitHub. When published on the home page they don't resolve to an existing route. This aligns the markup for the non-working links with those that do work.

Verifying:
1. Check todays [site](https://reacttraining.com/react-router/web/api/Router)
2. Press the static or memory router links
3. See that you are being redirected to the root page, not the subsection

Also, just check the links directly:
- Non working link: https://reacttraining.com/react-router/StaticRouter.md
- A working link on the actual header element: https://reacttraining.com/react-router/web/api/StaticRouter