### PR TITLE
Prompt doc: add example message returns true

### DIFF
--- a/packages/react-router/docs/api/Prompt.md
+++ b/packages/react-router/docs/api/Prompt.md
@@ -25,7 +25,7 @@ Will be called with the next `location` and `action` the user is attempting to n
 
 ```jsx
 <Prompt message={location => (
-  `Are you sure you want to go to ${location.pathname}?`
+  location.pathname.startsWith('/app') ? true : `Are you sure you want to go to ${location.pathname}?`
 )}/>
 ```
 


### PR DESCRIPTION
`true` to allow the transition was not yet shown, do you think it's a useful addition to the documentation ?