### PR TITLE
Update Babel plugin name

### DIFF
--- a/packages/react-router-dom/docs/guides/code-splitting.md
+++ b/packages/react-router-dom/docs/guides/code-splitting.md
@@ -1,13 +1,13 @@
 # Code Splitting
 
-One great feature of the web is that we don't have to make our visitors download the entire app before they can use it. You can think of code splitting as incrementally downloading the app. To accomplish this we'll use [webpack], [`babel-plugin-syntax-dynamic-import`], and [`react-loadable`].
+One great feature of the web is that we don't have to make our visitors download the entire app before they can use it. You can think of code splitting as incrementally downloading the app. To accomplish this we'll use [webpack], [`@babel/plugin-syntax-dynamic-import`], and [`react-loadable`].
 
-[webpack] has built-in support for [dynamic imports][import]; however, if you are using [Babel] (e.g., to compile JSX to JavaScript) then you will need to use the [`babel-plugin-syntax-dynamic-import`] plugin. This is a syntax-only plugin, meaning Babel won't do any additional transformations. The plugin simply allows Babel to parse dynamic imports so webpack can bundle them as a code split. Your `.babelrc` should look something like this:
+[webpack] has built-in support for [dynamic imports][import]; however, if you are using [Babel] (e.g., to compile JSX to JavaScript) then you will need to use the [`@babel/plugin-syntax-dynamic-import`] plugin. This is a syntax-only plugin, meaning Babel won't do any additional transformations. The plugin simply allows Babel to parse dynamic imports so webpack can bundle them as a code split. Your `.babelrc` should look something like this:
 
 ```json
 {
   "presets": ["react"],
-  "plugins": ["syntax-dynamic-import"]
+  "plugins": ["@babel/plugin-syntax-dynamic-import"]
 }
 ```
 
@@ -51,7 +51,7 @@ That's all there is to it! Simply use `LoadableDashboard` (or whatever you named
 ```
 
 [babel]: https://babeljs.io/
-[`babel-plugin-syntax-dynamic-import`]: https://babeljs.io/docs/plugins/syntax-dynamic-import/
+[`@babel/plugin-syntax-dynamic-import`]: https://babeljs.io/docs/plugins/syntax-dynamic-import/
 [`babel-plugin-import-inspector`]: https://github.com/thejameskyle/react-loadable/tree/6902cc87f618446c54daa85d8fecec6836c9461a#babel-plugin-import-inspector
 [`react-loadable`]: https://github.com/thejameskyle/react-loadable
 [import]: https://github.com/tc39/proposal-dynamic-import

--- a/packages/react-router-dom/docs/guides/code-splitting.md
+++ b/packages/react-router-dom/docs/guides/code-splitting.md
@@ -6,7 +6,7 @@ One great feature of the web is that we don't have to make our visitors download
 
 ```json
 {
-  "presets": ["react"],
+  "presets": ["@babel/react"],
   "plugins": ["@babel/plugin-syntax-dynamic-import"]
 }
 ```
@@ -37,9 +37,9 @@ That's all there is to it! Simply use `LoadableDashboard` (or whatever you named
 
 ```json
 {
-  "presets": ["react"],
+  "presets": ["@babel/react"],
   "plugins": [
-    "syntax-dynamic-import",
+    "@babel/plugin-syntax-dynamic-import",
     [
       "import-inspector",
       {


### PR DESCRIPTION
Babel has updated its core name to @babel/core and the same naming convention is now applied to plugins too. 

The plugin `babel-plugin-syntax-dynamic-import` is now available as `@babel/plugin-syntax-dynamic-import`. 

The old version is also available but that will not work with Babel v7+

Cheers 