### PR TITLE
 Make react-router-dom treeshakable

### DIFF
--- a/packages/react-router-dom/.size-snapshot.json
+++ b/packages/react-router-dom/.size-snapshot.json
@@ -1,26 +1,26 @@
 {
   "esm/react-router-dom.js": {
-    "bundled": 7978,
-    "minified": 4880,
+    "bundled": 7970,
+    "minified": 4872,
     "gzipped": 1618,
     "treeshaked": {
       "rollup": {
-        "code": 1250,
+        "code": 1242,
         "import_statements": 417
       },
       "webpack": {
-        "code": 3322
+        "code": 3314
       }
     }
   },
   "umd/react-router-dom.js": {
-    "bundled": 159709,
-    "minified": 57597,
-    "gzipped": 16540
+    "bundled": 126944,
+    "minified": 47084,
+    "gzipped": 14090
   },
   "umd/react-router-dom.min.js": {
-    "bundled": 97476,
-    "minified": 34651,
-    "gzipped": 10216
+    "bundled": 84862,
+    "minified": 30171,
+    "gzipped": 9983
   }
 }

--- a/packages/react-router-dom/.size-snapshot.json
+++ b/packages/react-router-dom/.size-snapshot.json
@@ -1,26 +1,26 @@
 {
   "esm/react-router-dom.js": {
-    "bundled": 7970,
-    "minified": 4872,
-    "gzipped": 1618,
+    "bundled": 8022,
+    "minified": 4817,
+    "gzipped": 1612,
     "treeshaked": {
       "rollup": {
-        "code": 1242,
+        "code": 453,
         "import_statements": 417
       },
       "webpack": {
-        "code": 3314
+        "code": 1661
       }
     }
   },
   "umd/react-router-dom.js": {
-    "bundled": 126944,
-    "minified": 47084,
-    "gzipped": 14090
+    "bundled": 126991,
+    "minified": 47032,
+    "gzipped": 14084
   },
   "umd/react-router-dom.min.js": {
-    "bundled": 84862,
-    "minified": 30171,
-    "gzipped": 9983
+    "bundled": 84909,
+    "minified": 30118,
+    "gzipped": 9978
   }
 }

--- a/packages/react-router-dom/modules/Link.js
+++ b/packages/react-router-dom/modules/Link.js
@@ -12,10 +12,6 @@ function isModifiedEvent(event) {
  * The public API for rendering a history-aware <a>.
  */
 class Link extends React.Component {
-  static defaultProps = {
-    replace: false
-  };
-
   handleClick(event, history) {
     if (this.props.onClick) this.props.onClick(event);
 

--- a/packages/react-router-dom/modules/NavLink.js
+++ b/packages/react-router-dom/modules/NavLink.js
@@ -12,8 +12,8 @@ function joinClassnames(...classnames) {
  * A <Link> wrapper that knows if it's "active" or not.
  */
 function NavLink({
-  "aria-current": ariaCurrent,
-  activeClassName,
+  "aria-current": ariaCurrent = "page",
+  activeClassName = "active",
   activeStyle,
   className: classNameProp,
   exact,
@@ -58,11 +58,6 @@ function NavLink({
     />
   );
 }
-
-NavLink.defaultProps = {
-  "aria-current": "page",
-  activeClassName: "active"
-};
 
 if (__DEV__) {
   const ariaCurrentType = PropTypes.oneOf([

--- a/packages/react-router-dom/package-lock.json
+++ b/packages/react-router-dom/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "react-router-dom",
-	"version": "4.4.0-beta.5",
+	"version": "4.4.0-beta.6",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
@@ -1748,6 +1748,11 @@
 			"integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
 			"dev": true
 		},
+		"asap": {
+			"version": "2.0.6",
+			"resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
+			"integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY="
+		},
 		"asn1": {
 			"version": "0.2.4",
 			"resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz",
@@ -3051,6 +3056,15 @@
 				"sha.js": "^2.4.8"
 			}
 		},
+		"create-react-context": {
+			"version": "0.2.3",
+			"resolved": "https://registry.npmjs.org/create-react-context/-/create-react-context-0.2.3.tgz",
+			"integrity": "sha512-CQBmD0+QGgTaxDL3OX1IDXYqjkp2It4RIbcb99jS6AEg27Ga+a9G3JtK6SIu0HBwPLZlmwt9F7UwWA4Bn92Rag==",
+			"requires": {
+				"fbjs": "^0.8.0",
+				"gud": "^1.0.0"
+			}
+		},
 		"cross-spawn": {
 			"version": "5.1.0",
 			"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
@@ -3470,6 +3484,14 @@
 			"resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-2.1.0.tgz",
 			"integrity": "sha1-TapNnbAPmBmIDHn6RXrlsJof04k=",
 			"dev": true
+		},
+		"encoding": {
+			"version": "0.1.12",
+			"resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
+			"integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
+			"requires": {
+				"iconv-lite": "~0.4.13"
+			}
 		},
 		"end-of-stream": {
 			"version": "1.4.1",
@@ -4099,6 +4121,27 @@
 			"dev": true,
 			"requires": {
 				"bser": "^2.0.0"
+			}
+		},
+		"fbjs": {
+			"version": "0.8.17",
+			"resolved": "https://registry.npmjs.org/fbjs/-/fbjs-0.8.17.tgz",
+			"integrity": "sha1-xNWY6taUkRJlPWWIsBpc3Nn5D90=",
+			"requires": {
+				"core-js": "^1.0.0",
+				"isomorphic-fetch": "^2.1.1",
+				"loose-envify": "^1.0.0",
+				"object-assign": "^4.1.0",
+				"promise": "^7.1.1",
+				"setimmediate": "^1.0.5",
+				"ua-parser-js": "^0.7.18"
+			},
+			"dependencies": {
+				"core-js": {
+					"version": "1.2.7",
+					"resolved": "http://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
+					"integrity": "sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY="
+				}
 			}
 		},
 		"figures": {
@@ -4938,6 +4981,11 @@
 			"integrity": "sha1-8QdIy+dq+WS3yWyTxrzCivEgwIE=",
 			"dev": true
 		},
+		"gud": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/gud/-/gud-1.0.0.tgz",
+			"integrity": "sha512-zGEOVKFM5sVPPrYs7J5/hYEw2Pof8KCyOwyhG8sAF26mCAeUFAcYPu1mwB7hhpIP29zOIBaDqwuHdLp0jvZXjw=="
+		},
 		"handlebars": {
 			"version": "4.0.12",
 			"resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.12.tgz",
@@ -5108,6 +5156,11 @@
 				"minimalistic-crypto-utils": "^1.0.1"
 			}
 		},
+		"hoist-non-react-statics": {
+			"version": "2.5.5",
+			"resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-2.5.5.tgz",
+			"integrity": "sha512-rqcy4pJo55FTTLWt+bU8ukscqHeE/e9KWvsOW2b/a3afxQZhwkQdT1rPPCJ0rYXdj4vNcasY8zHTH+jF/qStxw=="
+		},
 		"home-or-tmp": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-2.0.0.tgz",
@@ -5154,7 +5207,6 @@
 			"version": "0.4.24",
 			"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
 			"integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
-			"dev": true,
 			"requires": {
 				"safer-buffer": ">= 2.1.2 < 3"
 			}
@@ -5600,8 +5652,7 @@
 		"is-stream": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
-			"integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
-			"dev": true
+			"integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
 		},
 		"is-symbol": {
 			"version": "1.0.2",
@@ -5649,6 +5700,15 @@
 			"dev": true,
 			"requires": {
 				"isarray": "1.0.0"
+			}
+		},
+		"isomorphic-fetch": {
+			"version": "2.2.1",
+			"resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz",
+			"integrity": "sha1-YRrhrPFPXoH3KVB0coGf6XM1WKk=",
+			"requires": {
+				"node-fetch": "^1.0.1",
+				"whatwg-fetch": ">=0.10.0"
 			}
 		},
 		"isstream": {
@@ -7322,6 +7382,15 @@
 			"integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
 			"dev": true
 		},
+		"node-fetch": {
+			"version": "1.7.3",
+			"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
+			"integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
+			"requires": {
+				"encoding": "^0.1.11",
+				"is-stream": "^1.0.1"
+			}
+		},
 		"node-int64": {
 			"version": "0.4.0",
 			"resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
@@ -7755,6 +7824,21 @@
 			"integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
 			"dev": true
 		},
+		"path-to-regexp": {
+			"version": "1.7.0",
+			"resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.7.0.tgz",
+			"integrity": "sha1-Wf3g9DW62suhA6hOnTvGTpa5k30=",
+			"requires": {
+				"isarray": "0.0.1"
+			},
+			"dependencies": {
+				"isarray": {
+					"version": "0.0.1",
+					"resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+					"integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+				}
+			}
+		},
 		"path-type": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
@@ -7922,6 +8006,14 @@
 			"resolved": "https://registry.npmjs.org/progress/-/progress-2.0.1.tgz",
 			"integrity": "sha512-OE+a6vzqazc+K6LxJrX5UPyKFvGnL5CYmq2jFGNIBWHpc4QyE49/YOumcrpQFJpfejmvRtbJzgO1zPmMCqlbBg==",
 			"dev": true
+		},
+		"promise": {
+			"version": "7.3.1",
+			"resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
+			"integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==",
+			"requires": {
+				"asap": "~2.0.3"
+			}
 		},
 		"promise-inflight": {
 			"version": "1.0.1",
@@ -8120,6 +8212,28 @@
 				"object-assign": "^4.1.1",
 				"prop-types": "^15.6.2",
 				"schedule": "^0.5.0"
+			}
+		},
+		"react-is": {
+			"version": "16.6.1",
+			"resolved": "https://registry.npmjs.org/react-is/-/react-is-16.6.1.tgz",
+			"integrity": "sha512-wOKsGtvTMYs7WAscmwwdM8sfRRvE17Ym30zFj3n37Qx5tHRfhenPKEPILHaHob6WoLFADmQm1ZNrE5xMCM6sCw=="
+		},
+		"react-router": {
+			"version": "4.4.0-beta.6",
+			"resolved": "https://registry.npmjs.org/react-router/-/react-router-4.4.0-beta.6.tgz",
+			"integrity": "sha512-esR1UHsPpfvehX5Qn7wQrOTFsl4PxiaX3GaYvtFDSEioMsTl0zkASJBm1fXKgR9brUQX9kgiGq6XnCsiJU/82g==",
+			"requires": {
+				"@babel/runtime": "^7.1.2",
+				"create-react-context": "^0.2.2",
+				"history": "^4.8.0-beta.0",
+				"hoist-non-react-statics": "^2.5.0",
+				"loose-envify": "^1.3.1",
+				"path-to-regexp": "^1.7.0",
+				"prop-types": "^15.6.2",
+				"react-is": "^16.5.2",
+				"tiny-invariant": "^1.0.2",
+				"tiny-warning": "^1.0.0"
 			}
 		},
 		"read-pkg": {
@@ -9063,8 +9177,7 @@
 		"safer-buffer": {
 			"version": "2.1.2",
 			"resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-			"integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
-			"dev": true
+			"integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
 		},
 		"sane": {
 			"version": "2.5.2",
@@ -9475,8 +9588,7 @@
 		"setimmediate": {
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
-			"integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU=",
-			"dev": true
+			"integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU="
 		},
 		"sha.js": {
 			"version": "2.4.11",
@@ -10246,6 +10358,11 @@
 			"resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
 			"integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
 			"dev": true
+		},
+		"ua-parser-js": {
+			"version": "0.7.19",
+			"resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.19.tgz",
+			"integrity": "sha512-T3PVJ6uz8i0HzPxOF9SWzWAlfN/DavlpQqepn22xgve/5QecC+XMCAtmUNnY7C9StehaV6exjUCI801lOI7QlQ=="
 		},
 		"uglify-js": {
 			"version": "3.4.9",
@@ -11049,6 +11166,11 @@
 			"requires": {
 				"iconv-lite": "0.4.24"
 			}
+		},
+		"whatwg-fetch": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.0.0.tgz",
+			"integrity": "sha512-9GSJUgz1D4MfyKU7KRqwOjXCXTqWdFNvEr7eUBYchQiVc744mqK/MzXPNR2WsPkmkOa4ywfg8C2n8h+13Bey1Q=="
 		},
 		"whatwg-mimetype": {
 			"version": "2.2.0",

--- a/packages/react-router-dom/rollup.config.js
+++ b/packages/react-router-dom/rollup.config.js
@@ -23,7 +23,7 @@ const babelOptionsESM = {
 const commonjsOptions = {
   include: /node_modules/,
   namedExports: {
-    "../react-router/node_modules/react-is/index.js": ["isValidElementType"]
+    "react-is": ["isValidElementType"]
   }
 };
 

--- a/packages/react-router-dom/rollup.config.js
+++ b/packages/react-router-dom/rollup.config.js
@@ -23,7 +23,7 @@ const babelOptionsESM = {
 const commonjsOptions = {
   include: /node_modules/,
   namedExports: {
-    "react-is": ["isValidElementType"]
+    "../react-router/node_modules/react-is/index.js": ["isValidElementType"]
   }
 };
 


### PR DESCRIPTION
Ref https://github.com/ReactTraining/react-router/issues/6464

Here's the problem. Babel transpiles static class properties outside of class iife which blocks uglify/terser from this iife.

`defaultProps` will become a bad pattern soon since it's blocks treeshakability. For functions the problem is even more aggressive since it's not solvable these days.

I think the best we may do is use defaults in destructuring
```js
const Component = ({ prop1 = 'a', prop2 = 'b' }) => {
}
```

With classes this is harder because defaults can't be propagated in all methods.