### PR TITLE
 Update react-router-native Quickstart Guide

### DIFF
--- a/packages/react-router-native/docs/guides/quick-start.md
+++ b/packages/react-router-native/docs/guides/quick-start.md
@@ -57,10 +57,10 @@ const Topics = ({ match }) => (
       </Link>
     </View>
 
-    <Route path={`${match.url}/:topicId`} component={Topic} />
+    <Route path={`${match.path}/:topicId`} component={Topic} />
     <Route
       exact
-      path={match.url}
+      path={match.path}
       render={() => <Text style={styles.topic}>Please select a topic.</Text>}
     />
   </View>

--- a/website/modules/examples/Basic.js
+++ b/website/modules/examples/Basic.js
@@ -52,10 +52,10 @@ const Topics = ({ match }) => (
       </li>
     </ul>
 
-    <Route path={`${match.url}/:topicId`} component={Topic} />
+    <Route path={`${match.path}/:topicId`} component={Topic} />
     <Route
       exact
-      path={match.url}
+      path={match.path}
       render={() => <h3>Please select a topic.</h3>}
     />
   </div>


### PR DESCRIPTION
## Update react-router-native Quickstart Guide
Although match.url works in this basic example, match.path should be used for nested routes.