### PR TITLE
Add example to docs for working with url parameters.

### DIFF
--- a/website/modules/components/FakeBrowser.js
+++ b/website/modules/components/FakeBrowser.js
@@ -152,7 +152,9 @@ class FakeBrowser extends React.Component {
                 overflow="auto"
                 position="relative"
               >
-                {React.Children.only(children)}
+                {React.cloneElement(React.Children.only(children), {
+                  location
+                })}
               </Block>
             </Col>
           )}

--- a/website/modules/docs/Web.js
+++ b/website/modules/docs/Web.js
@@ -109,6 +109,12 @@ export default {
       slug: "static-router",
       load: require("../examples/StaticRouter?bundle"),
       loadSource: require("../examples/StaticRouter.js?prismjs")
+    },
+    {
+      label: "Query Parameters",
+      slug: "query-parameters",
+      load: require("../examples/QueryParams?bundle"),
+      loadSource: require("../examples/QueryParams.js?prismjs")
     }
   ]
 };

--- a/website/modules/examples/QueryParams.js
+++ b/website/modules/examples/QueryParams.js
@@ -1,30 +1,23 @@
 import React from "react";
 import { BrowserRouter as Router, Link } from "react-router-dom";
-import { parse as Parse, stringify as Stringify } from "query-string";
+import { parse, stringify } from "query-string";
 
 const ParamsExample = props => {
-  const urlParams = Parse(props.location.search);
+  const urlParams = parse(props.location.search);
 
   return (
     <Router>
       <p>
-        React Router v4 no longer includes its own query parameter
-        functionality. Instead you will want to include a library that provides
-        the functionality that you need. Below is an example using the{" "}
-        <a
-          href="https://github.com/sindresorhus/query-string"
-          target="_blank"
-          rel="noreferrer noopener"
-        >
-          query-string
-        </a>{" "}
+        React Router no longer handles query parameters in URLs. You will need
+        to use a 3rd-party library to handle them. Below is an example using the{" "}
+        <a href="https://github.com/sindresorhus/query-string">query-string</a>{" "}
         library.
       </p>
       <p>
         <em>
-          Again, this is only an example! You are free to use any library for
-          working with URL parameters that provides the functionality you are
-          looking for!
+          This is only an example of one such library. You are free to use any
+          library for working with query parameters that provides the
+          functionality you are looking for.
         </em>
       </p>
       <div>
@@ -34,7 +27,7 @@ const ParamsExample = props => {
             <Link
               to={{
                 pathname: "/account",
-                search: Stringify({ name: "netflix" })
+                search: stringify({ name: "netflix" })
               }}
             >
               Netflix
@@ -44,7 +37,7 @@ const ParamsExample = props => {
             <Link
               to={{
                 pathname: "/account",
-                search: Stringify({ name: "zillow-group" })
+                search: stringify({ name: "zillow-group" })
               }}
             >
               Zillow Group
@@ -54,7 +47,7 @@ const ParamsExample = props => {
             <Link
               to={{
                 pathname: "/account",
-                search: Stringify({ name: "yahoo" })
+                search: stringify({ name: "yahoo" })
               }}
             >
               Yahoo
@@ -64,7 +57,7 @@ const ParamsExample = props => {
             <Link
               to={{
                 pathname: "/account",
-                search: Stringify({ name: "modus-create" })
+                search: stringify({ name: "modus-create" })
               }}
             >
               Modus Create

--- a/website/modules/examples/QueryParams.js
+++ b/website/modules/examples/QueryParams.js
@@ -1,0 +1,87 @@
+import React from "react";
+import { BrowserRouter as Router, Link } from "react-router-dom";
+import { parse as Parse, stringify as Stringify } from "query-string";
+
+const ParamsExample = props => {
+  const urlParams = Parse(props.location.search);
+
+  return (
+    <Router>
+      <p>
+        React Router v4 no longer includes its own query parameter
+        functionality. Instead you will want to include a library that provides
+        the functionality that you need. Below is an example using the{" "}
+        <a
+          href="https://github.com/sindresorhus/query-string"
+          target="_blank"
+          rel="noreferrer noopener"
+        >
+          query-string
+        </a>{" "}
+        library.
+      </p>
+      <p>
+        <em>
+          Again, this is only an example! You are free to use any library for
+          working with URL parameters that provides the functionality you are
+          looking for!
+        </em>
+      </p>
+      <div>
+        <h2>Accounts</h2>
+        <ul>
+          <li>
+            <Link
+              to={{
+                pathname: "/account",
+                search: Stringify({ name: "netflix" })
+              }}
+            >
+              Netflix
+            </Link>
+          </li>
+          <li>
+            <Link
+              to={{
+                pathname: "/account",
+                search: Stringify({ name: "zillow-group" })
+              }}
+            >
+              Zillow Group
+            </Link>
+          </li>
+          <li>
+            <Link
+              to={{
+                pathname: "/account",
+                search: Stringify({ name: "yahoo" })
+              }}
+            >
+              Yahoo
+            </Link>
+          </li>
+          <li>
+            <Link
+              to={{
+                pathname: "/account",
+                search: Stringify({ name: "modus-create" })
+              }}
+            >
+              Modus Create
+            </Link>
+          </li>
+        </ul>
+
+        {urlParams && urlParams.name && <Child name={urlParams.name} />}
+      </div>
+    </Router>
+  );
+};
+
+const Child = ({ name }) => (
+  <div>
+    <h3>NAME: {name}</h3>
+  </div>
+);
+
+export default ParamsExample;

--- a/website/package.json
+++ b/website/package.json
@@ -2,7 +2,7 @@
   "private": true,
   "name": "react-router-website",
   "scripts": {
-    "build": "webpack -p",
+    "build": "NODE_ENV=production webpack -p",
     "clean": "git clean -fdX .",
     "start": "webpack-dev-server --inline --host 0.0.0.0"
   },

--- a/website/package.json
+++ b/website/package.json
@@ -2,7 +2,7 @@
   "private": true,
   "name": "react-router-website",
   "scripts": {
-    "build": "NODE_ENV=production webpack -p",
+    "build": "webpack -p",
     "clean": "git clean -fdX .",
     "start": "webpack-dev-server --inline --host 0.0.0.0"
   },
@@ -28,6 +28,7 @@
     "markdown-it-anchor": "^3.0.0",
     "postcss-loader": "^2.1.5",
     "prismjs": "^1.8.4",
+    "query-string": "^6.2.0",
     "style-loader": "^0.19.0",
     "sw-precache": "^4.2.2",
     "sw-precache-webpack-plugin": "^0.7.2",


### PR DESCRIPTION
Issue #5789 requested an example/guide for working with url parameters in `react-router`. I implemented this as an example since they allow for a functioning example that a visitor the docs can interact with and see it in action.

Almost all (if not all) of the code was gathered from that issue and formatted to work with the docs.

At the top of the example, I put a short bit of copy about the fact that url params are implemented using an external library. I just took a stab at this so please feel free to let me know if there are any additional changes that need to made to this copy or the code for the example.