### PR TITLE
Stripped the query strings from pathname before matching against path

### DIFF
--- a/packages/react-router/modules/__tests__/matchPath-test.js
+++ b/packages/react-router/modules/__tests__/matchPath-test.js
@@ -66,6 +66,33 @@ describe("matchPath", () => {
     });
   });
 
+  describe("with query string", () => {
+    it("matches the base URL only with trailing param", () => {
+      const options = {
+        path: "/base/:id"
+      };
+      const match = matchPath("/base/7?query=param", options);
+      expect(match).toMatchObject({
+        url: "/base/7",
+        path: "/base/:id",
+        params: { id: "7" },
+        isExact: false
+      });
+    });
+    it("matches the base URL only without trailing param", () => {
+      const options = {
+        path: "/base/home"
+      };
+      const match = matchPath("/base/home?query=param", options);
+      expect(match).toMatchObject({
+        url: "/base/home",
+        path: "/base/home",
+        params: {},
+        isExact: false
+      });
+    });
+  });
+
   describe("cache", () => {
     it("creates a cache entry for each exact/strict pair", () => {
       // true/false and false/true will collide when adding booleans

--- a/packages/react-router/modules/matchPath.js
+++ b/packages/react-router/modules/matchPath.js
@@ -22,6 +22,10 @@ const compilePath = (pattern, options) => {
   return compiledPattern;
 };
 
+const stripQueryString = url => {
+  return url.indexOf("?") < 0 ? url : url.split("?")[0];
+};
+
 /**
  * Public API for matching a URL pathname to a path pattern.
  */
@@ -35,7 +39,9 @@ const matchPath = (pathname, options = {}) => {
     sensitive = false
   } = options;
   const { re, keys } = compilePath(path, { end: exact, strict, sensitive });
-  const match = re.exec(pathname);
+  const basePath =
+    typeof pathname === "string" ? stripQueryString(pathname) : pathname;
+  const match = re.exec(basePath);
 
   if (!match) return null;
 


### PR DESCRIPTION
I'm new to public PR, please let me know if I've missed anything. Apologies if I'm breaking any convention (unknowingly).

Ran into an issue where the server side route match was not working correctly when the url contained query strings.

path: `/base/about`
does not match against url `/base/about?query=param`
but it does match with `/base/about/?query=param`

Also (not that this matters) path `/base/home/:id`
when matched against `/base/home/7?query=param`
gives params { "id" : ""7?query=param" }

Changes proposed:
- Do not consider query strings when matching pathname in matchPath. This will fix both issues mentioned above.
- Added two tests to check with query params, both with and without `:param`