### PR TITLE
Added warnAboutDeprecatedCJSRequire.js in package.json

### DIFF
--- a/packages/react-router-config/package.json
+++ b/packages/react-router-config/package.json
@@ -14,6 +14,7 @@
     "index.js",
     "matchRoutes.js",
     "renderRoutes.js",
+    "warnAboutDeprecatedCJSRequire.js",
     "umd"
   ],
   "main": "index.js",


### PR DESCRIPTION
There is a missing file in the `react-router-config` package (`warnAboutDeprecatedCJSRequire.js`). This PR adds it in package.json so that it's included when publishing a new version on npm.