### PR TITLE
Removed the "Anywhere" button from Home Page

### DIFF
--- a/website/modules/components/Home/Header.js
+++ b/website/modules/components/Home/Header.js
@@ -114,9 +114,6 @@ const Banner = () => (
             <Button to="/native" small={isSmallScreen}>
               Native
             </Button>
-            <Button to="/core" small={isSmallScreen}>
-              Anywhere
-            </Button>
           </Row>
         </Block>
       </Row>


### PR DESCRIPTION
While watching newcomers try navigate the Home Page, I think I've found a point of confusion. 

The presence of a button labelled "Anywhere" seems to throw them off. 

It sounds like a safe catch-all. Yet most people likely want to see usage examples for either "Web" or "Native"

![image](https://user-images.githubusercontent.com/397632/47613571-71241480-da57-11e8-9eba-e032aae5c4d2.png)



I'd leave the "Core" section in the docs for now:

![image](https://user-images.githubusercontent.com/397632/47613598-0921fe00-da58-11e8-9d7c-182c2a097729.png)
