### PR TITLE
Enabling url params support in PrivateRoute (Documentation Auth)

### DIFF
--- a/website/modules/examples/Auth.js
+++ b/website/modules/examples/Auth.js
@@ -62,23 +62,19 @@ const AuthButton = withRouter(
     )
 );
 
-const PrivateRoute = ({ component: Component, ...rest }) => (
-  <Route
-    {...rest}
-    render={props =>
-      fakeAuth.isAuthenticated ? (
-        <Component {...props} />
-      ) : (
-        <Redirect
-          to={{
-            pathname: "/login",
-            state: { from: props.location }
-          }}
-        />
-      )
-    }
-  />
-);
+class PrivateRoute extends Route {
+  render() {
+    const Component = this.props.component;
+    //Updating match in PrivateRoute props since match is updated only at render time.
+    const mergedPropsAfterMatch = Object.assign({}, this.props, {match: this.state.match});
+    return fakeAuth.isAuthenticated ? <Component {...mergedPropsAfterMatch} /> : <Redirect
+      to={{
+        pathname: '/login',
+        state: { from: this.props.location.pathname },
+      }}
+    />;
+  }
+}
 
 const Public = () => <h3>Public</h3>;
 const Protected = () => <h3>Protected</h3>;


### PR DESCRIPTION
I noticed that the match property is only updated in the state of the route when it is rendered.
I think it should be interesting to merge state during render to the props of the rendered component so it gets the right url Params.