### PR TITLE
Docs - Replace use of deprecated lifecycle methods with the methods r…

### DIFF
--- a/packages/react-router-config/README.md
+++ b/packages/react-router-config/README.md
@@ -4,8 +4,8 @@ Static route configuration helpers for React Router.
 
 This is alpha software, it needs:
 
-1. Realistic server rendering example with data preloading
-2. Pending navigation example
+1.  Realistic server rendering example with data preloading
+2.  Pending navigation example
 
 ## Installation
 
@@ -17,10 +17,10 @@ Then with a module bundler like [webpack](https://webpack.github.io/), use as yo
 
 ```js
 // using an ES6 transpiler, like babel
-import { matchRoutes, renderRoutes } from 'react-router-config'
+import { matchRoutes, renderRoutes } from 'react-router-config';
 
 // not using an ES6 transpiler
-var matchRoutes = require('react-router-config').matchRoutes
+var matchRoutes = require('react-router-config').matchRoutes;
 ```
 
 The UMD build is also available on [unpkg](https://unpkg.com):
@@ -35,9 +35,9 @@ You can find the library on `window.ReactRouterConfig`
 
 With the introduction of React Router v4, there is no longer a centralized route configuration. There are some use-cases where it is valuable to know about all the app's potential routes such as:
 
-- Loading data on the server or in the lifecycle before rendering the next screen
-- Linking to routes by name
-- Static analysis
+* Loading data on the server or in the lifecycle before rendering the next screen
+* Linking to routes by name
+* Static analysis
 
 This project seeks to define a shared format for others to build patterns on top of.
 
@@ -45,30 +45,34 @@ This project seeks to define a shared format for others to build patterns on top
 
 Routes are objects with the same properties as a `<Route>` with a couple differences:
 
-- the only render prop it accepts is `component` (no `render` or `children`)
-- introduces the `routes` key for sub routes
-- Consumers are free to add any additional props they'd like to a route, you can access `props.route` inside the `component`, this object is a reference to the object used to render and match.
-- accepts `key` prop to prevent remounting component when transition was made from route with the same component and same `key` prop
+* the only render prop it accepts is `component` (no `render` or `children`)
+* introduces the `routes` key for sub routes
+* Consumers are free to add any additional props they'd like to a route, you can access `props.route` inside the `component`, this object is a reference to the object used to render and match.
+* accepts `key` prop to prevent remounting component when transition was made from route with the same component and same `key` prop
 
 ```js
 const routes = [
-  { component: Root,
+  {
+    component: Root,
     routes: [
-      { path: '/',
+      {
+        path: '/',
         exact: true,
         component: Home
       },
-      { path: '/child/:id',
+      {
+        path: '/child/:id',
         component: Child,
         routes: [
-          { path: '/child/:id/grand-child',
+          {
+            path: '/child/:id/grand-child',
             component: GrandChild
           }
         ]
       }
     ]
   }
-]
+];
 ```
 
 **Note**: Just like `<Route>`, relative paths are not (yet) supported. When it is supported there, it will be supported here.
@@ -80,12 +84,13 @@ const routes = [
 Returns an array of matched routes.
 
 #### Parameters
-- routes - the route configuration
-- pathname - the [pathname](https://developer.mozilla.org/en-US/docs/Web/API/HTMLHyperlinkElementUtils/pathname) component of the url. This must be a decoded string representing the path.
+
+* routes - the route configuration
+* pathname - the [pathname](https://developer.mozilla.org/en-US/docs/Web/API/HTMLHyperlinkElementUtils/pathname) component of the url. This must be a decoded string representing the path.
 
 ```js
-import { matchRoutes } from 'react-router-config'
-const branch = matchRoutes(routes, '/child/23')
+import { matchRoutes } from 'react-router-config';
+const branch = matchRoutes(routes, '/child/23');
 // using the routes shown earlier, this returns
 // [
 //   routes[0],
@@ -95,12 +100,12 @@ const branch = matchRoutes(routes, '/child/23')
 
 Each item in the array contains two properties: `routes` and `match`.
 
-- `routes`: A reference to the routes array used to match
-- `match`: The match object that also gets passed to `<Route>` render methods.
+* `routes`: A reference to the routes array used to match
+* `match`: The match object that also gets passed to `<Route>` render methods.
 
 ```js
-branch[0].match.url
-branch[0].match.isExact
+branch[0].match.url;
+branch[0].match.isExact;
 // etc.
 ```
 
@@ -134,18 +139,18 @@ class PendingNavDataLoader extends Component {
     previousLocation: null
   }
 
-  componentWillReceiveProps(nextProps) {
-    const navigated = nextProps.location !== this.props.location
+  componentDidUpdate(prevProps) {
+    const navigated = prevProps.location !== this.props.location
     const { routes } = this.props
 
     if (navigated) {
       // save the location so we can render the old screen
       this.setState({
-        previousLocation: this.props.location
+        previousLocation: prevProps.location
       })
 
       // load data while the old screen remains
-      loadNextData(routes, nextProps.location).then((data) => {
+      loadNextData(routes, this.props.location).then((data) => {
         putTheDataSomewhereRoutesCanFindIt(data)
         // clear previousLocation so the next screen renders
         this.setState({
@@ -191,26 +196,30 @@ Again, that's all pseudo-code. There are a lot of ways to do server rendering wi
 In order to ensure that matching outside of render with `matchRoutes` and inside of render result in the same branch, you must use `renderRoutes` instead of `<Route>` inside your components. You can render a `<Route>` still, but know that it will not be accounted for in `matchRoutes` outside of render.
 
 ```js
-import { renderRoutes } from 'react-router-config'
+import { renderRoutes } from 'react-router-config';
 
 const routes = [
-  { component: Root,
+  {
+    component: Root,
     routes: [
-      { path: '/',
+      {
+        path: '/',
         exact: true,
         component: Home
       },
-      { path: '/child/:id',
+      {
+        path: '/child/:id',
         component: Child,
         routes: [
-          { path: '/child/:id/grand-child',
+          {
+            path: '/child/:id/grand-child',
             component: GrandChild
           }
         ]
       }
     ]
   }
-]
+];
 
 const Root = ({ route }) => (
   <div>
@@ -218,13 +227,13 @@ const Root = ({ route }) => (
     {/* child routes won't render without this */}
     {renderRoutes(route.routes)}
   </div>
-)
+);
 
 const Home = ({ route }) => (
   <div>
     <h2>Home</h2>
   </div>
-)
+);
 
 const Child = ({ route }) => (
   <div>
@@ -232,22 +241,20 @@ const Child = ({ route }) => (
     {/* child routes won't render without this */}
     {renderRoutes(route.routes, { someProp: 'these extra props are optional' })}
   </div>
-)
+);
 
 const GrandChild = ({ someProp }) => (
   <div>
     <h3>Grand Child</h3>
     <div>{someProp}</div>
   </div>
-)
+);
 
-
-ReactDOM.render((
+ReactDOM.render(
   <BrowserRouter>
     {/* kick it all off with the root route */}
     {renderRoutes(routes)}
-  </BrowserRouter>
-), document.getElementById('root'))
-
+  </BrowserRouter>,
+  document.getElementById('root')
+);
 ```
-

--- a/packages/react-router-native/docs/guides/animation.md
+++ b/packages/react-router-native/docs/guides/animation.md
@@ -5,7 +5,7 @@ This guide is a little sparse right now, but should provide enough insight to he
 # Element Transitions
 
 As the user navigates, some elements should animate while remaining on the
-page. The [`Route`][Route] `children` prop is perfect for these situations.
+page. The [`Route`][route] `children` prop is perfect for these situations.
 
 Consider this app without the router. When the `<TouchableHighlight/>` is pressed
 the sidebar's animation will toggle.
@@ -18,10 +18,10 @@ class Sidebar extends Component {
     )
   }
 
-  componentWillReceiveProps(nextProps) {
-    if (nextProps.isOpen !== this.props.isOpen) {
+  componentDidUpdate(prevProps) {
+    if (prevProps.isOpen !== this.props.isOpen) {
       Animated.timing(this.state.anim, {
-        toValue: nextProps.isOpen ? 1 : 0
+        toValue: this.props.isOpen ? 1 : 0
       }).start()
     }
   }
@@ -60,18 +60,21 @@ class App extends Component {
   render() {
     return (
       <View>
-        <Route path="/sidebar" children={({ match }) => (
-          // `children` always renders, match or not. This
-          // way we can always render the sidebar, and then
-          // tell it if its open or not
-          <Sidebar isOpen={!!match}/>
-        )}/>
+        <Route
+          path="/sidebar"
+          children={({ match }) => (
+            // `children` always renders, match or not. This
+            // way we can always render the sidebar, and then
+            // tell it if its open or not
+            <Sidebar isOpen={!!match} />
+          )}
+        />
         <Link to="/sidebar">
           <Text>Open Sidebar</Text>
         </Link>
-        <Screen/>
+        <Screen />
       </View>
-    )
+    );
   }
 }
 ```
@@ -85,9 +88,7 @@ header.
 <View>
   {chutneys.map(chutney => (
     <Route path={`/chutney/${chutney.id}`}>
-      {({ match }) => (
-        <Chutney isActive={match}/>
-      )}
+      {({ match }) => <Chutney isActive={match} />}
     </Route>
   ))}
 </View>
@@ -97,9 +98,9 @@ Each chutney has its own route thats always rendering as part of the list, when 
 
 ## Page Transitions
 
-Because of components' declarative nature, when you're at one screen, press a link, and navigate to another, the old page is not in the render tree to even animate anymore! The key is remembering that React elements are just objects. You can save them and render them again.  That's the strategy for animating from one page (that leaves the render tree) to another.
+Because of components' declarative nature, when you're at one screen, press a link, and navigate to another, the old page is not in the render tree to even animate anymore! The key is remembering that React elements are just objects. You can save them and render them again. That's the strategy for animating from one page (that leaves the render tree) to another.
 
-If you visited this site on mobile, or you shrink the browser really small, you can click the back button to see this type of animation.  The strategy is to not think about animations at first. Just render your routes and links and make that all work, then wrap your components with animated components to spiff things up.
+If you visited this site on mobile, or you shrink the browser really small, you can click the back button to see this type of animation. The strategy is to not think about animations at first. Just render your routes and links and make that all work, then wrap your components with animated components to spiff things up.
 
 We'll consider some child routes in a page:
 
@@ -109,17 +110,16 @@ class Parent extends Component {
     return (
       <View>
         <Switch>
-          <Route path="/settings"/>
-          <Route path="/notifications"/>
+          <Route path="/settings" />
+          <Route path="/notifications" />
         </Switch>
       </View>
-    )
+    );
   }
 }
 ```
 
 Once that works without animations, we're ready to add an animation around it.
-
 
 ```jsx
 <AnimatedChild
@@ -128,98 +128,99 @@ Once that works without animations, we're ready to add an animation around it.
   animating={this.state.animating}
 >
   <Switch location={this.props.location}>
-    <Route path="/settings"/>
-    <Route path="/notifications"/>
+    <Route path="/settings" />
+    <Route path="/notifications" />
   </Switch>
 </AnimatedChild>
 ```
 
-It's important to use a [`<Switch>`][Switch]. It will ensure that only one route can match, and therefore gives us a single element on `props.children` to hang on to and render during the animation. Finally, you *must* pass the location to `Switch`. It prefers `props.location` over the internal router location, which enables the saved child element to be renered later and continue to match the old location.
+It's important to use a [`<Switch>`][switch]. It will ensure that only one route can match, and therefore gives us a single element on `props.children` to hang on to and render during the animation. Finally, you _must_ pass the location to `Switch`. It prefers `props.location` over the internal router location, which enables the saved child element to be renered later and continue to match the old location.
 
 There are a handful of props handed to `AnimatedChild` that the parent will know about as it manages the animation. Again, this guide is more inspiration than copy/paste right now, feel free to look at the source of this website for exact implementation. Alright, let's check out the implementation of `AnimatedChild` (it's copy pasted from the animation used on this site).
 
 ```jsx
 class AnimatedChild extends Component {
-
   static propTypes = {
     children: PropTypes.node,
     anim: PropTypes.object,
     atParent: PropTypes.bool,
     animating: PropTypes.bool
-  }
+  };
 
   state = {
     // we're going to save the old children so we can render
     // it when it doesnt' actually match the location anymore
     previousChildren: null
-  }
+  };
 
-  componentWillReceiveProps(nextProps) {
+  componentDidUpdate(prevProps) {
     // figure out what to do with the children
-    const navigatingToParent = nextProps.atParent && !this.props.atParent
-    const animationEnded = this.props.animating && !nextProps.animating
+    const navigatingToParent = !this.props.atParent && prevProps.atParent;
+    const animationEnded = !prevProps.animating && this.props.animating;
 
     if (navigatingToParent) {
       // we were rendering, but now we're heading back up to the parent,
       // so we need to save the children (har har) so we can render them
       // while the animation is playing
       this.setState({
-        previousChildren: this.props.children
-      })
+        previousChildren: prevProps.children
+      });
     } else if (animationEnded) {
       // When we're done animating, we can get rid of the old children.
       this.setState({
         previousChildren: null
-      })
+      });
     }
   }
 
   render() {
-    const { anim, children } = this.props
-    const { previousChildren } = this.state
+    const { anim, children } = this.props;
+    const { previousChildren } = this.state;
     return (
-      <Animated.View style={{
-        position: 'absolute',
-        left: 0,
-        right: 0,
-        top: anim.interpolate({
-          inputRange: [ 0, 1 ],
-          outputRange: [ 20, 0 ]
-        }),
-        opacity: anim.interpolate({
-          inputRange: [ 0, 0.75 ],
-          outputRange: [ 0, 1 ]
-        })
-      }}>
+      <Animated.View
+        style={{
+          position: 'absolute',
+          left: 0,
+          right: 0,
+          top: anim.interpolate({
+            inputRange: [0, 1],
+            outputRange: [20, 0]
+          }),
+          opacity: anim.interpolate({
+            inputRange: [0, 0.75],
+            outputRange: [0, 1]
+          })
+        }}
+      >
         {/* render the old ones if we have them */}
         {previousChildren || children}
       </Animated.View>
-    )
+    );
   }
 }
 ```
 
-Hope that helps get you thinking. Again, the animations themselves are the same with the router or not, the difference is knowing when to trigger them. Here's a list for things to check in `componentWillReceiveProps` to decide what to do with an animation based on the router's location:
+Hope that helps get you thinking. Again, the animations themselves are the same with the router or not, the difference is knowing when to trigger them. Here's a list for things to check in `componentDidUpdate` to decide what to do with an animation based on the router's location:
 
 General change in location
 
 ```js
-nextProps.location !== this.props.location`
+this.props.location !== prevProps.location`
 ```
 
 Going from child to parent:
 
 ```js
-nextProps.match.isExact && !this.props.match.isExact
+this.props.match.isExact && !prevProps.match.isExact;
 ```
 
 Going from parent to child:
 
 ```js
-!nextProps.match.isExact && this.props.match.isExact
+!this.props.match.isExact && prevProps.match.isExact;
 ```
 
 Good luck! We hope to expand on this section with a lot more detail and live examples.
 
-  [Route]:../api/Route.md
-  [Switch]:../api/Switch.md
+[route]: ../api/Route.md
+[switch]: ../api/Switch.md

--- a/packages/react-router/docs/api/history.md
+++ b/packages/react-router/docs/api/history.md
@@ -4,25 +4,25 @@ The term "history" and "`history` object" in this documentation refers to [the `
 
 The following terms are also used:
 
-- "browser history" - A DOM-specific implementation, useful in web browsers that support the HTML5 history API
-- "hash history" - A DOM-specific implementation for legacy web browsers
-- "memory history" - An in-memory history implementation, useful in testing and non-DOM environments like React Native
+* "browser history" - A DOM-specific implementation, useful in web browsers that support the HTML5 history API
+* "hash history" - A DOM-specific implementation for legacy web browsers
+* "memory history" - An in-memory history implementation, useful in testing and non-DOM environments like React Native
 
 `history` objects typically have the following properties and methods:
 
-- `length` - (number) The number of entries in the history stack
-- `action` - (string) The current action (`PUSH`, `REPLACE`, or `POP`)
-- `location` - (object) The current location. May have the following properties:
-  - `pathname` - (string) The path of the URL
-  - `search` - (string) The URL query string
-  - `hash` - (string) The URL hash fragment
-  - `state` - (object) location-specific state that was provided to e.g. `push(path, state)` when this location was pushed onto the stack. Only available in browser and memory history.
-- `push(path, [state])` - (function) Pushes a new entry onto the history stack
-- `replace(path, [state])` - (function) Replaces the current entry on the history stack
-- `go(n)` - (function) Moves the pointer in the history stack by `n` entries
-- `goBack()` - (function) Equivalent to `go(-1)`
-- `goForward()` - (function) Equivalent to `go(1)`
-- `block(prompt)` - (function) Prevents navigation (see [the history docs](https://github.com/ReactTraining/history#blocking-transitions))
+* `length` - (number) The number of entries in the history stack
+* `action` - (string) The current action (`PUSH`, `REPLACE`, or `POP`)
+* `location` - (object) The current location. May have the following properties:
+  * `pathname` - (string) The path of the URL
+  * `search` - (string) The URL query string
+  * `hash` - (string) The URL hash fragment
+  * `state` - (object) location-specific state that was provided to e.g. `push(path, state)` when this location was pushed onto the stack. Only available in browser and memory history.
+* `push(path, [state])` - (function) Pushes a new entry onto the history stack
+* `replace(path, [state])` - (function) Replaces the current entry on the history stack
+* `go(n)` - (function) Moves the pointer in the history stack by `n` entries
+* `goBack()` - (function) Equivalent to `go(-1)`
+* `goForward()` - (function) Equivalent to `go(1)`
+* `block(prompt)` - (function) Prevents navigation (see [the history docs](https://github.com/ReactTraining/history#blocking-transitions))
 
 ## history is mutable
 
@@ -30,16 +30,17 @@ The history object is mutable. Therefore it is recommended to access the [`locat
 
 ```jsx
 class Comp extends React.Component {
-  componentWillReceiveProps(nextProps) {
+  componentDidUpdate(prevProps) {
     // will be true
-    const locationChanged = nextProps.location !== this.props.location
+    const locationChanged = prevProps.location !== this.props.location;
 
     // INCORRECT, will *always* be false because history is mutable.
-    const locationChanged = nextProps.history.location !== this.props.history.location
+    const locationChanged =
+      prevProps.history.location !== this.props.history.location;
   }
 }
 
-<Route component={Comp}/>
+<Route component={Comp} />;
 ```
 
 Additional properties may also be present depending on the implementation you're using. Please refer to [the history documentation](https://github.com/ReactTraining/history#properties) for more details.

--- a/packages/react-router/docs/api/location.md
+++ b/packages/react-router/docs/api/location.md
@@ -17,18 +17,18 @@ even where it was. It looks like this:
 
 The router will provide you with a location object in a few places:
 
-- [Route component](./Route.md#component) as `this.props.location`
-- [Route render](./Route.md#render-func) as `({ location }) => ()`
-- [Route children](./Route.md#children-func) as `({ location }) => ()`
-- [withRouter](./withRouter.md) as `this.props.location`
+* [Route component](./Route.md#component) as `this.props.location`
+* [Route render](./Route.md#render-func) as `({ location }) => ()`
+* [Route children](./Route.md#children-func) as `({ location }) => ()`
+* [withRouter](./withRouter.md) as `this.props.location`
 
 It is also found on `history.location` but you shouldn't use that because its mutable. You can read more about that in the [history](./history.md) doc.
 
 A location object is never mutated so you can use it in the lifecycle hooks to determine when navigation happens, this is really useful for data fetching and animation.
 
 ```js
-componentWillReceiveProps(nextProps) {
-  if (nextProps.location !== this.props.location) {
+componentDidUpdate(prevProps) {
+  if (prevProps.location !== this.props.location) {
     // navigated!
   }
 }
@@ -36,11 +36,11 @@ componentWillReceiveProps(nextProps) {
 
 You can provide locations instead of strings to the various places that navigate:
 
-- Web [Link to](../../../react-router-dom/docs/api/Link.md#to)
-- Native [Link to](../../../react-router-native/docs/api/Link.md#to)
-- [Redirect to](./Redirect.md#to)
-- [history.push](./history.md#push)
-- [history.replace](./history.md#push)
+* Web [Link to](../../../react-router-dom/docs/api/Link.md#to)
+* Native [Link to](../../../react-router-native/docs/api/Link.md#to)
+* [Redirect to](./Redirect.md#to)
+* [history.push](./history.md#push)
+* [history.replace](./history.md#push)
 
 Normally you just use a string, but if you need to add some "location state" that will be available whenever the app returns to that specific location, you can use a location object instead. This is useful if you want to branch UI based on navigation history instead of just paths (like modals).
 
@@ -62,8 +62,7 @@ history.replace(location)
 
 Finally, you can pass a location to the following components:
 
-- [Route](./Route.md#location)
-- [Switch](./Switch.md#location)
+* [Route](./Route.md#location)
+* [Switch](./Switch.md#location)
 
 This will prevent them from using the actual location in the router's state. This is useful for animation and pending navigation, or any time you want to trick a component into rendering at a different location than the real one.
-

--- a/packages/react-router/docs/guides/migrating.md
+++ b/packages/react-router/docs/guides/migrating.md
@@ -9,7 +9,7 @@ React Router v4 is a complete rewrite, so there is not a simple migration path. 
 * [The Router](#the-router)
 * [Routes](#routes)
   * [Nesting Routes](#nesting-routes)
-  * [on* properties](#on-properties)
+  * [on\* properties](#on-properties)
   * [Optional Parameters](#optional-parameters)
   * [Query Strings](#query-strings)
   * [Switch](#switch)
@@ -43,8 +43,8 @@ In v4, there is no centralized route configuration. Anywhere that you need to re
 //v4
 <BrowserRouter>
   <div>
-    <Route path='/about' component={About} />
-    <Route path='/contact' component={Contact} />
+    <Route path="/about" component={About} />
+    <Route path="/contact" component={Contact} />
   </div>
 </BrowserRouter>
 ```
@@ -90,9 +90,9 @@ The v4 `<Route>` component is actually a component, so wherever you render a `<R
 In v3, `<Route>`s were nested by passing them as the `children` of their parent `<Route>`.
 
 ```jsx
-<Route path='parent' component={Parent}>
-  <Route path='child' component={Child} />
-  <Route path='other' component={Other} />
+<Route path="parent" component={Parent}>
+  <Route path="child" component={Child} />
+  <Route path="other" component={Other} />
 </Route>
 ```
 
@@ -107,21 +107,21 @@ When a nested `<Route>` matched, React elements would be created using both the 
 With v4, children `<Route>`s should just be rendered by the parent `<Route>`'s component.
 
 ```jsx
-<Route path='parent' component={Parent} />
+<Route path="parent" component={Parent} />;
 
 const Parent = () => (
   <div>
-    <Route path='child' component={Child} />
-    <Route path='other' component={Other} />
+    <Route path="child" component={Child} />
+    <Route path="other" component={Other} />
   </div>
-)
+);
 ```
 
 ### `on*` properties
 
 React Router v3 provides `onEnter`, `onUpdate`, and `onLeave` methods. These were essentially recreating React's lifecycle methods.
 
-With v4, you should use the lifecycle methods of the component rendered by a `<Route>`. Instead of `onEnter`, you would use `componentDidMount` or `componentWillMount`. Where you would use `onUpdate`, you can use `componentDidUpdate` or `componentWillUpdate` (or possibly `componentWillReceiveProps`). `onLeave` can be replaced with `componentWillUnmount`.
+With v4, you should use the lifecycle methods of the component rendered by a `<Route>`. Instead of `onEnter`, you would use `componentDidMount` or `componentWillMount`. Where you would use `onUpdate`, you can use `componentDidUpdate` or `componentWillUpdate` (or possibly `componentWillReceiveProps`). `onLeave` can be replaced with `componentWillUnmount`. Though, `componentWillUpdate`, `componentWillReceiveProps`, and `componentWillMount` will [soon be deprecated](https://reactjs.org/blog/2018/03/27/update-on-async-rendering.html).
 
 ### Optional Parameters
 
@@ -143,10 +143,10 @@ In v3, you could specify a number of child routes, and only the first one that m
 
 ```jsx
 // v3
-<Route path='/' component={App}>
+<Route path="/" component={App}>
   <IndexRoute component={Home} />
-  <Route path='about' component={About} />
-  <Route path='contact' component={Contact} />
+  <Route path="about" component={About} />
+  <Route path="contact" component={Contact} />
 </Route>
 ```
 
@@ -156,12 +156,11 @@ v4 provides a similar functionality with the `<Switch>` component. When a `<Swit
 // v4
 const App = () => (
   <Switch>
-    <Route exact path='/' component={Home} />
-    <Route path='/about' component={About} />
-    <Route path='/contact' component={Contact} />
+    <Route exact path="/" component={Home} />
+    <Route path="/about" component={About} />
+    <Route path="/contact" component={Contact} />
   </Switch>
-)
-
+);
 ```
 
 ### `<Redirect>`
@@ -173,7 +172,6 @@ In v3, if you wanted to redirect from one path to another, for instance / to /we
 <Route path="/" component={App}>
   <IndexRedirect to="/welcome" />
 </Route>
-
 ```
 
 In v4, you can achieve the same functionality using `<Redirect>`.
@@ -187,7 +185,6 @@ In v4, you can achieve the same functionality using `<Redirect>`.
   <Route path="/login" component={Login} />
   <Redirect path="*" to="/" />
 </Switch>
-
 ```
 
 In v3, `<Redirect>` preserved the query string:
@@ -214,16 +211,18 @@ In v4, you must re-pass these properties to the `to` prop:
 ## PatternUtils
 
 ### matchPattern(pattern, pathname)
+
 In v3, you could use the same matching code used internally to check if a path matched a pattern. In v4 this has been replaced by [matchPath](/packages/react-router/docs/api/matchPath.md) which is powered by the [`path-to-regexp@^1.7.0`](https://github.com/pillarjs/path-to-regexp/tree/v1.7.0) library.
 
 ### formatPattern(pattern, params)
+
 In v3, you could use PatternUtils.formatPattern to generate a valid path from a path pattern (perhaps in a constant or in your central routing config) and an object containing the names parameters:
 
 ```jsx
 // v3
 const THING_PATH = '/thing/:id';
 
-<Link to={PatternUtils.formatPattern(THING_PATH, {id: 1})}>A thing</Link>
+<Link to={PatternUtils.formatPattern(THING_PATH, { id: 1 })}>A thing</Link>;
 ```
 
 In v4, you can achieve the same functionality using the [`compile`](https://github.com/pillarjs/path-to-regexp/tree/v1.7.0#compile-reverse-path-to-regexp) function in [`path-to-regexp@^1.7.0`](https://github.com/pillarjs/path-to-regexp/tree/v1.7.0).
@@ -234,7 +233,7 @@ const THING_PATH = '/thing/:id';
 
 const thingPath = pathToRegexp.compile(THING_PATH);
 
-<Link to={thingPath({id: 1})}>A thing</Link>
+<Link to={thingPath({ id: 1 })}>A thing</Link>;
 ```
 
 ### getParamNames
@@ -244,6 +243,7 @@ The `getParamNames` functionality can be achieved using the [`parse`](https://gi
 ## Link
 
 ### `to` property is required
+
 In v3, you could omit `to` property or set it to null to create an anchor tag without `href` attribute.
 
 ```jsx


### PR DESCRIPTION
Replace use of deprecated lifecycle methods with the methods recommended by the React team in the documentation.

I am not sure if the automatic editing of the files because of this precommit hook: `"precommit": "pretty-quick --staged"` was supposed to happen but I assume that the style changes are desired. All I changed was replacing `componentWillReceiveProps` with `componentDidUpdate` and add one sentence that it is not recommended to use the lifecycle methods that are soon to be deprecated with a link that explains.

I used `componentDidUpdate` in each example as that is what is recommended: [Check out Abramov comment](https://github.com/reactjs/reactjs.org/issues/721).

*Also*, if desired, I can go through the docs and make sure that each page in the docs gets the precommit hook and send another quick PR.

Thanks!