### PR TITLE
[Redirect] don't import entire history module

### DIFF
--- a/packages/react-router/modules/Redirect.js
+++ b/packages/react-router/modules/Redirect.js
@@ -2,7 +2,7 @@ import React from "react";
 import PropTypes from "prop-types";
 import warning from "warning";
 import invariant from "invariant";
-import { createLocation, locationsAreEqual } from "history";
+import { createLocation, locationsAreEqual } from "history/LocationUtils";
 import generatePath from "./generatePath";
 
 /**


### PR DESCRIPTION
Hello, I was looking through my webpack bundle and found this optimization to reduce bundle size.

With these changes, my bundle goes from 797.3kb to 782.9kb, a savings of 14.4kb.

Before:

<img width="838" alt="screen shot 2018-08-02 at 4 24 14 pm" src="https://user-images.githubusercontent.com/1571918/43616274-8a252864-9670-11e8-842b-cb562296b90b.png">

After:

<img width="818" alt="screen shot 2018-08-02 at 4 24 22 pm" src="https://user-images.githubusercontent.com/1571918/43616276-8e0fa8be-9670-11e8-80d2-0e31c716c54c.png">
