### PR TITLE
Embiggen the large breakpoint

### DIFF
--- a/website/modules/base.css
+++ b/website/modules/base.css
@@ -131,7 +131,7 @@ markdown h1, h2, h3 {
   clear: both;
 }
 
-@media screen and (max-width: 1170px) {
+@media screen and (max-width: 1270px) {
   .api-doc-wrapper {
     background: white;
   }


### PR DESCRIPTION
Fixes #6052

Prevents large code blocks from being wrapped at sub 1266px widths.