### PR TITLE
Update Redux Notes to add missing HOC info

### DIFF
--- a/packages/react-router/docs/guides/redux.md
+++ b/packages/react-router/docs/guides/redux.md
@@ -23,6 +23,14 @@ import { withRouter } from 'react-router-dom'
 export default withRouter(connect(mapStateToProps)(Something))
 ```
 
+Important to note that the opposite configuration of Higher Order Components does *not* work correctly.
+
+```js
+// does not work!
+import { withRouter } from 'react-router-dom'
+export default connect(mapStateToProps)(withRouter(Something))
+```
+
 ## Deep integration
 
 Some folks want to:


### PR DESCRIPTION
Docs elsewhere in [codebase](https://github.com/ReactTraining/react-router/blob/master/packages/react-router/docs/api/withRouter.md) note that the order of connect and withRouter matter, but the website does not. 

As a teacher that directs students here, this will help them find the answer on their own.