### PR TITLE
Fix typo

### DIFF
--- a/packages/react-router-dom/docs/guides/basic-components.md
+++ b/packages/react-router-dom/docs/guides/basic-components.md
@@ -62,7 +62,7 @@ The `<Switch>` is not required for grouping `<Route>`s, but it can be quite usef
 
 ## Route Rendering Props
 
-You have three prop choices for how you render a component for a given `<Route>`: `component`, `render`, and `children`. You can check the out the [`<Route>` documentation](../api/Route.md) for more information on each one, but here we'll focus on `component` and `render` because those are the two you will almost always use.
+You have three prop choices for how you render a component for a given `<Route>`: `component`, `render`, and `children`. You can check out the [`<Route>` documentation](../api/Route.md) for more information on each one, but here we'll focus on `component` and `render` because those are the two you will almost always use.
 
 `component` should be used when you have an existing component (either a `React.Component` or a stateless functional component) that you want to render. `render`, which takes an inline function, should only be used when you have to pass in-scope variables to the component you want to render. You should **not** use the `component` prop with an inline function to pass in-scope variables because you will get undesired component unmounts/remounts.
 


### PR DESCRIPTION
Fixing that typo was easy, but I'd like also to clarify the following:

> you should use a \<BrowserRouter\> if you have a server that responds to requests and a \<HashRouter\> if you are using a static file server

It seems to me that both descriptions apply to any situation, so I'm confused.

> if you have a server that responds to requests

What kind of a server there is that doesn't respond to requests?

>  if you are using a static file server

React stuff is compiled and served as static assets, so it also applies to any case.

Maybe it gets obvious as you dig deeper into the docs, but I just start reading it and feel like it should be more clear.