### PR TITLE
Fix import of react-is

### DIFF
--- a/packages/react-router/modules/Route.js
+++ b/packages/react-router/modules/Route.js
@@ -1,5 +1,5 @@
 import React from "react";
-import ReactIs from "react-is";
+import * as ReactIs from "react-is";
 import PropTypes from "prop-types";
 import invariant from "tiny-invariant";
 import warning from "tiny-warning";


### PR DESCRIPTION
This PR fixes the issue #6445 where ReactIs is being imported as default while it shouldn't.