### PR TITLE
Fix documentation for Route's sensitive attribute

### DIFF
--- a/packages/react-router/docs/api/Route.md
+++ b/packages/react-router/docs/api/Route.md
@@ -199,5 +199,6 @@ When `true`, will match if the path is __case sensitive__.
 | path | location.pathname | sensitive | matches? |
 | --- | --- | --- | --- |
 | `/one`  | `/one`  | `true` | yes |
-| `/One`  | `/one`  | `false` | no |
+| `/One`  | `/one`  | `true` | no |
+| `/One`  | `/one`  | `false`| yes |
 


### PR DESCRIPTION
The old example was wrong: with path=`/One`, location.pathname=`/one` and sensitive=`false`, the Route will match