### PR TITLE
Routes with 'children' prop are still rendered inside a Switch

### DIFF
--- a/packages/react-router/modules/Switch.js
+++ b/packages/react-router/modules/Switch.js
@@ -43,30 +43,32 @@ class Switch extends React.Component {
     const { children } = this.props;
     const location = this.props.location || route.location;
 
-    let match, child;
-    React.Children.forEach(children, element => {
-      if (match == null && React.isValidElement(element)) {
-        const {
-          path: pathProp,
-          exact,
-          strict,
-          sensitive,
-          from
-        } = element.props;
-        const path = pathProp || from;
-
-        child = element;
-        match = matchPath(
-          location.pathname,
-          { path, exact, strict, sensitive },
-          route.match
-        );
+    let match;
+    return React.Children.map(children, element => {
+      if (match !== null && React.isValidElement(element)) {
+        if (!element.props.children) {
+          return null;
+        }
+        return React.cloneElement(element, {location, computedMatch: null});
       }
-    });
 
-    return match
-      ? React.cloneElement(child, { location, computedMatch: match })
-      : null;
+      const {
+        path: pathProp,
+        exact,
+        strict,
+        sensitive,
+        from
+      } = element.props;
+      const path = pathProp || from;
+
+      match = matchPath(
+        location.pathname,
+        { path, exact, strict, sensitive },
+        route.match
+      );
+
+      return React.cloneElement(element, {location, computedMatch: match});
+    });
   }
 }
 


### PR DESCRIPTION
In the current `<Switch />` implementation, only the first matching route is rendered. This doesn't seem consistent with the behaviour of a `<Route />`, which according to the documentation should continue to be rendered if using a `children` prop (with `match` being null).

This PR adds a presence check for `children` on children of the `<Switch />` component to allow them to be rendered.

This behaviour is necessary in order to implement route animations within a Switch