### PR TITLE
Update scroll-restoration.md

### DIFF
--- a/packages/react-router-dom/docs/guides/scroll-restoration.md
+++ b/packages/react-router-dom/docs/guides/scroll-restoration.md
@@ -13,7 +13,7 @@ Most of the time all you need is to "scroll to the top" because you have a long 
 ```jsx
 class ScrollToTop extends Component {
   componentDidUpdate(prevProps) {
-    if (this.props.location !== prevProps.location) {
+    if (this.props.location.pathname !== prevProps.location.pathname) {
       window.scrollTo(0, 0);
     }
   }


### PR DESCRIPTION
In Safari using location comparison rather than location.pathanme causes anchor links to fail.