### PR TITLE
Removal of React 16.3 unsafe lifecycles

### DIFF
--- a/packages/react-router/modules/Router.js
+++ b/packages/react-router/modules/Router.js
@@ -20,6 +20,17 @@ class Router extends React.Component {
     router: PropTypes.object.isRequired
   };
 
+  static getDerivedStateFromProps(nextProps) {
+    const { children } = nextProps;
+
+    invariant(
+      children == null || React.Children.count(children) === 1,
+      "A <Router> may have only one child element"
+    );
+
+    return null;
+  }
+
   getChildContext() {
     return {
       router: {
@@ -50,11 +61,6 @@ class Router extends React.Component {
     super(props);
     const { children, history } = props;
 
-    invariant(
-      children == null || React.Children.count(children) === 1,
-      "A <Router> may have only one child element"
-    );
-
     // Do this here so we can setState when a <Redirect> changes the
     // location in componentWillMount. This happens e.g. when doing
     // server rendering using a <StaticRouter>.
@@ -65,9 +71,9 @@ class Router extends React.Component {
     });
   }
 
-  shouldComponentUpdate(nextProps) {
+  componentDidUpdate(prevProps) {
     warning(
-      this.props.history === nextProps.history,
+      this.props.history === prevProps.history,
       "You cannot change <Router history>"
     );
     return true;

--- a/packages/react-router/modules/Router.js
+++ b/packages/react-router/modules/Router.js
@@ -76,7 +76,6 @@ class Router extends React.Component {
       this.props.history === prevProps.history,
       "You cannot change <Router history>"
     );
-    return true;
   }
 
   componentWillUnmount() {

--- a/packages/react-router/modules/Router.js
+++ b/packages/react-router/modules/Router.js
@@ -33,6 +33,10 @@ class Router extends React.Component {
     };
   }
 
+  state = {
+    match: this.computeMatch(this.props.history.location.pathname)
+  };
+
   computeMatch(pathname) {
     return {
       path: "/",
@@ -59,10 +63,6 @@ class Router extends React.Component {
         match: this.computeMatch(history.location.pathname)
       });
     });
-
-    this.state = {
-      match: this.computeMatch(this.props.history.location.pathname)
-    };
   }
 
   shouldComponentUpdate(nextProps) {

--- a/packages/react-router/modules/Router.js
+++ b/packages/react-router/modules/Router.js
@@ -33,10 +33,6 @@ class Router extends React.Component {
     };
   }
 
-  state = {
-    match: this.computeMatch(this.props.history.location.pathname)
-  };
-
   computeMatch(pathname) {
     return {
       path: "/",
@@ -46,8 +42,9 @@ class Router extends React.Component {
     };
   }
 
-  componentWillMount() {
-    const { children, history } = this.props;
+  constructor(props) {
+    super(props);
+    const { children, history } = props;
 
     invariant(
       children == null || React.Children.count(children) === 1,
@@ -62,13 +59,18 @@ class Router extends React.Component {
         match: this.computeMatch(history.location.pathname)
       });
     });
+
+    this.state = {
+      match: this.computeMatch(this.props.history.location.pathname)
+    };
   }
 
-  componentWillReceiveProps(nextProps) {
+  shouldComponentUpdate(nextProps) {
     warning(
       this.props.history === nextProps.history,
       "You cannot change <Router history>"
     );
+    return true;
   }
 
   componentWillUnmount() {


### PR DESCRIPTION
This is intended to resolve #6060.

The warning that was activated in `componentWillReceiveProps` was moved to component `shouldComponentUpdate`, and the `this.unlisten` function is now being set in `constructor`.

**WARNING**: The unit tests are all green, but I was not able to run a real life setup (at the time of this writing, accepting help) to test this. If someone can test this with React.StrictMode, I would be glad.