### PR TITLE
Basic support of partial <Route /> paths.

### DIFF
--- a/packages/react-router/modules/__tests__/Route-test.js
+++ b/packages/react-router/modules/__tests__/Route-test.js
@@ -119,83 +119,6 @@ describe("A <Route> with dynamic segments in the path", () => {
   });
 });
 
-describe("A <Route> with relative path", () => {
-  it("renders them as children", () => {
-    const TEXT = "some text";
-    const node = document.createElement("div");
-    ReactDOM.render(
-      <MemoryRouter initialEntries={["/some/path"]}>
-        <Route path="/">
-          <Route path="some/path">
-            <div>{TEXT}</div>
-          </Route>
-        </Route>
-      </MemoryRouter>,
-      node
-    );
-
-    expect(node.innerHTML).toContain(TEXT);
-  });
-
-  it("renders them as using child function", () => {
-    const TEXT = "some text";
-    const node = document.createElement("div");
-    ReactDOM.render(
-      <MemoryRouter initialEntries={["/some/path"]}>
-        <Route path="/">
-          {() => (
-            <Route path="some/path">
-              <div>{TEXT}</div>
-            </Route>
-          )}
-        </Route>
-      </MemoryRouter>,
-      node
-    );
-
-    expect(node.innerHTML).toContain(TEXT);
-  });
-
-  it("renders them as using render prop", () => {
-    const TEXT = "some text";
-    const node = document.createElement("div");
-    ReactDOM.render(
-      <MemoryRouter initialEntries={["/some/path"]}>
-        <Route
-          path="/"
-          render={() => (
-            <Route path="some/path">
-              <div>{TEXT}</div>
-            </Route>
-          )}
-        />
-      </MemoryRouter>,
-      node
-    );
-
-    expect(node.innerHTML).toContain(TEXT);
-  });
-
-  it("renders them as children despite dom nesting", () => {
-    const TEXT = "some text";
-    const node = document.createElement("div");
-    ReactDOM.render(
-      <MemoryRouter initialEntries={["/some/path"]}>
-        <Route path="/">
-          <div>
-            <Route path="some/path">
-              <div>{TEXT}</div>
-            </Route>
-          </div>
-        </Route>
-      </MemoryRouter>,
-      node
-    );
-
-    expect(node.innerHTML).toContain(TEXT);
-  });
-});
-
 describe("A unicode <Route>", () => {
   it("is able to match", () => {
     const node = document.createElement("div");
@@ -510,5 +433,38 @@ describe("A pathless <Route>", () => {
       node
     );
     expect(rootContext).toBe(undefined);
+  });
+});
+
+describe("A partial <Route>", () => {
+  it("joins with root (/) when there is no parent match", () => {
+    const TEXT = "uncle";
+    const node = document.createElement("div");
+
+    ReactDOM.render(
+      <MemoryRouter initialEntries={["/uncle"]}>
+        <Route path="uncle" render={() => <h1>{TEXT}</h1>} />
+      </MemoryRouter>,
+      node
+    );
+
+    expect(node.innerHTML).toContain(TEXT);
+  });
+
+  it("joins its path with parent match", () => {
+    const TEXT = "cousin";
+    const node = document.createElement("div");
+
+    ReactDOM.render(
+      <MemoryRouter initialEntries={["/uncle/cousin"]}>
+        <Route
+          path="uncle"
+          render={() => <Route path="cousin" render={() => <h1>{TEXT}</h1>} />}
+        />
+      </MemoryRouter>,
+      node
+    );
+
+    expect(node.innerHTML).toContain(TEXT);
   });
 });

--- a/packages/react-router/modules/__tests__/Route-test.js
+++ b/packages/react-router/modules/__tests__/Route-test.js
@@ -119,6 +119,83 @@ describe("A <Route> with dynamic segments in the path", () => {
   });
 });
 
+describe("A <Route> with relative path", () => {
+  it("renders them as children", () => {
+    const TEXT = "some text";
+    const node = document.createElement("div");
+    ReactDOM.render(
+      <MemoryRouter initialEntries={["/some/path"]}>
+        <Route path="/">
+          <Route path="some/path">
+            <div>{TEXT}</div>
+          </Route>
+        </Route>
+      </MemoryRouter>,
+      node
+    );
+
+    expect(node.innerHTML).toContain(TEXT);
+  });
+
+  it("renders them as using child function", () => {
+    const TEXT = "some text";
+    const node = document.createElement("div");
+    ReactDOM.render(
+      <MemoryRouter initialEntries={["/some/path"]}>
+        <Route path="/">
+          {() => (
+            <Route path="some/path">
+              <div>{TEXT}</div>
+            </Route>
+          )}
+        </Route>
+      </MemoryRouter>,
+      node
+    );
+
+    expect(node.innerHTML).toContain(TEXT);
+  });
+
+  it("renders them as using render prop", () => {
+    const TEXT = "some text";
+    const node = document.createElement("div");
+    ReactDOM.render(
+      <MemoryRouter initialEntries={["/some/path"]}>
+        <Route
+          path="/"
+          render={() => (
+            <Route path="some/path">
+              <div>{TEXT}</div>
+            </Route>
+          )}
+        />
+      </MemoryRouter>,
+      node
+    );
+
+    expect(node.innerHTML).toContain(TEXT);
+  });
+
+  it("renders them as children despite dom nesting", () => {
+    const TEXT = "some text";
+    const node = document.createElement("div");
+    ReactDOM.render(
+      <MemoryRouter initialEntries={["/some/path"]}>
+        <Route path="/">
+          <div>
+            <Route path="some/path">
+              <div>{TEXT}</div>
+            </Route>
+          </div>
+        </Route>
+      </MemoryRouter>,
+      node
+    );
+
+    expect(node.innerHTML).toContain(TEXT);
+  });
+});
+
 describe("A unicode <Route>", () => {
   it("is able to match", () => {
     const node = document.createElement("div");

--- a/packages/react-router/modules/__tests__/Switch-test.js
+++ b/packages/react-router/modules/__tests__/Switch-test.js
@@ -338,5 +338,46 @@ describe("A <Switch location>", () => {
       );
       expect(propLocation).toEqual(switchLocation);
     });
+
+    it("renders partial Routes", () => {
+      const node = document.createElement("div");
+
+      ReactDOM.render(
+        <MemoryRouter initialEntries={["/sauce/sriracha"]}>
+          <Route
+            path="/sauce"
+            render={() => (
+              <Switch>
+                <Route path="sriracha" render={() => <div>sriracha</div>} />
+              </Switch>
+            )}
+          />
+        </MemoryRouter>,
+        node
+      );
+
+      expect(node.innerHTML).toContain("sriracha");
+    });
+
+    it("renders partial <Redirect>s", () => {
+      const node = document.createElement("div");
+
+      ReactDOM.render(
+        <MemoryRouter initialEntries={["/sauce/tobasco"]}>
+          <Route
+            path="/sauce"
+            render={() => (
+              <Switch>
+                <Route path="sriracha" render={() => <div>sriracha</div>} />
+                <Redirect from="tobasco" to="/sauce/sriracha" />
+              </Switch>
+            )}
+          />
+        </MemoryRouter>,
+        node
+      );
+
+      expect(node.innerHTML).toContain("sriracha");
+    });
   });
 });

--- a/packages/react-router/modules/__tests__/matchPath-test.js
+++ b/packages/react-router/modules/__tests__/matchPath-test.js
@@ -54,6 +54,48 @@ describe("matchPath", () => {
     });
   });
 
+  describe("with relative path (no leading slash)", () => {
+    it("returns correct match url and params with no parent", () => {
+      const pathname = "/7";
+      const options = {
+        path: ":number"
+      };
+      const match = matchPath(pathname, options, null);
+      expect(match.url).toBe("/7");
+      expect(match.params).toEqual({ number: "7" });
+    });
+    it("returns correct match url and params with parent", () => {
+      const pathname = "/test-location/7";
+      const options = {
+        path: ":number"
+      };
+      const parentMatch = {
+        url: "/test-location",
+        path: "/test-location",
+        params: {},
+        isExact: true
+      };
+      const match = matchPath(pathname, options, parentMatch);
+      expect(match.url).toBe("/test-location/7");
+      expect(match.params).toEqual({ number: "7" });
+    });
+    it("passes along parent match params", () => {
+      const pathname = "/test-location/hello/7";
+      const options = {
+        path: ":number"
+      };
+      const parentMatch = {
+        url: "/test-location/:something",
+        path: "/test-location/hello",
+        params: { something: "hello" },
+        isExact: true
+      };
+      const match = matchPath(pathname, options, parentMatch);
+      expect(match.url).toBe("/test-location/hello/7");
+      expect(match.params).toEqual({ something: "hello", number: "7" });
+    });
+  });
+
   describe("cache", () => {
     it("creates a cache entry for each exact/strict pair", () => {
       // true/false and false/true will collide when adding booleans

--- a/packages/react-router/modules/matchPath.js
+++ b/packages/react-router/modules/matchPath.js
@@ -1,6 +1,6 @@
 import pathToRegexp from "path-to-regexp";
 
-const isAbsolute = pathname => !!(pathname && pathname.charAt(0) === "/");
+const isAbsolute = pathname => /^\\?\/.*/.test(pathname);
 
 const addTrailingSlash = pathname =>
   hasTrailingSlash(pathname) ? pathname : pathname + "/";


### PR DESCRIPTION
Most of this PR is pulled from #4539 which is outdated and has a lot of merge conflicts.

The implementation is simple: the `matchPath` method will infer that if `options.path` does not have a leading slash, then it is relative to the parent w/ the parent's matched url used as the base.

I'm hoping that this continues the conversation started in #5127 so that we can move closer to having a solution.

In my opinion, `Route` paths should not support `./` or `../`. As for linking, relative links are already working as demonstrated by [this comment](https://github.com/ReactTraining/react-router/issues/5127#issuecomment-374019025). 

Relative route paths should remain simple and straightforward and the logic around relative linking should be delegated to `history` as much as possible possible.