### PR TITLE
StaticRouter: retain location.state [WiP]

### DIFF
--- a/packages/react-router/modules/StaticRouter.js
+++ b/packages/react-router/modules/StaticRouter.js
@@ -6,12 +6,13 @@ import { createPath, parsePath } from "history";
 import Router from "./Router";
 
 const normalizeLocation = object => {
-  const { pathname = "/", search = "", hash = "" } = object;
+  const { pathname = "/", search = "", hash = "", state } = object;
 
   return {
     pathname,
     search: search === "?" ? "" : search,
-    hash: hash === "#" ? "" : hash
+    hash: hash === "#" ? "" : hash,
+    state
   };
 };
 


### PR DESCRIPTION
When redirecting, `location.state` is lost. This can be useful to pass information like `state: {permanent: true}` which could result in HTTP 301 response.

Spiritual continuation of #5930; no tests yet, just a proposal.