### PR TITLE
Native > Support Text as component

### DIFF
--- a/packages/react-router-native/Link.js
+++ b/packages/react-router-native/Link.js
@@ -48,6 +48,7 @@ if (__DEV__) {
     onPress: PropTypes.func,
     component: PropTypes.oneOfType([
       PropTypes.func,
+      // TODO: Use forwardRef PropType when it is available.
       PropTypes.shape({
         render: PropTypes.func.isRequired,
       }),

--- a/packages/react-router-native/Link.js
+++ b/packages/react-router-native/Link.js
@@ -46,7 +46,12 @@ const __DEV__ = true; // TODO
 if (__DEV__) {
   Link.propTypes = {
     onPress: PropTypes.func,
-    component: PropTypes.func,
+    component: PropTypes.oneOfType([
+      PropTypes.func,
+      PropTypes.shape({
+        render: PropTypes.func.isRequired,
+      }),
+    ]),
     replace: PropTypes.bool,
     to: PropTypes.oneOfType([PropTypes.string, PropTypes.object])
   };


### PR DESCRIPTION
Hi all,
[since six months](https://github.com/facebook/react-native/commit/e708010d18f938e2d6b6424cfc9485d8e5dd2800) the `react-native` implementation of `Text` implemented `forwardRef`. This means that, while a `Text` component is legit as a `Link` (it implements the `onPress` prop), it's not a function anymore. Instead, it will be an object with a render function.

Unfortunately, the right prop type for `forwardRef` [does not exists yet](https://github.com/facebook/prop-types/issues/200).

This PR allows `Text` to be passed as `component` to `Link`, without `prop-types` warnings and maintaining a good level of safety checks.

I hope you'll be ok with merging this, and thanks again for `react-router` 🙌