### PR TITLE
[Proposal | WiP] Redirect: add addContext prop

### DIFF
--- a/packages/react-router/modules/Redirect.js
+++ b/packages/react-router/modules/Redirect.js
@@ -14,7 +14,8 @@ class Redirect extends React.Component {
     computedMatch: PropTypes.object, // private, from <Switch>
     push: PropTypes.bool,
     from: PropTypes.string,
-    to: PropTypes.oneOfType([PropTypes.string, PropTypes.object]).isRequired
+    to: PropTypes.oneOfType([PropTypes.string, PropTypes.object]).isRequired,
+    addContext: PropTypes.object
   };
 
   static defaultProps = {
@@ -81,8 +82,13 @@ class Redirect extends React.Component {
 
   perform() {
     const { history } = this.context.router;
-    const { push } = this.props;
+    const { push, addContext } = this.props;
     const to = this.computeTo(this.props);
+
+    if (addContext && this.isStatic()) {
+      const { staticContext } = this.context.router;
+      Object.assign(staticContext, addContext);
+    }
 
     if (push) {
       history.push(to);


### PR DESCRIPTION
This allows easily assigning context information at redirect time. It would turn the [example code for handling this](https://github.com/ReactTraining/react-router/blob/master/packages/react-router-dom/docs/guides/server-rendering.md#adding-app-specific-context-information) into just

```jsx
  <Redirect to="/somewhere" addContext={{permanent: true}} />
```

thoughts?