### PR TITLE
react-router-redux adds assertHistory

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,7 @@
 - Add invariant for missing "to" property on `<Link>` ([#5792] by @selbekk)
 - Use Prettier on the code ([e6f9017] by @mjackson)
 - Fix pathless route's match when parent is null ([#5964] by @pshrmn)
+- Assert history passed to react-router-redux is valid ([#5991] by @brigand)
 
 [#5209]: https://github.com/ReactTraining/react-router/pull/5209
 [#5489]: https://github.com/ReactTraining/react-router/pull/5489
@@ -22,6 +23,7 @@
 [#5792]: https://github.com/ReactTraining/react-router/pull/5792
 [e6f9017]: https://github.com/ReactTraining/react-router/commit/e6f9017c947b3ae49affa24cc320d0a86f765b55
 [#5964]: https://github.com/ReactTraining/react-router/pull/5964
+[#5991]: https://github.com/ReactTraining/react-router/pull/5991
 
 ## [v4.2.0](https://github.com/ReactTraining/react-router/compare/v4.1.1...v4.2.0)
 > Aug 23, 2017

--- a/packages/react-router-redux/modules/ConnectedRouter.js
+++ b/packages/react-router-redux/modules/ConnectedRouter.js
@@ -2,6 +2,7 @@ import React, { Component } from "react";
 import PropTypes from "prop-types";
 import { Router } from "react-router";
 
+import assertHistory from "./assertHistory";
 import { LOCATION_CHANGE } from "./reducer";
 
 class ConnectedRouter extends Component {
@@ -25,6 +26,9 @@ class ConnectedRouter extends Component {
 
   componentWillMount() {
     const { store: propsStore, history, isSSR } = this.props;
+
+    assertHistory(history);
+
     this.store = propsStore || this.context.store;
 
     if (!isSSR)

--- a/packages/react-router-redux/modules/assertHistory.js
+++ b/packages/react-router-redux/modules/assertHistory.js
@@ -1,0 +1,29 @@
+const PRODUCTION_ERROR = "Invalid history object";
+
+function assertHistory(maybeHistory) {
+  if (!maybeHistory) {
+    throw new Error(
+      process.env.NODE_ENV === "production"
+        ? PRODUCTION_ERROR
+        : 'Expected history object to be created by the "history" package, but received ' +
+          maybeHistory
+    );
+  }
+  if (maybeHistory instanceof global.History) {
+    throw new Error(
+      process.env.NODE_ENV === "production"
+        ? PRODUCTION_ERROR
+        : 'Expected history object to be created by the "history" package, but received a DOM History object'
+    );
+  }
+
+  if (!maybeHistory.push) {
+    throw new Error(
+      process.env.NODE_ENV === "production"
+        ? PRODUCTION_ERROR
+        : 'Expected history object to be created by the "history" package, but received some other value'
+    );
+  }
+}
+
+export default assertHistory;

--- a/packages/react-router-redux/modules/middleware.js
+++ b/packages/react-router-redux/modules/middleware.js
@@ -1,4 +1,5 @@
 import { CALL_HISTORY_METHOD } from "./actions";
+import assertHistory from "./assertHistory";
 
 /**
  * This middleware captures CALL_HISTORY_METHOD actions to redirect to the
@@ -6,6 +7,8 @@ import { CALL_HISTORY_METHOD } from "./actions";
  * reducer or any middleware that comes after this one.
  */
 export default function routerMiddleware(history) {
+  assertHistory(history);
+
   return () => next => action => {
     if (action.type !== CALL_HISTORY_METHOD) {
       return next(action);


### PR DESCRIPTION
I was helping someone on IRC who accidentally passed the global 'history' variable (instance of window.History), instead of the variable called 'history' in the readme.

This just adds a few checks with helpful errors when someone passes an invalid history.

Unfortunately, I couldn't figure out how to get the tests running, so for now I put a testcase on [codesandbox](https://codesandbox.io/s/j7z531y9ww).

Edit: I'm confused about what's going on in this repo. I had to `git commit --no-verify` to prevent the lerna script from completely reformatting CHANGES.md, and it was trying to update a bunch of package-lock.json files.