### PR TITLE
Add sideEffects: false to react-router-dom package.json

### DIFF
--- a/packages/react-router-config/package.json
+++ b/packages/react-router-config/package.json
@@ -16,6 +16,7 @@
   ],
   "main": "index.js",
   "module": "es/index.js",
+  "sideEffects": false,
   "scripts": {
     "build": "node ./tools/build.js",
     "watch": "babel ./modules -d . --ignore __tests__ --watch",

--- a/packages/react-router-dom/package.json
+++ b/packages/react-router-dom/package.json
@@ -29,6 +29,7 @@
   ],
   "main": "index.js",
   "module": "es/index.js",
+  "sideEffects": false,
   "scripts": {
     "build": "node ./tools/build.js",
     "watch": "babel ./modules -d . --ignore __tests__ --watch",

--- a/packages/react-router-native/package.json
+++ b/packages/react-router-native/package.json
@@ -9,6 +9,7 @@
     "Ryan Florence"
   ],
   "main": "main.js",
+  "sideEffects": false,
   "scripts": {
     "start": "node node_modules/react-native/local-cli/cli.js start",
     "clean": "git clean -fdX .",

--- a/packages/react-router-redux/package.json
+++ b/packages/react-router-redux/package.json
@@ -19,6 +19,7 @@
   ],
   "main": "index.js",
   "module": "es/index.js",
+  "sideEffects": false,
   "scripts": {
     "build": "node ./tools/build.js",
     "prepublishOnly": "node ./tools/build.js",

--- a/packages/react-router/package.json
+++ b/packages/react-router/package.json
@@ -25,6 +25,7 @@
   ],
   "main": "index.js",
   "module": "es/index.js",
+  "sideEffects": false,
   "scripts": {
     "build": "node ./tools/build.js",
     "watch": "babel ./modules -d . --ignore __tests__ --watch",


### PR DESCRIPTION
Webpack 4.0 introduced support for a `sideEffects` flag in a project's `package.json`: https://webpack.js.org/guides/tree-shaking/#mark-the-file-as-side-effect-free. This is awesome because we can now get Webpack's tree shaking to work as intended for most, if not all projects. 🎉 

I've noticed that in my projects where I've used `react-router-dom`, the recommended import syntax (eg. `import { Route } from 'react-router-dom'`) still pulls in the entire library. While react-router-dom and it's associated packages aren't _that_ large, I'm a bit of a performance junkie 😃. All this PR does is add the `sideEffects: false` flag to the `react-router-dom` package. I created a simple test repo to demo the effects of this flag: https://github.com/taylorc93/react-router-test. I'm noticing ~20KB of minified JS removed from my bundle as a result of this change.

The only thing I'm slightly unsure of is whether there are, in fact, side effects. From what I can see, there aren't any, but I could definitely be missing something. Let me know what you think / if there's anything else you need from me to get this merged!

Side note: Love this project, I've been using it for years and it's worked fabulously. Keep up the great work!