### PR TITLE
Added support for using "onBeforeUnload" to prompt on external nav.

### DIFF
--- a/packages/react-router/docs/api/Prompt.md
+++ b/packages/react-router/docs/api/Prompt.md
@@ -8,6 +8,7 @@ import { Prompt } from 'react-router'
 <Prompt
   when={formIsHalfFilledOut}
   message="Are you sure you want to leave?"
+  beforeUnload={promptOnExternalNavigation}
 />
 ```
 
@@ -35,4 +36,12 @@ Instead of conditionally rendering a `<Prompt>` behind a guard, you can always r
 
 ```jsx
 <Prompt when={formIsHalfFilledOut} message="Are you sure?"/>
+```
+
+## beforeUnload: bool
+
+If you need to warn on external navigation in addition to internal app navation, `beforeUnload={true}` can be used. This prop defaults to `false` to avoid hijacking external navigation unless explicitly opted in to.
+
+```jsx
+<Prompt when={formIsHalfFilledOut} message="Are you sure?" beforeUnload/>
 ```

--- a/packages/react-router/modules/Prompt.js
+++ b/packages/react-router/modules/Prompt.js
@@ -9,11 +9,13 @@ import invariant from "invariant";
 class Prompt extends React.Component {
   static propTypes = {
     when: PropTypes.bool,
-    message: PropTypes.oneOfType([PropTypes.func, PropTypes.string]).isRequired
+    message: PropTypes.oneOfType([PropTypes.func, PropTypes.string]).isRequired,
+    beforeUnload: propTypes.bool
   };
 
   static defaultProps = {
-    when: true
+    when: true,
+    beforeUnload: false
   };
 
   static contextTypes = {
@@ -37,6 +39,14 @@ class Prompt extends React.Component {
     }
   }
 
+  handleBeforeUnload = () => {
+    if (this.props.when) {
+      return typeof this.props.message === 'function'
+        ? this.props.message()
+        : this.props.message;
+    }
+  }
+
   componentWillMount() {
     invariant(
       this.context.router,
@@ -44,6 +54,10 @@ class Prompt extends React.Component {
     );
 
     if (this.props.when) this.enable(this.props.message);
+  }
+
+  componentDidMount() {
+    window.addEventListener('beforeunload', this.handleBeforeUnload);
   }
 
   componentWillReceiveProps(nextProps) {
@@ -57,6 +71,7 @@ class Prompt extends React.Component {
 
   componentWillUnmount() {
     this.disable();
+    window.removeEventListener('beforeunload', this.handleBeforeUnload);
   }
 
   render() {


### PR DESCRIPTION
Updates to the `Prompt` component to allow opt in support for the onBeforeUnload browser event. This has been implemented as part of the existing `Prompt` component rather than a new component to allow more convenient use within apps.

The functionality is opt in only and will default to the current functionality to keep full backwards compatibility. Support can also be toggled on or off through the prop.