### PR TITLE
Fix for Issue #6109 - aria-current has incorrect value "true"

### DIFF
--- a/packages/react-router-dom/modules/NavLink.js
+++ b/packages/react-router-dom/modules/NavLink.js
@@ -67,13 +67,14 @@ NavLink.propTypes = {
     "location",
     "date",
     "time",
-    "true"
+    "true",
+    "false"
   ])
 };
 
 NavLink.defaultProps = {
   activeClassName: "active",
-  "aria-current": "true"
+  "aria-current": "page"
 };
 
 export default NavLink;

--- a/packages/react-router-dom/modules/__tests__/NavLink-test.js
+++ b/packages/react-router-dom/modules/__tests__/NavLink-test.js
@@ -53,7 +53,7 @@ describe("NavLink", () => {
       expect(a.style.color).toBe(activeStyle.color);
     });
 
-    it("applies aria-current of true if no override value is given", () => {
+    it("applies aria-current of page if no override value is given", () => {
       ReactDOM.render(
         <MemoryRouter initialEntries={["/pizza"]}>
           <NavLink to="/pizza" activeClassName="selected">
@@ -63,20 +63,20 @@ describe("NavLink", () => {
         node
       );
       const a = node.getElementsByTagName("a")[0];
-      expect(a.getAttribute("aria-current")).toEqual("true");
+      expect(a.getAttribute("aria-current")).toEqual("page");
     });
 
     it("applies the override aria-current value when given", () => {
       ReactDOM.render(
         <MemoryRouter initialEntries={["/pizza"]}>
-          <NavLink to="/pizza" activeClassName="selected" aria-current="page">
+          <NavLink to="/pizza" activeClassName="selected" aria-current="true">
             Pizza!
           </NavLink>
         </MemoryRouter>,
         node
       );
       const a = node.getElementsByTagName("a")[0];
-      expect(a.getAttribute("aria-current")).toEqual("page");
+      expect(a.getAttribute("aria-current")).toEqual("true");
     });
 
     it("handles locations without a pathname", () => {


### PR DESCRIPTION
For Issue #6109. I updated the default value of `aria-current` on `NavLink` to `"page"`. I also added `"false"` as a valid option, as defined in the [spec for aria-current](https://www.w3.org/TR/wai-aria-1.1/#aria-current). 

Also included are updated tests for `NavLink`, to reflect the above changes. The tests pass when I run `npm run test` in the root directory.

Please let me know if any further changes need to be made for this PR. If any documentation for `NavLink `needs to be changed, please send me a link to the locations that need to be modified, and I will update them accordingly. Thank you!