### PR TITLE
wrap text in a Link with a Text element

### DIFF
--- a/packages/react-router-native/docs/api/Link.md
+++ b/packages/react-router-native/docs/api/Link.md
@@ -5,7 +5,7 @@ Provide declarative, accessible navigation around your application.
 ```jsx
 import { Link } from 'react-router-native'
 
-<Link to='/about'>About</Link>
+<Link to='/about'><Text>About</Text></Link>
 ```
 
 ## to: string


### PR DESCRIPTION
otherwise it throws Invariant Violation: React.Children.only expected to receive a single React element child.