### PR TITLE
Simplify the Quick Start examples

### DIFF
--- a/packages/react-router-dom/docs/guides/quick-start.md
+++ b/packages/react-router-dom/docs/guides/quick-start.md
@@ -4,11 +4,10 @@ You'll need a React web app to add `react-router`.
 
 If you need to create one, the easiest way to get started is with a popular tool called [Create React App][crapp].
 
-First install `create-react-app`, if you don't already have it, and then make a new project with it.
+The easiest way to run `create-react-app` is with `npx`.
 
 ```sh
-npm install -g create-react-app
-create-react-app demo-app
+npx create-react-app demo-app
 cd demo-app
 ```
 

--- a/packages/react-router-dom/docs/guides/quick-start.md
+++ b/packages/react-router-dom/docs/guides/quick-start.md
@@ -40,17 +40,9 @@ const AppRouter = () => (
   <Router>
     <div>
       <nav>
-        <ul>
-          <li>
-            <Link to="/">Home</Link>
-          </li>
-          <li>
-            <Link to="/about/">About</Link>
-          </li>
-          <li>
-            <Link to="/users/">Users</Link>
-          </li>
-        </ul>
+        <Link to="/">Home</Link>
+        <Link to="/about/">About</Link>
+        <Link to="/users/">Users</Link>
       </nav>
 
       <Route path="/" exact component={Index} />
@@ -74,7 +66,11 @@ import { BrowserRouter as Router, Route, Link } from "react-router-dom";
 const App = () => (
   <Router>
     <div>
-      <Header />
+      <nav>
+        <Link to="/">Home</Link>
+        <Link to="/about">About</Link>
+        <Link to="/topics">Topics</Link>
+      </nav>
 
       <Route exact path="/" component={Home} />
       <Route path="/about" component={About} />
@@ -90,14 +86,10 @@ const Topics = ({ match }) => (
   <div>
     <h2>Topics</h2>
 
-    <ul>
-      <li>
-        <Link to={`${match.url}/components`}>Components</Link>
-      </li>
-      <li>
-        <Link to={`${match.url}/props-v-state`}>Props v. State</Link>
-      </li>
-    </ul>
+    <nav>
+      <Link to={`${match.url}/components`}>Components</Link>
+      <Link to={`${match.url}/props-v-state`}>Props v. State</Link>
+    </nav>
 
     <Route path={`${match.path}/:id`} component={Topic} />
     <Route
@@ -106,19 +98,6 @@ const Topics = ({ match }) => (
       render={() => <h3>Please select a topic.</h3>}
     />
   </div>
-);
-const Header = () => (
-  <ul>
-    <li>
-      <Link to="/">Home</Link>
-    </li>
-    <li>
-      <Link to="/about">About</Link>
-    </li>
-    <li>
-      <Link to="/topics">Topics</Link>
-    </li>
-  </ul>
 );
 
 export default App;

--- a/packages/react-router-dom/docs/guides/quick-start.md
+++ b/packages/react-router-dom/docs/guides/quick-start.md
@@ -2,9 +2,7 @@
 
 You'll need a React web app to add `react-router`.
 
-If you need to create one, the easiest way to get started is with a popular tool called [Create React App][crapp].
-
-The easiest way to run `create-react-app` is with `npx`.
+If you need to create one, the popular tool [Create React App][crapp] can get you started quickly. Calling `npx create-react-app <app-name>` will create an application and install its dependencies for you.
 
 ```sh
 npx create-react-app demo-app


### PR DESCRIPTION
Hopefully these updates further simplify the Quick Start examples. 

Trying to make both examples more digestible, with less filler (`<ul> and <li>` tags).

Here's screenshots of the changes, compared to my last update:

#### Basic Example:

**Updated version on left.**

![image](https://user-images.githubusercontent.com/397632/47613403-69af3c00-da54-11e8-961c-c8865d7b8acb.png)

#### And the Nested example:

**Updated version on left.**

![image](https://user-images.githubusercontent.com/397632/47613411-96635380-da54-11e8-9ad8-5df2be0be83a.png)


I'd like the nested example to read a little better. The mix (or order) of Components doesn't seem right... 🤔 