### PR TITLE
Revert namespaced history import

### DIFF
--- a/packages/react-router/modules/Redirect.js
+++ b/packages/react-router/modules/Redirect.js
@@ -2,7 +2,7 @@ import React from "react";
 import PropTypes from "prop-types";
 import warning from "warning";
 import invariant from "invariant";
-import { createLocation, locationsAreEqual } from "history/LocationUtils";
+import { createLocation, locationsAreEqual } from "history";
 import generatePath from "./generatePath";
 
 /**


### PR DESCRIPTION
See https://github.com/ReactTraining/react-router/pull/6278#issuecomment-412213622 for rationale. In short, the change merged in #6278 will actually _increase_ bundle size for ESM builds if other parts of react-router are used which include other parts of the history module.

Instead, please consider merging ReactTraining/history#597 and releasing a new version of the history module, which would allow webpack to more aggressively tree-shake react-router's use of history, providing equivalent bundle size savings regardless of how much of react-router is used.