### PR TITLE
Fix history api changes in react-router-redux

### DIFF
--- a/packages/react-router-redux/modules/ConnectedRouter.js
+++ b/packages/react-router-redux/modules/ConnectedRouter.js
@@ -16,10 +16,13 @@ class ConnectedRouter extends Component {
     store: PropTypes.object
   };
 
-  handleLocationChange = location => {
+  handleLocationChange = (location, action) => {
     this.store.dispatch({
       type: LOCATION_CHANGE,
-      payload: location
+      payload: {
+        location,
+        action
+      }
     });
   };
 

--- a/packages/react-router-redux/modules/__tests__/ConnectedRouter-test.js
+++ b/packages/react-router-redux/modules/__tests__/ConnectedRouter-test.js
@@ -61,6 +61,8 @@ describe("A <ConnectedRouter>", () => {
     history.push("/foo");
 
     expect(store.getState()).toHaveProperty("router.location.pathname", "/foo");
+    expect(store.getState()).toHaveProperty("router.location.pathname", "/foo");
+    expect(store.getState()).toHaveProperty("router.action", "PUSH");
   });
 
   describe("with children", () => {

--- a/packages/react-router-redux/modules/__tests__/reducer-test.js
+++ b/packages/react-router-redux/modules/__tests__/reducer-test.js
@@ -3,9 +3,9 @@ import { LOCATION_CHANGE, routerReducer } from "../reducer";
 describe("routerReducer", () => {
   const state = {
     location: {
-      pathname: "/foo",
-      action: "POP"
-    }
+      pathname: "/foo"
+    },
+    action: "POP"
   };
 
   it("updates the path", () => {
@@ -13,15 +13,13 @@ describe("routerReducer", () => {
       routerReducer(state, {
         type: LOCATION_CHANGE,
         payload: {
-          path: "/bar",
+          location: { path: "/bar" },
           action: "PUSH"
         }
       })
     ).toEqual({
-      location: {
-        path: "/bar",
-        action: "PUSH"
-      }
+      location: { path: "/bar" },
+      action: "PUSH"
     });
   });
 
@@ -30,15 +28,13 @@ describe("routerReducer", () => {
       routerReducer(undefined, {
         type: LOCATION_CHANGE,
         payload: {
-          path: "/bar",
+          location: { path: "/bar" },
           action: "PUSH"
         }
       })
     ).toEqual({
-      location: {
-        path: "/bar",
-        action: "PUSH"
-      }
+      location: { path: "/bar" },
+      action: "PUSH"
     });
   });
 
@@ -47,15 +43,13 @@ describe("routerReducer", () => {
       routerReducer(state, {
         type: LOCATION_CHANGE,
         payload: {
-          path: "/bar",
+          location: { path: "/bar" },
           action: "REPLACE"
         }
       })
     ).toEqual({
-      location: {
-        path: "/bar",
-        action: "REPLACE"
-      }
+      location: { path: "/bar" },
+      action: "REPLACE"
     });
   });
 });

--- a/packages/react-router-redux/modules/__tests__/selectors-test.js
+++ b/packages/react-router-redux/modules/__tests__/selectors-test.js
@@ -1,4 +1,4 @@
-import { getLocation, createMatchSelector } from "../selectors";
+import { getLocation, createMatchSelector, getAction } from "../selectors";
 import { createStore, combineReducers } from "redux";
 import { routerReducer, LOCATION_CHANGE } from "../reducer";
 
@@ -18,10 +18,26 @@ describe("selectors", () => {
       const location = { pathname: "/" };
       store.dispatch({
         type: LOCATION_CHANGE,
-        payload: location
+        payload: {
+          location
+        }
       });
       const state = store.getState();
       expect(getLocation(state)).toBe(location);
+    });
+  });
+
+  describe("getLocation", () => {
+    it("gets the location from the state", () => {
+      const action = "PUSH";
+      store.dispatch({
+        type: LOCATION_CHANGE,
+        payload: {
+          action
+        }
+      });
+      const state = store.getState();
+      expect(getAction(state)).toBe(action);
     });
   });
 
@@ -30,7 +46,9 @@ describe("selectors", () => {
       const matchSelector = createMatchSelector("/");
       store.dispatch({
         type: LOCATION_CHANGE,
-        payload: { pathname: "/test" }
+        payload: {
+          location: { pathname: "/test" }
+        }
       });
       const state = store.getState();
       expect(matchSelector(state)).toEqual({
@@ -51,12 +69,16 @@ describe("selectors", () => {
       const matchSelector = createMatchSelector("/");
       store.dispatch({
         type: LOCATION_CHANGE,
-        payload: { pathname: "/test1" }
+        payload: {
+          location: { pathname: "/test1" }
+        }
       });
       const match1 = matchSelector(store.getState());
       store.dispatch({
         type: LOCATION_CHANGE,
-        payload: { pathname: "/test2" }
+        payload: {
+          location: { pathname: "/test2" }
+        }
       });
       const match2 = matchSelector(store.getState());
       expect(match1).toBe(match2);
@@ -66,7 +88,9 @@ describe("selectors", () => {
       const matchSelector = createMatchSelector("/sushi/:type");
       store.dispatch({
         type: LOCATION_CHANGE,
-        payload: { pathname: "/sushi/california" }
+        payload: {
+          location: { pathname: "/sushi/california" }
+        }
       });
       const match1 = matchSelector(store.getState());
       store.dispatch({
@@ -84,7 +108,9 @@ describe("selectors", () => {
       });
       store.dispatch({
         type: LOCATION_CHANGE,
-        payload: { pathname: "/sushi" }
+        payload: {
+          location: { pathname: "/sushi" }
+        }
       });
       const match1 = matchSelector(store.getState());
       store.dispatch({

--- a/packages/react-router-redux/modules/index.js
+++ b/packages/react-router-redux/modules/index.js
@@ -1,5 +1,5 @@
 export ConnectedRouter from "./ConnectedRouter";
-export { getLocation, createMatchSelector } from "./selectors";
+export { getAction, getLocation, createMatchSelector } from "./selectors";
 export { LOCATION_CHANGE, routerReducer } from "./reducer";
 export {
   CALL_HISTORY_METHOD,

--- a/packages/react-router-redux/modules/reducer.js
+++ b/packages/react-router-redux/modules/reducer.js
@@ -5,7 +5,8 @@
 export const LOCATION_CHANGE = "@@router/LOCATION_CHANGE";
 
 const initialState = {
-  location: null
+  location: null,
+  action: null
 };
 
 /**
@@ -16,7 +17,9 @@ const initialState = {
  */
 export function routerReducer(state = initialState, { type, payload } = {}) {
   if (type === LOCATION_CHANGE) {
-    return { ...state, location: payload };
+    const { location, action } = payload || {};
+
+    return { ...state, location, action };
   }
 
   return state;

--- a/packages/react-router-redux/modules/selectors.js
+++ b/packages/react-router-redux/modules/selectors.js
@@ -1,6 +1,7 @@
 import { matchPath } from "react-router";
 
 export const getLocation = state => state.router.location;
+export const getAction = state => state.router.action;
 
 export const createMatchSelector = path => {
   let lastPathname = null;


### PR DESCRIPTION
It seems like react-router-redux assumes the action property is in the location object provided by the history module. So I've added the action property back into the store and added a selector. I've also updated the tests and added a test for this change.

We're interested in the action used to cause the route change, to react to `POP`s and `PUSH`s

The `location` object doesn't seem to have an `action` property when using `history/createBrowserHistory`

The createLocation function is missing the action property https://github.com/ReactTraining/history/blob/master/modules/LocationUtils.js#L5