### PR TITLE
Don't hard-code version in ISSUE_TEMPLATE

### DIFF
--- a/ISSUE_TEMPLATE.md
+++ b/ISSUE_TEMPLATE.md
@@ -22,7 +22,8 @@ Remove the template from below and provide thoughtful commentary *and code sampl
 
 <!-- BUG TEMPLATE -->
 ## Version
-4.1.1
+
+**Please replace this sentence with the React Router version that you are using.**
 
 ## Test Case
 https://codesandbox.io/s/n55VljYk7


### PR DESCRIPTION
Even when the issue template is used, this value seems to be ignored. If the user doesn't update the string we can probably assume that they are on the latest release, but hopefully the bold text will encourage people opening issues to set the correct version.