### PR TITLE
Add the ability to pass in an existing React element

### DIFF
--- a/packages/react-router/modules/Route.js
+++ b/packages/react-router/modules/Route.js
@@ -115,7 +115,14 @@ class Route extends React.Component {
     const location = this.props.location || route.location;
     const props = { match, location, history, staticContext };
 
-    if (component) return match ? React.createElement(component, props) : null;
+    if (component) {
+      if (match) {
+        if (React.isValidElement(component) === true) {
+          return React.cloneElement(component, props);
+        }
+        return React.createElement(component, props);
+      }
+    }
 
     if (render) return match ? render(props) : null;
 

--- a/packages/react-router/modules/__tests__/Route-test.js
+++ b/packages/react-router/modules/__tests__/Route-test.js
@@ -192,6 +192,23 @@ describe("<Route component>", () => {
     expect(node.innerHTML).toContain(TEXT);
   });
 
+  it("renders the react element", () => {
+    const TEXT = "Mrs. Kato";
+    const node = document.createElement("div");
+    const Home = props => <div>{props.text}</div>;
+    const home = React.createElement(Home, {
+      text: TEXT
+    });
+    ReactDOM.render(
+      <MemoryRouter initialEntries={["/"]}>
+        <Route path="/" component={home} />
+      </MemoryRouter>,
+      node
+    );
+
+    expect(node.innerHTML).toContain(TEXT);
+  });
+
   it("receives { match, location, history } props", () => {
     let actual = null;
     const Component = props => (actual = props) && null;


### PR DESCRIPTION
When passing a `component` it can now either be a React element which has yet to be created (existing functionality), or an element that has already been created.
This functionality adds the ability to setup a component which props from the current closure whilst accepting props from the route.
*Example:*
```jsx
// MyParentComponent.js
render(props) {
  const myPage = (
    <MyPage
      a={props.a}
    />
  );

  return (
    <Route path="/" component={myPage}/>
  );
}
```
`MyPage` will now get `a` and route props.
