### PR TITLE
withRouter now uses children so that Component is always rendered

### DIFF
--- a/packages/react-router/modules/withRouter.js
+++ b/packages/react-router/modules/withRouter.js
@@ -11,7 +11,7 @@ const withRouter = Component => {
     const { wrappedComponentRef, ...remainingProps } = props;
     return (
       <Route
-        render={routeComponentProps => (
+        children={routeComponentProps => (
           <Component
             {...remainingProps}
             {...routeComponentProps}


### PR DESCRIPTION
According the docs:
> You can get access to the history object’s properties and the closest <Route>'s match via the withRouter higher-order component. withRouter will pass updated match, location, and history props to the wrapped component whenever it renders.

If you wrap component in `withRouter` but current route is not matched **your component will not be rendered** try example. This pull request changes this behaviour and make sure that component is always rendered.

https://codesandbox.io/s/r0nx8z97qn

```jsx
import React from "react";
import { render } from "react-dom";
import { BrowserRouter, Route, withRouter, Link } from "react-router-dom";

function Component() {
  return <p>Here is Component.</p>
}

const ComponentWithRouter = withRouter(Component);

function App() {
  const children = ({ match }) => {
    return (
      <div>
        <p>This {!match && "not"} matched route</p>
        <Component />
        <ComponentWithRouter /> /* this is not rendered if no match */
      </div>
    );
  };

  return (
    <BrowserRouter>
      <div>
        <p>
          <Link to="/">/</Link>
        </p>
        <p>
          <Link to="/abc">/abc</Link>
        </p>
        <Route path="/abc" children={children} />
      </div>
    </BrowserRouter>
  );
}

render(<App />, document.getElementById("root"));
```