### PR TITLE
Change match.url to match.path for nested routes

### DIFF
--- a/website/modules/examples/Basic.js
+++ b/website/modules/examples/Basic.js
@@ -52,10 +52,10 @@ const Topics = ({ match }) => (
       </li>
     </ul>
 
-    <Route path={`${match.url}/:topicId`} component={Topic} />
+    <Route path={`${match.path}/:topicId`} component={Topic} />
     <Route
       exact
-      path={match.url}
+      path={match.path}
       render={() => <h3>Please select a topic.</h3>}
     />
   </div>


### PR DESCRIPTION
### Update Basic Example on Website
Although match.url works in this basic example, match.path should be used for nested routes.