### PR TITLE
nested Route with relative path support

### DIFF
--- a/packages/react-router/modules/Route.js
+++ b/packages/react-router/modules/Route.js
@@ -54,7 +54,7 @@ class Route extends React.Component {
     match: this.computeMatch(this.props, this.context.router)
   }
 
-  computeMatch({ computedMatch, location, path, strict, exact, sensitive }, router) {
+  computeMatch({ computedMatch, location, path, strict, exact, sensitive, nested }, router) {
     if (computedMatch)
       return computedMatch // <Switch> already computed the match for us
 
@@ -66,7 +66,9 @@ class Route extends React.Component {
     const { route } = router
     const pathname = (location || route.location).pathname
 
-    return path ? matchPath(pathname, { path, strict, exact, sensitive }) : route.match
+    const fullPath = path && nested? route.match.path + path : path
+
+    return path ? matchPath(pathname, { path:fullPath, strict, exact, sensitive }) : route.match
   }
 
   componentWillMount() {

--- a/packages/react-router/modules/Switch.js
+++ b/packages/react-router/modules/Switch.js
@@ -46,11 +46,13 @@ class Switch extends React.Component {
     let match, child
     React.Children.forEach(children, element => {
       if (match == null && React.isValidElement(element)) {
-        const { path: pathProp, exact, strict, sensitive, from } = element.props
+        const { path: pathProp, exact, strict, sensitive, from, nested } = element.props
         const path = pathProp || from
 
         child = element
-        match = path ? matchPath(location.pathname, { path, exact, strict, sensitive }) : route.match
+        const fullPath = path && nested? route.match.path + path : path
+
+        match = path ? matchPath(location.pathname, { path:fullPath, exact, strict, sensitive }) : route.match
       }
     })
 


### PR DESCRIPTION
Hi,
this should be support relative path on nested route <Route nested path="relativeToParent">

use case:

```javascript

<Route path='/home' >
     <Switch>
          <Route nested path='/section1' />
          <Route nested path='/section2' />
          <Route nested path='/section3' />
     </Switch>
</Route >
```
is same as 

```javascript
<Route path='/home/section1'> 
```



