### PR TITLE
Added react-is to validate the proptype for Route's component.

### DIFF
--- a/packages/react-router-config/package-lock.json
+++ b/packages/react-router-config/package-lock.json
@@ -3671,12 +3671,6 @@
 			"integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
 			"dev": true
 		},
-		"asap": {
-			"version": "2.0.6",
-			"resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
-			"integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY=",
-			"dev": true
-		},
 		"asn1": {
 			"version": "0.2.4",
 			"resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz",
@@ -4968,16 +4962,6 @@
 				"sha.js": "^2.4.8"
 			}
 		},
-		"create-react-context": {
-			"version": "0.2.3",
-			"resolved": "https://registry.npmjs.org/create-react-context/-/create-react-context-0.2.3.tgz",
-			"integrity": "sha512-CQBmD0+QGgTaxDL3OX1IDXYqjkp2It4RIbcb99jS6AEg27Ga+a9G3JtK6SIu0HBwPLZlmwt9F7UwWA4Bn92Rag==",
-			"dev": true,
-			"requires": {
-				"fbjs": "^0.8.0",
-				"gud": "^1.0.0"
-			}
-		},
 		"cross-spawn": {
 			"version": "5.1.0",
 			"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
@@ -5392,15 +5376,6 @@
 			"resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-2.1.0.tgz",
 			"integrity": "sha1-TapNnbAPmBmIDHn6RXrlsJof04k=",
 			"dev": true
-		},
-		"encoding": {
-			"version": "0.1.12",
-			"resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
-			"integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
-			"dev": true,
-			"requires": {
-				"iconv-lite": "~0.4.13"
-			}
 		},
 		"end-of-stream": {
 			"version": "1.4.1",
@@ -6036,29 +6011,6 @@
 			"dev": true,
 			"requires": {
 				"bser": "^2.0.0"
-			}
-		},
-		"fbjs": {
-			"version": "0.8.17",
-			"resolved": "https://registry.npmjs.org/fbjs/-/fbjs-0.8.17.tgz",
-			"integrity": "sha1-xNWY6taUkRJlPWWIsBpc3Nn5D90=",
-			"dev": true,
-			"requires": {
-				"core-js": "^1.0.0",
-				"isomorphic-fetch": "^2.1.1",
-				"loose-envify": "^1.0.0",
-				"object-assign": "^4.1.0",
-				"promise": "^7.1.1",
-				"setimmediate": "^1.0.5",
-				"ua-parser-js": "^0.7.18"
-			},
-			"dependencies": {
-				"core-js": {
-					"version": "1.2.7",
-					"resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
-					"integrity": "sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY=",
-					"dev": true
-				}
 			}
 		},
 		"figures": {
@@ -6909,12 +6861,6 @@
 			"integrity": "sha1-8QdIy+dq+WS3yWyTxrzCivEgwIE=",
 			"dev": true
 		},
-		"gud": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/gud/-/gud-1.0.0.tgz",
-			"integrity": "sha512-zGEOVKFM5sVPPrYs7J5/hYEw2Pof8KCyOwyhG8sAF26mCAeUFAcYPu1mwB7hhpIP29zOIBaDqwuHdLp0jvZXjw==",
-			"dev": true
-		},
 		"gzip-size": {
 			"version": "4.1.0",
 			"resolved": "https://registry.npmjs.org/gzip-size/-/gzip-size-4.1.0.tgz",
@@ -7102,12 +7048,6 @@
 				"minimalistic-assert": "^1.0.0",
 				"minimalistic-crypto-utils": "^1.0.1"
 			}
-		},
-		"hoist-non-react-statics": {
-			"version": "2.5.5",
-			"resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-2.5.5.tgz",
-			"integrity": "sha512-rqcy4pJo55FTTLWt+bU8ukscqHeE/e9KWvsOW2b/a3afxQZhwkQdT1rPPCJ0rYXdj4vNcasY8zHTH+jF/qStxw==",
-			"dev": true
 		},
 		"home-or-tmp": {
 			"version": "2.0.0",
@@ -7650,16 +7590,6 @@
 			"dev": true,
 			"requires": {
 				"isarray": "1.0.0"
-			}
-		},
-		"isomorphic-fetch": {
-			"version": "2.2.1",
-			"resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz",
-			"integrity": "sha1-YRrhrPFPXoH3KVB0coGf6XM1WKk=",
-			"dev": true,
-			"requires": {
-				"node-fetch": "^1.0.1",
-				"whatwg-fetch": ">=0.10.0"
 			}
 		},
 		"isstream": {
@@ -9284,16 +9214,6 @@
 			"integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
 			"dev": true
 		},
-		"node-fetch": {
-			"version": "1.7.3",
-			"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
-			"integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
-			"dev": true,
-			"requires": {
-				"encoding": "^0.1.11",
-				"is-stream": "^1.0.1"
-			}
-		},
 		"node-int64": {
 			"version": "0.4.0",
 			"resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
@@ -9728,23 +9648,6 @@
 			"integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
 			"dev": true
 		},
-		"path-to-regexp": {
-			"version": "1.7.0",
-			"resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.7.0.tgz",
-			"integrity": "sha1-Wf3g9DW62suhA6hOnTvGTpa5k30=",
-			"dev": true,
-			"requires": {
-				"isarray": "0.0.1"
-			},
-			"dependencies": {
-				"isarray": {
-					"version": "0.0.1",
-					"resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-					"integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
-					"dev": true
-				}
-			}
-		},
 		"path-type": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
@@ -9918,15 +9821,6 @@
 			"resolved": "https://registry.npmjs.org/progress/-/progress-2.0.1.tgz",
 			"integrity": "sha512-OE+a6vzqazc+K6LxJrX5UPyKFvGnL5CYmq2jFGNIBWHpc4QyE49/YOumcrpQFJpfejmvRtbJzgO1zPmMCqlbBg==",
 			"dev": true
-		},
-		"promise": {
-			"version": "7.3.1",
-			"resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
-			"integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==",
-			"dev": true,
-			"requires": {
-				"asap": "~2.0.3"
-			}
 		},
 		"promise-inflight": {
 			"version": "1.0.1",
@@ -10126,32 +10020,6 @@
 				"object-assign": "^4.1.1",
 				"prop-types": "^15.6.2",
 				"schedule": "^0.5.0"
-			}
-		},
-		"react-router": {
-			"version": "4.4.0-beta.4",
-			"resolved": "https://registry.npmjs.org/react-router/-/react-router-4.4.0-beta.4.tgz",
-			"integrity": "sha512-Ktdx4prUdHc/mY/M4G3Dge3y/ubO7+WVV/RpJQRVQeJXErAXspgn3fYmdBRuMdGBHwOqskdTqwkE+dEmkgdrxA==",
-			"dev": true,
-			"requires": {
-				"create-react-context": "^0.2.2",
-				"history": "^4.7.2",
-				"hoist-non-react-statics": "^2.5.0",
-				"invariant": "^2.2.4",
-				"loose-envify": "^1.3.1",
-				"path-to-regexp": "^1.7.0",
-				"warning": "^4.0.1"
-			},
-			"dependencies": {
-				"warning": {
-					"version": "4.0.2",
-					"resolved": "https://registry.npmjs.org/warning/-/warning-4.0.2.tgz",
-					"integrity": "sha512-wbTp09q/9C+jJn4KKJfJfoS6VleK/Dti0yqWSm6KMvJ4MRCXFQNapHuJXutJIrWV0Cf4AhTdeIe4qdKHR1+Hug==",
-					"dev": true,
-					"requires": {
-						"loose-envify": "^1.0.0"
-					}
-				}
 			}
 		},
 		"read-pkg": {
@@ -12241,12 +12109,6 @@
 			"integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
 			"dev": true
 		},
-		"ua-parser-js": {
-			"version": "0.7.18",
-			"resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.18.tgz",
-			"integrity": "sha512-LtzwHlVHwFGTptfNSgezHp7WUlwiqb0gA9AALRbKaERfxwJoiX0A73QbTToxteIAuIaFshhgIZfqK8s7clqgnA==",
-			"dev": true
-		},
 		"uglify-js": {
 			"version": "3.4.9",
 			"resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.4.9.tgz",
@@ -13059,12 +12921,6 @@
 			"requires": {
 				"iconv-lite": "0.4.24"
 			}
-		},
-		"whatwg-fetch": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.0.0.tgz",
-			"integrity": "sha512-9GSJUgz1D4MfyKU7KRqwOjXCXTqWdFNvEr7eUBYchQiVc744mqK/MzXPNR2WsPkmkOa4ywfg8C2n8h+13Bey1Q==",
-			"dev": true
 		},
 		"whatwg-mimetype": {
 			"version": "2.2.0",

--- a/packages/react-router-dom/.size-snapshot.json
+++ b/packages/react-router-dom/.size-snapshot.json
@@ -1,8 +1,8 @@
 {
   "esm/react-router-dom.js": {
-    "bundled": 7935,
-    "minified": 4844,
-    "gzipped": 1607,
+    "bundled": 7968,
+    "minified": 4870,
+    "gzipped": 1613,
     "treeshaked": {
       "rollup": {
         "code": 1240,
@@ -14,13 +14,13 @@
     }
   },
   "umd/react-router-dom.js": {
-    "bundled": 161801,
-    "minified": 58038,
-    "gzipped": 16043
+    "bundled": 171152,
+    "minified": 61992,
+    "gzipped": 16916
   },
   "umd/react-router-dom.min.js": {
-    "bundled": 101990,
-    "minified": 36745,
-    "gzipped": 10247
+    "bundled": 106635,
+    "minified": 38911,
+    "gzipped": 11286
   }
 }

--- a/packages/react-router-dom/package-lock.json
+++ b/packages/react-router-dom/package-lock.json
@@ -1754,11 +1754,6 @@
 			"integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
 			"dev": true
 		},
-		"asap": {
-			"version": "2.0.6",
-			"resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
-			"integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY="
-		},
 		"asn1": {
 			"version": "0.2.4",
 			"resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz",
@@ -3063,15 +3058,6 @@
 				"sha.js": "^2.4.8"
 			}
 		},
-		"create-react-context": {
-			"version": "0.2.3",
-			"resolved": "https://registry.npmjs.org/create-react-context/-/create-react-context-0.2.3.tgz",
-			"integrity": "sha512-CQBmD0+QGgTaxDL3OX1IDXYqjkp2It4RIbcb99jS6AEg27Ga+a9G3JtK6SIu0HBwPLZlmwt9F7UwWA4Bn92Rag==",
-			"requires": {
-				"fbjs": "^0.8.0",
-				"gud": "^1.0.0"
-			}
-		},
 		"cross-spawn": {
 			"version": "5.1.0",
 			"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
@@ -3492,14 +3478,6 @@
 			"resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-2.1.0.tgz",
 			"integrity": "sha1-TapNnbAPmBmIDHn6RXrlsJof04k=",
 			"dev": true
-		},
-		"encoding": {
-			"version": "0.1.12",
-			"resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
-			"integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
-			"requires": {
-				"iconv-lite": "~0.4.13"
-			}
 		},
 		"end-of-stream": {
 			"version": "1.4.1",
@@ -4129,27 +4107,6 @@
 			"dev": true,
 			"requires": {
 				"bser": "^2.0.0"
-			}
-		},
-		"fbjs": {
-			"version": "0.8.17",
-			"resolved": "https://registry.npmjs.org/fbjs/-/fbjs-0.8.17.tgz",
-			"integrity": "sha1-xNWY6taUkRJlPWWIsBpc3Nn5D90=",
-			"requires": {
-				"core-js": "^1.0.0",
-				"isomorphic-fetch": "^2.1.1",
-				"loose-envify": "^1.0.0",
-				"object-assign": "^4.1.0",
-				"promise": "^7.1.1",
-				"setimmediate": "^1.0.5",
-				"ua-parser-js": "^0.7.18"
-			},
-			"dependencies": {
-				"core-js": {
-					"version": "1.2.7",
-					"resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
-					"integrity": "sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY="
-				}
 			}
 		},
 		"figures": {
@@ -5000,11 +4957,6 @@
 			"integrity": "sha1-8QdIy+dq+WS3yWyTxrzCivEgwIE=",
 			"dev": true
 		},
-		"gud": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/gud/-/gud-1.0.0.tgz",
-			"integrity": "sha512-zGEOVKFM5sVPPrYs7J5/hYEw2Pof8KCyOwyhG8sAF26mCAeUFAcYPu1mwB7hhpIP29zOIBaDqwuHdLp0jvZXjw=="
-		},
 		"gzip-size": {
 			"version": "4.1.0",
 			"resolved": "https://registry.npmjs.org/gzip-size/-/gzip-size-4.1.0.tgz",
@@ -5202,11 +5154,6 @@
 				"minimalistic-crypto-utils": "^1.0.1"
 			}
 		},
-		"hoist-non-react-statics": {
-			"version": "2.5.5",
-			"resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-2.5.5.tgz",
-			"integrity": "sha512-rqcy4pJo55FTTLWt+bU8ukscqHeE/e9KWvsOW2b/a3afxQZhwkQdT1rPPCJ0rYXdj4vNcasY8zHTH+jF/qStxw=="
-		},
 		"home-or-tmp": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-2.0.0.tgz",
@@ -5253,6 +5200,7 @@
 			"version": "0.4.24",
 			"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
 			"integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+			"dev": true,
 			"requires": {
 				"safer-buffer": ">= 2.1.2 < 3"
 			}
@@ -5697,7 +5645,8 @@
 		"is-stream": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
-			"integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
+			"integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
+			"dev": true
 		},
 		"is-symbol": {
 			"version": "1.0.2",
@@ -5745,15 +5694,6 @@
 			"dev": true,
 			"requires": {
 				"isarray": "1.0.0"
-			}
-		},
-		"isomorphic-fetch": {
-			"version": "2.2.1",
-			"resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz",
-			"integrity": "sha1-YRrhrPFPXoH3KVB0coGf6XM1WKk=",
-			"requires": {
-				"node-fetch": "^1.0.1",
-				"whatwg-fetch": ">=0.10.0"
 			}
 		},
 		"isstream": {
@@ -7376,15 +7316,6 @@
 			"integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
 			"dev": true
 		},
-		"node-fetch": {
-			"version": "1.7.3",
-			"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
-			"integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
-			"requires": {
-				"encoding": "^0.1.11",
-				"is-stream": "^1.0.1"
-			}
-		},
 		"node-int64": {
 			"version": "0.4.0",
 			"resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
@@ -7818,21 +7749,6 @@
 			"integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
 			"dev": true
 		},
-		"path-to-regexp": {
-			"version": "1.7.0",
-			"resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.7.0.tgz",
-			"integrity": "sha1-Wf3g9DW62suhA6hOnTvGTpa5k30=",
-			"requires": {
-				"isarray": "0.0.1"
-			},
-			"dependencies": {
-				"isarray": {
-					"version": "0.0.1",
-					"resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-					"integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
-				}
-			}
-		},
 		"path-type": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
@@ -8006,14 +7922,6 @@
 			"resolved": "https://registry.npmjs.org/progress/-/progress-2.0.1.tgz",
 			"integrity": "sha512-OE+a6vzqazc+K6LxJrX5UPyKFvGnL5CYmq2jFGNIBWHpc4QyE49/YOumcrpQFJpfejmvRtbJzgO1zPmMCqlbBg==",
 			"dev": true
-		},
-		"promise": {
-			"version": "7.3.1",
-			"resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
-			"integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==",
-			"requires": {
-				"asap": "~2.0.3"
-			}
 		},
 		"promise-inflight": {
 			"version": "1.0.1",
@@ -8212,20 +8120,6 @@
 				"object-assign": "^4.1.1",
 				"prop-types": "^15.6.2",
 				"schedule": "^0.5.0"
-			}
-		},
-		"react-router": {
-			"version": "4.4.0-beta.4",
-			"resolved": "https://registry.npmjs.org/react-router/-/react-router-4.4.0-beta.4.tgz",
-			"integrity": "sha512-Ktdx4prUdHc/mY/M4G3Dge3y/ubO7+WVV/RpJQRVQeJXErAXspgn3fYmdBRuMdGBHwOqskdTqwkE+dEmkgdrxA==",
-			"requires": {
-				"create-react-context": "^0.2.2",
-				"history": "^4.7.2",
-				"hoist-non-react-statics": "^2.5.0",
-				"invariant": "^2.2.4",
-				"loose-envify": "^1.3.1",
-				"path-to-regexp": "^1.7.0",
-				"warning": "^4.0.1"
 			}
 		},
 		"read-pkg": {
@@ -9169,7 +9063,8 @@
 		"safer-buffer": {
 			"version": "2.1.2",
 			"resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-			"integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+			"integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+			"dev": true
 		},
 		"sane": {
 			"version": "2.5.2",
@@ -9590,7 +9485,8 @@
 		"setimmediate": {
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
-			"integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU="
+			"integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU=",
+			"dev": true
 		},
 		"sha.js": {
 			"version": "2.4.11",
@@ -10351,11 +10247,6 @@
 			"resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
 			"integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
 			"dev": true
-		},
-		"ua-parser-js": {
-			"version": "0.7.18",
-			"resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.18.tgz",
-			"integrity": "sha512-LtzwHlVHwFGTptfNSgezHp7WUlwiqb0gA9AALRbKaERfxwJoiX0A73QbTToxteIAuIaFshhgIZfqK8s7clqgnA=="
 		},
 		"uglify-js": {
 			"version": "3.4.9",
@@ -11167,11 +11058,6 @@
 			"requires": {
 				"iconv-lite": "0.4.24"
 			}
-		},
-		"whatwg-fetch": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.0.0.tgz",
-			"integrity": "sha512-9GSJUgz1D4MfyKU7KRqwOjXCXTqWdFNvEr7eUBYchQiVc744mqK/MzXPNR2WsPkmkOa4ywfg8C2n8h+13Bey1Q=="
 		},
 		"whatwg-mimetype": {
 			"version": "2.2.0",

--- a/packages/react-router-native/Link.js
+++ b/packages/react-router-native/Link.js
@@ -41,8 +41,6 @@ class Link extends React.Component {
   }
 }
 
-const __DEV__ = true; // TODO
-
 if (__DEV__) {
   Link.propTypes = {
     onPress: PropTypes.func,

--- a/packages/react-router-native/NativeRouter.js
+++ b/packages/react-router-native/NativeRouter.js
@@ -20,8 +20,6 @@ NativeRouter.defaultProps = {
   }
 };
 
-const __DEV__ = true; // TODO
-
 if (__DEV__) {
   NativeRouter.propTypes = {
     initialEntries: PropTypes.array,

--- a/packages/react-router-native/package-lock.json
+++ b/packages/react-router-native/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "react-router-native",
-	"version": "4.4.0-beta.3",
+	"version": "4.4.0-beta.4",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/react-router/.size-snapshot.json
+++ b/packages/react-router/.size-snapshot.json
@@ -1,26 +1,26 @@
 {
   "esm/react-router.js": {
-    "bundled": 24445,
-    "minified": 14277,
-    "gzipped": 3696,
+    "bundled": 24703,
+    "minified": 14453,
+    "gzipped": 3773,
     "treeshaked": {
       "rollup": {
-        "code": 4437,
-        "import_statements": 445
+        "code": 4454,
+        "import_statements": 462
       },
       "webpack": {
-        "code": 5877
+        "code": 5930
       }
     }
   },
   "umd/react-router.js": {
-    "bundled": 95663,
-    "minified": 34078,
-    "gzipped": 10776
+    "bundled": 105148,
+    "minified": 38022,
+    "gzipped": 11676
   },
   "umd/react-router.min.js": {
-    "bundled": 62084,
-    "minified": 21688,
-    "gzipped": 7606
+    "bundled": 66787,
+    "minified": 23895,
+    "gzipped": 8200
   }
 }

--- a/packages/react-router/modules/Route.js
+++ b/packages/react-router/modules/Route.js
@@ -1,4 +1,5 @@
 import React from "react";
+import ReactIs from "react-is";
 import PropTypes from "prop-types";
 import invariant from "invariant";
 import warning from "warning";
@@ -127,7 +128,13 @@ if (!React.createContext) {
 if (__DEV__) {
   Route.propTypes = {
     children: PropTypes.oneOfType([PropTypes.func, PropTypes.node]),
-    component: PropTypes.func,
+    component: function(props, propName) {
+      if (props[propName] && !ReactIs.isValidElementType(props[propName])) {
+        return new Error(
+          `Invalid prop 'component' supplied to 'Route': prop was not a valid React component`
+        );
+      }
+    },
     exact: PropTypes.bool,
     location: PropTypes.object,
     path: PropTypes.oneOfType([

--- a/packages/react-router/modules/__tests__/Route-test.js
+++ b/packages/react-router/modules/__tests__/Route-test.js
@@ -419,6 +419,34 @@ describe("A <Route>", () => {
       expect(typeof props.location).toBe("object");
       expect(typeof props.match).toBe("object");
     });
+
+    it("won't throw a prop-type warning when passed valid React components that aren't functions", () => {
+      function forwardRef(Component) {
+        class ForwardComponent extends React.Component {
+          render() {
+            const { forwardedRef, ...rest } = this.props;
+            return <Component ref={forwardedRef} {...rest} />;
+          }
+        }
+        return React.forwardRef((props, ref) => {
+          return <ForwardComponent {...props} forwardedRef={ref} />;
+        });
+      }
+
+      const history = createHistory();
+      const Component = () => null;
+      const WrappedComponent = forwardRef(Component);
+      const errorSpy = jest.spyOn(console, "error");
+
+      ReactDOM.render(
+        <Router history={history}>
+          <Route path="/" component={WrappedComponent} />
+        </Router>,
+        node
+      );
+
+      expect(errorSpy).not.toHaveBeenCalled();
+    });
   });
 
   describe("the `render` prop", () => {

--- a/packages/react-router/package-lock.json
+++ b/packages/react-router/package-lock.json
@@ -8359,6 +8359,11 @@
 				"schedule": "^0.5.0"
 			}
 		},
+		"react-is": {
+			"version": "16.5.2",
+			"resolved": "https://registry.npmjs.org/react-is/-/react-is-16.5.2.tgz",
+			"integrity": "sha512-hSl7E6l25GTjNEZATqZIuWOgSnpXb3kD0DVCujmg46K5zLxsbiKaaT6VO9slkSBDPZfYs30lwfJwbOFOnoEnKQ=="
+		},
 		"read-pkg": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",

--- a/packages/react-router/package.json
+++ b/packages/react-router/package.json
@@ -47,6 +47,7 @@
     "invariant": "^2.2.4",
     "loose-envify": "^1.3.1",
     "path-to-regexp": "^1.7.0",
+    "react-is": "^16.5.2",
     "warning": "^4.0.1"
   },
   "devDependencies": {

--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "react-router-website",
-	"version": "4.4.0-beta.3",
+	"version": "4.4.0-beta.4",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {


### PR DESCRIPTION
Removed a couple of outdated TODOs that dealt with __DEV__

The rest of the changes were done just from an npm install command

React-is does add a tiny bit of size ( https://bundlephobia.com/result?p=react-is@16.5.2 ) as noted by the snapshots, but it seems like the best (and official) way to support the check.

Adds the changes and feedback found in #6327 while also removing a duplicated test