### PR TITLE
add matchPath to NavLink

### DIFF
--- a/packages/react-router-dom/docs/api/NavLink.md
+++ b/packages/react-router-dom/docs/api/NavLink.md
@@ -80,6 +80,23 @@ const oddEvent = (match, location) => {
 The [`isActive`](#isactive-func) compares the current history location (usually the current browser URL).
 To compare to a different location, a [`location`](../../../react-router/docs/api/location.md) can be passed.
 
+## matchPath: string
+
+When `matchPath` is provided, `NavLink` will become active when the current location matches `matchPath` instead of the `to` props.
+This is useful when the path linked is a subroute of `matchPath`.
+
+```jsx
+// This NavLink will become active in `/events/dashboard`,
+// `/events/otherRoute` and any other route matching `/events`,
+// but when clicked will navigate to `/events/dashboard`
+<NavLink
+  matchPath="/events"
+  to="/events/dashboard"
+>
+  Events dashboard
+</NavLink>
+```
+
 ## ariaCurrent: string
 
 The value of the `aria-current` attribute used on an active link. Available values are:

--- a/packages/react-router-dom/modules/NavLink.js
+++ b/packages/react-router-dom/modules/NavLink.js
@@ -8,6 +8,7 @@ import Link from "./Link";
  */
 const NavLink = ({
   to,
+  matchPath,
   exact,
   strict,
   location,
@@ -19,7 +20,7 @@ const NavLink = ({
   "aria-current": ariaCurrent,
   ...rest
 }) => {
-  const path = typeof to === "object" ? to.pathname : to;
+  const path = matchPath || (typeof to === "object" ? to.pathname : to);
 
   // Regex taken from: https://github.com/pillarjs/path-to-regexp/blob/master/index.js#L202
   const escapedPath = path && path.replace(/([.+*?=^!:${}()[\]|/\\])/g, "\\$1");
@@ -53,6 +54,7 @@ const NavLink = ({
 
 NavLink.propTypes = {
   to: Link.propTypes.to,
+  matchPath: PropTypes.string,
   exact: PropTypes.bool,
   strict: PropTypes.bool,
   location: PropTypes.object,


### PR DESCRIPTION
Hey, first PR over here.

I just stumbled upon this problem using `NavLinks` and wanted to know what you thought about this change.

## Motivation
I have a website with a Navbar, with `NavLink`s to different parts of the website, that should become active when different sections are, well, active. Let's say those routes in the Navbar are something like `/events`, `/classes` and such. And inside `/events` you have `/events/home` (which is the default), `/events/cancelled`, etc.

So having:

```<NavLink to="/events" />```

there works fine, but with one detail. The `/events` component is the one in charge of redirecting to `/events/home` (which is what is happening now). Making a short flicker appear in the URL.

## Proposal
Add a `matchPath` prop to `NavLink`, so that for cases like this, one could have the navigated link and the match link be different.

```<NavLink to="/events/home" matchPath="/events" />```

In this example, this `NavLink` would match with `/events/home` and `/events/otherRoutes`, but still navigate to the default `/events/home` when clicked.

## Tests

I would like to add some tests for this, but I'm not sure how to tackle that or where to start testing this. If you like this idea I'd be happy to add tests then :)