### PR TITLE
Add UNSAFE to near deprecate lifeCycles

### DIFF
--- a/packages/react-router-dom/modules/BrowserRouter.js
+++ b/packages/react-router-dom/modules/BrowserRouter.js
@@ -18,7 +18,7 @@ class BrowserRouter extends React.Component {
 
   history = createHistory(this.props);
 
-  componentWillMount() {
+  UNSAFE_componentWillMount() {
     warning(
       !this.props.history,
       "<BrowserRouter> ignores the history prop. To use a custom history, " +

--- a/packages/react-router-dom/modules/HashRouter.js
+++ b/packages/react-router-dom/modules/HashRouter.js
@@ -17,7 +17,7 @@ class HashRouter extends React.Component {
 
   history = createHistory(this.props);
 
-  componentWillMount() {
+  UNSAFE_componentWillMount() {
     warning(
       !this.props.history,
       "<HashRouter> ignores the history prop. To use a custom history, " +

--- a/packages/react-router/modules/MemoryRouter.js
+++ b/packages/react-router/modules/MemoryRouter.js
@@ -18,7 +18,7 @@ class MemoryRouter extends React.Component {
 
   history = createHistory(this.props);
 
-  componentWillMount() {
+  UNSAFE_componentWillMount() {
     warning(
       !this.props.history,
       "<MemoryRouter> ignores the history prop. To use a custom history, " +

--- a/packages/react-router/modules/Prompt.js
+++ b/packages/react-router/modules/Prompt.js
@@ -37,7 +37,7 @@ class Prompt extends React.Component {
     }
   }
 
-  componentWillMount() {
+  UNSAFE_componentWillMount() {
     invariant(
       this.context.router,
       "You should not use <Prompt> outside a <Router>"
@@ -46,7 +46,7 @@ class Prompt extends React.Component {
     if (this.props.when) this.enable(this.props.message);
   }
 
-  componentWillReceiveProps(nextProps) {
+  UNSAFE_componentWillReceiveProps(nextProps) {
     if (nextProps.when) {
       if (!this.props.when || this.props.message !== nextProps.message)
         this.enable(nextProps.message);

--- a/packages/react-router/modules/Redirect.js
+++ b/packages/react-router/modules/Redirect.js
@@ -35,7 +35,7 @@ class Redirect extends React.Component {
     return this.context.router && this.context.router.staticContext;
   }
 
-  componentWillMount() {
+  UNSAFE_componentWillMount() {
     invariant(
       this.context.router,
       "You should not use <Redirect> outside a <Router>"

--- a/packages/react-router/modules/Route.js
+++ b/packages/react-router/modules/Route.js
@@ -67,7 +67,7 @@ class Route extends React.Component {
     return matchPath(pathname, { path, strict, exact, sensitive }, route.match);
   }
 
-  componentWillMount() {
+  UNSAFE_componentWillMount() {
     warning(
       !(this.props.component && this.props.render),
       "You should not use <Route component> and <Route render> in the same route; <Route render> will be ignored"
@@ -92,7 +92,7 @@ class Route extends React.Component {
     );
   }
 
-  componentWillReceiveProps(nextProps, nextContext) {
+  UNSAFE_componentWillReceiveProps(nextProps, nextContext) {
     warning(
       !(nextProps.location && !this.props.location),
       '<Route> elements should not change from uncontrolled to controlled (or vice versa). You initially used no "location" prop and then provided one on a subsequent render.'

--- a/packages/react-router/modules/Router.js
+++ b/packages/react-router/modules/Router.js
@@ -46,7 +46,7 @@ class Router extends React.Component {
     };
   }
 
-  componentWillMount() {
+  UNSAFE_componentWillMount() {
     const { children, history } = this.props;
 
     invariant(
@@ -64,7 +64,7 @@ class Router extends React.Component {
     });
   }
 
-  componentWillReceiveProps(nextProps) {
+  UNSAFE_componentWillReceiveProps(nextProps) {
     warning(
       this.props.history === nextProps.history,
       "You cannot change <Router history>"

--- a/packages/react-router/modules/StaticRouter.js
+++ b/packages/react-router/modules/StaticRouter.js
@@ -90,7 +90,7 @@ class StaticRouter extends React.Component {
 
   handleBlock = () => noop;
 
-  componentWillMount() {
+  UNSAFE_componentWillMount() {
     warning(
       !this.props.history,
       "<StaticRouter> ignores the history prop. To use a custom history, " +

--- a/packages/react-router/modules/Switch.js
+++ b/packages/react-router/modules/Switch.js
@@ -19,14 +19,14 @@ class Switch extends React.Component {
     location: PropTypes.object
   };
 
-  componentWillMount() {
+  UNSAFE_componentWillMount() {
     invariant(
       this.context.router,
       "You should not use <Switch> outside a <Router>"
     );
   }
 
-  componentWillReceiveProps(nextProps) {
+  UNSAFE_componentWillReceiveProps(nextProps) {
     warning(
       !(nextProps.location && !this.props.location),
       '<Switch> elements should not change from uncontrolled to controlled (or vice versa). You initially used no "location" prop and then provided one on a subsequent render.'

--- a/packages/react-router/modules/__tests__/SwitchMount-test.js
+++ b/packages/react-router/modules/__tests__/SwitchMount-test.js
@@ -12,7 +12,7 @@ describe("A <Switch>", () => {
     let mountCount = 0;
 
     class App extends React.Component {
-      componentWillMount() {
+      UNSAFE_componentWillMount() {
         mountCount++;
       }
 


### PR DESCRIPTION
This PR try to make react-router more compatible with next versions of react.
UNSAFE keyword added to componentWillReceiveProps and componentWillMount .
this may help with #6060 issue.