### PR TITLE
Added failing test check for Route and forwardRef

### DIFF
--- a/packages/react-router/modules/__tests__/Route-test.js
+++ b/packages/react-router/modules/__tests__/Route-test.js
@@ -342,6 +342,37 @@ describe("A <Route>", () => {
       expect(typeof props.location).toBe("object");
       expect(typeof props.match).toBe("object");
     });
+
+    it("won't throw a prop-type warning when passed valid React components that aren't functions", () => {
+      function forwardRef(Component) {
+        class ForwardComponent extends React.Component {
+          render() {
+            const { forwardedRef, ...rest } = this.props;
+            return <Component ref={forwardedRef} {...rest} />;
+          }
+        }
+
+        return React.forwardRef((props, ref) => {
+          return <ForwardComponent {...props} forwardedRef={ref} />;
+        });
+      }
+
+      const history = createHistory();
+
+      const Component = () => null;
+      const WrappedComponent = forwardRef(Component);
+
+      const errorSpy = jest.spyOn(console, "error");
+
+      ReactDOM.render(
+        <Router history={history}>
+          <Route path="/" component={WrappedComponent} />
+        </Router>,
+        node
+      );
+
+      expect(errorSpy).not.toHaveBeenCalled();
+    });
   });
 
   describe("the `render` prop", () => {


### PR DESCRIPTION
Currently, [`Route` uses the prop-type of `func`](https://github.com/ReactTraining/react-router/blob/master/packages/react-router/modules/Route.js#L130) to check the `Component` prop. 

However, that doesn't cover all valid React components, since `React.forwardRef` returns an object [as noted here](https://github.com/facebook/react/issues/12453).

So this failing test is being added to help correct this at some point in the future.

I thought it may be nice to talk about possible solutions here as well:

- Wait until the proptypes package [adds support for a Component type](https://github.com/facebook/prop-types/issues/200)
- Change to a custom proptype function that can use [react-is' `isValidElementType`](https://www.npmjs.com/package/react-is) to add the prop type check manually

Hopefully this is helpful!