### PR TITLE
fix confused names of presentational and container components in react-router-redux examples

### DIFF
--- a/packages/react-router-redux/examples/AuthExample.js
+++ b/packages/react-router-redux/examples/AuthExample.js
@@ -50,13 +50,13 @@ const store = createStore(
   applyMiddleware(routerMiddleware(history)),
 )
 
-class LoginContainer extends React.Component {
+class Login extends React.Component {//
   render() {
     return <button onClick={this.props.login}>Login Here!</button>
   }
 }
 
-class HomeContainer extends React.Component {
+class Home extends React.Component {//
   componentWillMount() {
     alert('Private home is at: ' + this.props.location.pathname)
   }
@@ -66,7 +66,7 @@ class HomeContainer extends React.Component {
   }
 }
 
-class PrivateRouteContainer extends React.Component {
+class PrivateRoute extends React.Component {//
   render() {
     const {
       isAuthenticated,
@@ -92,30 +92,30 @@ class PrivateRouteContainer extends React.Component {
   }
 }
 
-const PrivateRoute = connect(state => ({
+const PrivateRouteContainer = connect(state => ({
   isAuthenticated: state.authReducer.isAuthenticated
-}))(PrivateRouteContainer)
+}))(PrivateRoute)//
 
-const Login = connect(null, dispatch => ({
+const LoginContainer = connect(null, dispatch => ({
   login: () => {
     dispatch(authSuccess())
     dispatch(push('/'))
   }
-}))(LoginContainer)
+}))(Login)//
 
-const Home = connect(null, dispatch => ({
+const HomeContainer = connect(null, dispatch => ({
   logout: () => {
     dispatch(authFail())
     dispatch(push('/login'))
   }
-}))(HomeContainer)
+}))(Home)//
 
 render(
   <Provider store={store}>
     <ConnectedRouter history={history}>
       <Switch>
-        <Route path="/login" component={Login} />
-        <PrivateRoute exact path="/" component={Home} />
+        <Route path="/login" component={LoginContainer} />
+        <PrivateRoute exact path="/" component={HomeContainer} />
       </Switch>
     </ConnectedRouter>
   </Provider>,

--- a/packages/react-router-redux/examples/AuthExample.js
+++ b/packages/react-router-redux/examples/AuthExample.js
@@ -50,13 +50,13 @@ const store = createStore(
   applyMiddleware(routerMiddleware(history)),
 )
 
-class Login extends React.Component {//
+class Login extends React.Component {
   render() {
     return <button onClick={this.props.login}>Login Here!</button>
   }
 }
 
-class Home extends React.Component {//
+class Home extends React.Component {
   componentWillMount() {
     alert('Private home is at: ' + this.props.location.pathname)
   }
@@ -66,7 +66,7 @@ class Home extends React.Component {//
   }
 }
 
-class PrivateRoute extends React.Component {//
+class PrivateRoute extends React.Component {
   render() {
     const {
       isAuthenticated,
@@ -94,21 +94,21 @@ class PrivateRoute extends React.Component {//
 
 const PrivateRouteContainer = connect(state => ({
   isAuthenticated: state.authReducer.isAuthenticated
-}))(PrivateRoute)//
+}))(PrivateRoute)
 
 const LoginContainer = connect(null, dispatch => ({
   login: () => {
     dispatch(authSuccess())
     dispatch(push('/'))
   }
-}))(Login)//
+}))(Login)
 
 const HomeContainer = connect(null, dispatch => ({
   logout: () => {
     dispatch(authFail())
     dispatch(push('/login'))
   }
-}))(Home)//
+}))(Home)
 
 render(
   <Provider store={store}>

--- a/packages/react-router-redux/examples/BasicExample.js
+++ b/packages/react-router-redux/examples/BasicExample.js
@@ -20,21 +20,21 @@ const ConnectedSwitch = connect(state => ({
   location: state.location
 }))(Switch)
 
-const AppContainer = () => (
+const App = () => (
   <ConnectedSwitch>
     <Route exact path="/" component={() => (<h1>Home <Link to="/about">About</Link></h1>)} />
     <Route path="/about" component={() => (<h1>About <Link to="/">Home</Link></h1>)} />
   </ConnectedSwitch>
 )
 
-const App = connect(state => ({
+const AppContainer = connect(state => ({
   location: state.location,
-}))(AppContainer)
+}))(App)
 
 render(
   <Provider store={store}>
     <ConnectedRouter history={history}>
-      <App />
+      <AppContainer />
     </ConnectedRouter>
   </Provider>,
   document.getElementById('root'),


### PR DESCRIPTION
It seems like [react-router-redux examples](https://github.com/ReactTraining/react-router/tree/master/packages/react-router-redux/examples) have wrong names of Presentational and Container Components.

---
As far as I know we should call `connect()` this way:
```jsx
const MyContainer = connect(mapStateToProps, mapDispatchToProps)(MyComponent)
     └────────────────── container that passes    ─────────────┘      ↑
                         state and action creators                    │
                         into your component ─────────────────────────┘
```

i see this way of using connect there:
- [Usage with React · Redux](https://redux.js.org/docs/basics/UsageWithReact.html) | [Full Source](https://github.com/reactjs/redux/tree/master/examples/todos)
- [connect() - returns - react-redux/api.md](https://github.com/reactjs/react-redux/blob/master/docs/api.md#returns)
---
Instead in current examples we see opposite:
```jsx
const MyComponent = connect(mapStateToProps, mapDispatchToProps)(MyContainer)
     └────────────────── component passes  ───────────────┘           ↑
                         to container! ───────────────────────────────┘
```
---
I'm new in react world so maybe I'm missing something.