### PR TITLE
Added support for render method in react-router-config

### DIFF
--- a/packages/react-router-config/modules/__tests__/renderRoutes-test.js
+++ b/packages/react-router-config/modules/__tests__/renderRoutes-test.js
@@ -433,4 +433,21 @@ describe("renderRoutes", () => {
       expect(renderedRoutes[1]).toEqual(routes[1].routes[1]);
     });
   });
+
+  it("allows rendering a component using a function with render property", () => {
+    const routes = [
+      {
+        path: "/path",
+        render: props => <Comp {...props} />
+      }
+    ];
+
+    ReactDOMServer.renderToString(
+      <StaticRouter location="/path" context={{}}>
+        {renderRoutes(routes)}
+      </StaticRouter>
+    );
+    expect(renderedRoutes.length).toEqual(1);
+    expect(renderedRoutes[0]).toEqual(routes[0]);
+  });
 });

--- a/packages/react-router-config/modules/renderRoutes.js
+++ b/packages/react-router-config/modules/renderRoutes.js
@@ -11,9 +11,13 @@ const renderRoutes = (routes, extraProps = {}, switchProps = {}) =>
           path={route.path}
           exact={route.exact}
           strict={route.strict}
-          render={props => (
-            <route.component {...props} {...extraProps} route={route} />
-          )}
+          render={props =>
+            route.render ? (
+              route.render(props)
+            ) : (
+              <route.component {...props} {...extraProps} route={route} />
+            )
+          }
         />
       ))}
     </Switch>

--- a/packages/react-router-config/modules/renderRoutes.js
+++ b/packages/react-router-config/modules/renderRoutes.js
@@ -13,7 +13,7 @@ const renderRoutes = (routes, extraProps = {}, switchProps = {}) =>
           strict={route.strict}
           render={props =>
             route.render ? (
-              route.render(props)
+              route.render({ ...props, ...extraProps, route: route })
             ) : (
               <route.component {...props} {...extraProps} route={route} />
             )


### PR DESCRIPTION
This PR allows to use render as valid callback in the `react-router-config` configuration tree.

It tries to resolve the #4962 issue and it's implemented based on this idea:
https://github.com/ReactTraining/react-router/issues/4962#issuecomment-376567551

For example:
```
{
    {
        path: "/restricted-area",
        render: (props) => isUserLoggedIn() ? <RestrictedArea/> : <Redirect to="/login"/>
    },
    {
        path: "/login",
        component: Login
    }
}
```