### PR TITLE
Default to NOT_FOUND when match.params.id is bogus

### DIFF
--- a/website/modules/examples/Recursive.js
+++ b/website/modules/examples/Recursive.js
@@ -8,6 +8,8 @@ const PEEPS = [
   { id: 3, name: "David", friends: [1, 2] }
 ];
 
+const NOT_FOUND = { id: -1, name: "¯\\_(ツ)_/¯", friends: [0, 1, 2, 3] };
+
 const find = id => PEEPS.find(p => p.id == id);
 
 const RecursiveExample = () => (
@@ -17,7 +19,7 @@ const RecursiveExample = () => (
 );
 
 const Person = ({ match }) => {
-  const person = find(match.params.id);
+  const person = find(match.params.id) || NOT_FOUND;
 
   return (
     <div>


### PR DESCRIPTION
- This stops the recursive example from exploding when a bogus param is passed in

<img width="360" alt="screen shot 2018-08-09 at 12 58 43 pm" src="https://user-images.githubusercontent.com/1310430/43919774-2947d140-9bd4-11e8-9865-cc1ee4802928.png">
