### PR TITLE
Used named imports for react-router in react-router-config

### DIFF
--- a/packages/react-router-config/modules/matchRoutes.js
+++ b/packages/react-router-config/modules/matchRoutes.js
@@ -1,5 +1,4 @@
-import matchPath from "react-router/matchPath";
-import Router from "react-router/Router";
+import { matchPath, Router } from "react-router";
 
 // ensure we're using the exact code for default root match
 const { computeMatch } = Router.prototype;

--- a/packages/react-router-config/modules/renderRoutes.js
+++ b/packages/react-router-config/modules/renderRoutes.js
@@ -1,6 +1,5 @@
 import React from "react";
-import Switch from "react-router/Switch";
-import Route from "react-router/Route";
+import { Switch, Route } from "react-router";
 
 const renderRoutes = (routes, extraProps = {}, switchProps = {}) =>
   routes ? (


### PR DESCRIPTION
I was recently doing some bundle size analysis using source-map-explorer
and noticed that we had a little bit of duplication of react-router
code. It seems as though our import of react-router-config was bringing
in modules from react-router/Foo, while our named imports from
react-router was bringing in modules from react-router/es/Foo.

As a workaround, I've set up a webpack alias to avoid the duplication,
but I think this should be solved in this package so that everyone can
benefit.

I believe this is similar to:

- https://github.com/ReactTraining/react-router/pull/5589