### PR TITLE
Convert components to functions

### DIFF
--- a/packages/react-router-dom/.size-snapshot.json
+++ b/packages/react-router-dom/.size-snapshot.json
@@ -1,26 +1,26 @@
 {
   "esm/react-router-dom.js": {
-    "bundled": 7219,
-    "minified": 4420,
-    "gzipped": 1583,
+    "bundled": 6630,
+    "minified": 4063,
+    "gzipped": 1430,
     "treeshaked": {
       "rollup": {
-        "code": 341,
-        "import_statements": 329
+        "code": 221,
+        "import_statements": 221
       },
       "webpack": {
-        "code": 1600
+        "code": 1471
       }
     }
   },
   "umd/react-router-dom.js": {
-    "bundled": 159265,
-    "minified": 57114,
-    "gzipped": 16588
+    "bundled": 158530,
+    "minified": 56761,
+    "gzipped": 16538
   },
   "umd/react-router-dom.min.js": {
-    "bundled": 97032,
-    "minified": 34144,
-    "gzipped": 10256
+    "bundled": 96436,
+    "minified": 33890,
+    "gzipped": 10206
   }
 }

--- a/packages/react-router-dom/.size-snapshot.json
+++ b/packages/react-router-dom/.size-snapshot.json
@@ -14,13 +14,13 @@
     }
   },
   "umd/react-router-dom.js": {
-    "bundled": 157831,
-    "minified": 56457,
-    "gzipped": 16553
+    "bundled": 157116,
+    "minified": 56070,
+    "gzipped": 16451
   },
   "umd/react-router-dom.min.js": {
-    "bundled": 95880,
-    "minified": 33700,
-    "gzipped": 10193
+    "bundled": 95235,
+    "minified": 33361,
+    "gzipped": 10086
   }
 }

--- a/packages/react-router-dom/.size-snapshot.json
+++ b/packages/react-router-dom/.size-snapshot.json
@@ -14,13 +14,13 @@
     }
   },
   "umd/react-router-dom.js": {
-    "bundled": 158305,
-    "minified": 56670,
-    "gzipped": 16565
+    "bundled": 157831,
+    "minified": 56457,
+    "gzipped": 16553
   },
   "umd/react-router-dom.min.js": {
-    "bundled": 96284,
-    "minified": 33862,
-    "gzipped": 10216
+    "bundled": 95880,
+    "minified": 33700,
+    "gzipped": 10193
   }
 }

--- a/packages/react-router-dom/.size-snapshot.json
+++ b/packages/react-router-dom/.size-snapshot.json
@@ -1,26 +1,26 @@
 {
   "esm/react-router-dom.js": {
-    "bundled": 7601,
-    "minified": 4573,
-    "gzipped": 1552,
+    "bundled": 7219,
+    "minified": 4420,
+    "gzipped": 1583,
     "treeshaked": {
       "rollup": {
-        "code": 379,
-        "import_statements": 355
+        "code": 341,
+        "import_statements": 329
       },
       "webpack": {
-        "code": 1612
+        "code": 1600
       }
     }
   },
   "umd/react-router-dom.js": {
-    "bundled": 159620,
-    "minified": 57243,
-    "gzipped": 16508
+    "bundled": 159265,
+    "minified": 57114,
+    "gzipped": 16588
   },
   "umd/react-router-dom.min.js": {
-    "bundled": 97387,
-    "minified": 34278,
-    "gzipped": 10187
+    "bundled": 97032,
+    "minified": 34144,
+    "gzipped": 10256
   }
 }

--- a/packages/react-router-dom/.size-snapshot.json
+++ b/packages/react-router-dom/.size-snapshot.json
@@ -1,26 +1,26 @@
 {
   "esm/react-router-dom.js": {
-    "bundled": 8022,
-    "minified": 4817,
-    "gzipped": 1612,
+    "bundled": 7601,
+    "minified": 4573,
+    "gzipped": 1552,
     "treeshaked": {
       "rollup": {
-        "code": 453,
-        "import_statements": 417
+        "code": 379,
+        "import_statements": 355
       },
       "webpack": {
-        "code": 1661
+        "code": 1612
       }
     }
   },
   "umd/react-router-dom.js": {
-    "bundled": 160055,
-    "minified": 57467,
-    "gzipped": 16536
+    "bundled": 159620,
+    "minified": 57243,
+    "gzipped": 16508
   },
   "umd/react-router-dom.min.js": {
-    "bundled": 97822,
-    "minified": 34506,
-    "gzipped": 10211
+    "bundled": 97387,
+    "minified": 34278,
+    "gzipped": 10187
   }
 }

--- a/packages/react-router-dom/.size-snapshot.json
+++ b/packages/react-router-dom/.size-snapshot.json
@@ -14,13 +14,13 @@
     }
   },
   "umd/react-router-dom.js": {
-    "bundled": 158530,
-    "minified": 56761,
-    "gzipped": 16538
+    "bundled": 158305,
+    "minified": 56670,
+    "gzipped": 16565
   },
   "umd/react-router-dom.min.js": {
-    "bundled": 96436,
-    "minified": 33890,
-    "gzipped": 10206
+    "bundled": 96284,
+    "minified": 33862,
+    "gzipped": 10216
   }
 }

--- a/packages/react-router-dom/modules/BrowserRouter.js
+++ b/packages/react-router-dom/modules/BrowserRouter.js
@@ -1,5 +1,5 @@
 import React from "react";
-import { Router } from "react-router";
+import { Router, __Lifecycle as Lifecycle } from "react-router";
 import { createBrowserHistory as createHistory } from "history";
 import PropTypes from "prop-types";
 import warning from "tiny-warning";
@@ -7,12 +7,22 @@ import warning from "tiny-warning";
 /**
  * The public API for a <Router> that uses HTML5 history.
  */
-class BrowserRouter extends React.Component {
-  history = createHistory(this.props);
-
-  render() {
-    return <Router history={this.history} children={this.props.children} />;
-  }
+function BrowserRouter(props) {
+  return (
+    <Lifecycle>
+      {instance => {
+        if (!instance.history) {
+          warning(
+            !props.history,
+            "<BrowserRouter> ignores the history prop. To use a custom history, " +
+              "use `import { Router }` instead of `import { BrowserRouter as Router }`."
+          );
+          instance.history = createHistory(props);
+        }
+        return <Router history={instance.history} children={props.children} />;
+      }}
+    </Lifecycle>
+  );
 }
 
 if (__DEV__) {
@@ -22,14 +32,6 @@ if (__DEV__) {
     forceRefresh: PropTypes.bool,
     getUserConfirmation: PropTypes.func,
     keyLength: PropTypes.number
-  };
-
-  BrowserRouter.prototype.componentDidMount = function() {
-    warning(
-      !this.props.history,
-      "<BrowserRouter> ignores the history prop. To use a custom history, " +
-        "use `import { Router }` instead of `import { BrowserRouter as Router }`."
-    );
   };
 }
 

--- a/packages/react-router-dom/modules/HashRouter.js
+++ b/packages/react-router-dom/modules/HashRouter.js
@@ -1,5 +1,5 @@
 import React from "react";
-import { Router } from "react-router";
+import { Router, __Lifecycle as Lifecycle } from "react-router";
 import { createHashHistory as createHistory } from "history";
 import PropTypes from "prop-types";
 import warning from "tiny-warning";
@@ -7,12 +7,22 @@ import warning from "tiny-warning";
 /**
  * The public API for a <Router> that uses window.location.hash.
  */
-class HashRouter extends React.Component {
-  history = createHistory(this.props);
-
-  render() {
-    return <Router history={this.history} children={this.props.children} />;
-  }
+function HashRouter(props) {
+  return (
+    <Lifecycle>
+      {instance => {
+        if (!instance.history) {
+          instance.history = createHistory(props);
+          warning(
+            !props.history,
+            "<HashRouter> ignores the history prop. To use a custom history, " +
+              "use `import { Router }` instead of `import { HashRouter as Router }`."
+          );
+        }
+        return <Router history={instance.history} children={props.children} />;
+      }}
+    </Lifecycle>
+  );
 }
 
 if (__DEV__) {
@@ -21,14 +31,6 @@ if (__DEV__) {
     children: PropTypes.node,
     getUserConfirmation: PropTypes.func,
     hashType: PropTypes.oneOf(["hashbang", "noslash", "slash"])
-  };
-
-  HashRouter.prototype.componentDidMount = function() {
-    warning(
-      !this.props.history,
-      "<HashRouter> ignores the history prop. To use a custom history, " +
-        "use `import { Router }` instead of `import { HashRouter as Router }`."
-    );
   };
 }
 

--- a/packages/react-router-dom/modules/Link.js
+++ b/packages/react-router-dom/modules/Link.js
@@ -11,50 +11,48 @@ function isModifiedEvent(event) {
 /**
  * The public API for rendering a history-aware <a>.
  */
-class Link extends React.Component {
-  handleClick(event, history) {
-    if (this.props.onClick) this.props.onClick(event);
+function Link(props) {
+  const { innerRef, replace, to, ...rest } = props; // eslint-disable-line no-unused-vars
+
+  const handleClick = (event, history) => {
+    if (props.onClick) props.onClick(event);
 
     if (
       !event.defaultPrevented && // onClick prevented default
       event.button === 0 && // ignore everything but left clicks
-      (!this.props.target || this.props.target === "_self") && // let browser handle "target=_blank" etc.
+      (!props.target || props.target === "_self") && // let browser handle "target=_blank" etc.
       !isModifiedEvent(event) // ignore clicks with modifier keys
     ) {
       event.preventDefault();
 
-      const method = this.props.replace ? history.replace : history.push;
+      const method = props.replace ? history.replace : history.push;
 
-      method(this.props.to);
+      method(props.to);
     }
-  }
+  };
 
-  render() {
-    const { innerRef, replace, to, ...rest } = this.props; // eslint-disable-line no-unused-vars
+  return (
+    <RouterContext.Consumer>
+      {context => {
+        invariant(context, "You should not use <Link> outside a <Router>");
 
-    return (
-      <RouterContext.Consumer>
-        {context => {
-          invariant(context, "You should not use <Link> outside a <Router>");
+        const location =
+          typeof to === "string"
+            ? createLocation(to, null, null, context.location)
+            : to;
+        const href = location ? context.history.createHref(location) : "";
 
-          const location =
-            typeof to === "string"
-              ? createLocation(to, null, null, context.location)
-              : to;
-          const href = location ? context.history.createHref(location) : "";
-
-          return (
-            <a
-              {...rest}
-              onClick={event => this.handleClick(event, context.history)}
-              href={href}
-              ref={innerRef}
-            />
-          );
-        }}
-      </RouterContext.Consumer>
-    );
-  }
+        return (
+          <a
+            {...rest}
+            onClick={event => handleClick(event, context.history)}
+            href={href}
+            ref={innerRef}
+          />
+        );
+      }}
+    </RouterContext.Consumer>
+  );
 }
 
 if (__DEV__) {

--- a/packages/react-router/.size-snapshot.json
+++ b/packages/react-router/.size-snapshot.json
@@ -1,26 +1,26 @@
 {
   "esm/react-router.js": {
-    "bundled": 25084,
-    "minified": 14401,
-    "gzipped": 3810,
+    "bundled": 24866,
+    "minified": 14300,
+    "gzipped": 3838,
     "treeshaked": {
       "rollup": {
-        "code": 3293,
+        "code": 3281,
         "import_statements": 472
       },
       "webpack": {
-        "code": 4688
+        "code": 4674
       }
     }
   },
   "umd/react-router.js": {
-    "bundled": 100318,
-    "minified": 35960,
-    "gzipped": 11389
+    "bundled": 100086,
+    "minified": 35868,
+    "gzipped": 11414
   },
   "umd/react-router.min.js": {
-    "bundled": 63802,
-    "minified": 22345,
-    "gzipped": 7896
+    "bundled": 63645,
+    "minified": 22320,
+    "gzipped": 7910
   }
 }

--- a/packages/react-router/.size-snapshot.json
+++ b/packages/react-router/.size-snapshot.json
@@ -1,26 +1,26 @@
 {
   "esm/react-router.js": {
-    "bundled": 24866,
-    "minified": 14300,
-    "gzipped": 3838,
+    "bundled": 24405,
+    "minified": 14071,
+    "gzipped": 3851,
     "treeshaked": {
       "rollup": {
-        "code": 3281,
-        "import_statements": 472
+        "code": 3244,
+        "import_statements": 447
       },
       "webpack": {
-        "code": 4674
+        "code": 4660
       }
     }
   },
   "umd/react-router.js": {
-    "bundled": 100086,
-    "minified": 35868,
-    "gzipped": 11414
+    "bundled": 97084,
+    "minified": 35655,
+    "gzipped": 11430
   },
   "umd/react-router.min.js": {
-    "bundled": 63645,
-    "minified": 22320,
-    "gzipped": 7910
+    "bundled": 61532,
+    "minified": 22136,
+    "gzipped": 7906
   }
 }

--- a/packages/react-router/.size-snapshot.json
+++ b/packages/react-router/.size-snapshot.json
@@ -1,8 +1,8 @@
 {
   "esm/react-router.js": {
-    "bundled": 25037,
-    "minified": 14355,
-    "gzipped": 3799,
+    "bundled": 25084,
+    "minified": 14401,
+    "gzipped": 3810,
     "treeshaked": {
       "rollup": {
         "code": 3293,
@@ -14,13 +14,13 @@
     }
   },
   "umd/react-router.js": {
-    "bundled": 100262,
-    "minified": 35923,
-    "gzipped": 11378
+    "bundled": 100318,
+    "minified": 35960,
+    "gzipped": 11389
   },
   "umd/react-router.min.js": {
-    "bundled": 63746,
-    "minified": 22308,
-    "gzipped": 7882
+    "bundled": 63802,
+    "minified": 22345,
+    "gzipped": 7896
   }
 }

--- a/packages/react-router/.size-snapshot.json
+++ b/packages/react-router/.size-snapshot.json
@@ -1,26 +1,26 @@
 {
   "esm/react-router.js": {
-    "bundled": 24405,
-    "minified": 14071,
-    "gzipped": 3851,
+    "bundled": 23704,
+    "minified": 13668,
+    "gzipped": 3735,
     "treeshaked": {
       "rollup": {
-        "code": 3244,
-        "import_statements": 447
+        "code": 3039,
+        "import_statements": 399
       },
       "webpack": {
-        "code": 4660
+        "code": 4467
       }
     }
   },
   "umd/react-router.js": {
-    "bundled": 97084,
-    "minified": 35655,
-    "gzipped": 11430
+    "bundled": 96369,
+    "minified": 35267,
+    "gzipped": 11332
   },
   "umd/react-router.min.js": {
-    "bundled": 61532,
-    "minified": 22136,
-    "gzipped": 7906
+    "bundled": 60887,
+    "minified": 21796,
+    "gzipped": 7802
   }
 }

--- a/packages/react-router/modules/Lifecycle.js
+++ b/packages/react-router/modules/Lifecycle.js
@@ -14,7 +14,7 @@ class Lifecycle extends React.Component {
   }
 
   render() {
-    return this.props.children(this);
+    return this.props.children ? this.props.children(this) : null;
   }
 }
 

--- a/packages/react-router/modules/Lifecycle.js
+++ b/packages/react-router/modules/Lifecycle.js
@@ -14,7 +14,7 @@ class Lifecycle extends React.Component {
   }
 
   render() {
-    return null;
+    return this.props.children(this);
   }
 }
 

--- a/packages/react-router/modules/MemoryRouter.js
+++ b/packages/react-router/modules/MemoryRouter.js
@@ -4,16 +4,27 @@ import { createMemoryHistory as createHistory } from "history";
 import warning from "tiny-warning";
 
 import Router from "./Router";
+import Lifecycle from "./Lifecycle";
 
 /**
  * The public API for a <Router> that stores location in memory.
  */
-class MemoryRouter extends React.Component {
-  history = createHistory(this.props);
-
-  render() {
-    return <Router history={this.history} children={this.props.children} />;
-  }
+function MemoryRouter(props) {
+  return (
+    <Lifecycle>
+      {instance => {
+        if (!instance.history) {
+          instance.history = createHistory(props);
+          warning(
+            !props.history,
+            "<MemoryRouter> ignores the history prop. To use a custom history, " +
+              "use `import { Router }` instead of `import { MemoryRouter as Router }`."
+          );
+        }
+        return <Router history={instance.history} children={props.children} />;
+      }}
+    </Lifecycle>
+  );
 }
 
 if (__DEV__) {
@@ -23,14 +34,6 @@ if (__DEV__) {
     getUserConfirmation: PropTypes.func,
     keyLength: PropTypes.number,
     children: PropTypes.node
-  };
-
-  MemoryRouter.prototype.componentDidMount = function() {
-    warning(
-      !this.props.history,
-      "<MemoryRouter> ignores the history prop. To use a custom history, " +
-        "use `import { Router }` instead of `import { MemoryRouter as Router }`."
-    );
   };
 }
 

--- a/packages/react-router/modules/Switch.js
+++ b/packages/react-router/modules/Switch.js
@@ -5,62 +5,70 @@ import warning from "tiny-warning";
 
 import RouterContext from "./RouterContext";
 import matchPath from "./matchPath";
+import Lifecycle from "./Lifecycle";
 
 /**
  * The public API for rendering the first <Route> that matches.
  */
-class Switch extends React.Component {
-  render() {
-    return (
-      <RouterContext.Consumer>
-        {context => {
-          invariant(context, "You should not use <Switch> outside a <Router>");
+function Switch(props) {
+  return (
+    <RouterContext.Consumer>
+      {context => {
+        invariant(context, "You should not use <Switch> outside a <Router>");
 
-          const location = this.props.location || context.location;
+        const location = props.location || context.location;
 
-          let element, match;
+        let element, match;
 
-          // We use React.Children.forEach instead of React.Children.toArray().find()
-          // here because toArray adds keys to all child elements and we do not want
-          // to trigger an unmount/remount for two <Route>s that render the same
-          // component at different URLs.
-          React.Children.forEach(this.props.children, child => {
-            if (match == null && React.isValidElement(child)) {
-              element = child;
+        // We use React.Children.forEach instead of React.Children.toArray().find()
+        // here because toArray adds keys to all child elements and we do not want
+        // to trigger an unmount/remount for two <Route>s that render the same
+        // component at different URLs.
+        React.Children.forEach(props.children, child => {
+          if (match == null && React.isValidElement(child)) {
+            element = child;
 
-              const path = child.props.path || child.props.from;
+            const path = child.props.path || child.props.from;
 
-              match = path
-                ? matchPath(location.pathname, { ...child.props, path })
-                : context.match;
+            match = path
+              ? matchPath(location.pathname, { ...child.props, path })
+              : context.match;
+          }
+        });
+        return (
+          <Lifecycle
+            location={props.location}
+            onUpdate={(instance, prevProps) => {
+              warning(
+                !(props.location && !prevProps.location),
+                '<Switch> elements should not change from uncontrolled to controlled (or vice versa). You initially used no "location" prop and then provided one on a subsequent render.'
+              );
+
+              warning(
+                !(!props.location && prevProps.location),
+                '<Switch> elements should not change from controlled to uncontrolled (or vice versa). You provided a "location" prop initially but omitted it on a subsequent render.'
+              );
+            }}
+          >
+            {() =>
+              match
+                ? React.cloneElement(element, {
+                    location,
+                    computedMatch: match
+                  })
+                : null
             }
-          });
-
-          return match
-            ? React.cloneElement(element, { location, computedMatch: match })
-            : null;
-        }}
-      </RouterContext.Consumer>
-    );
-  }
+          </Lifecycle>
+        );
+      }}
+    </RouterContext.Consumer>
+  );
 }
 
 if (__DEV__) {
   Switch.propTypes = {
     children: PropTypes.node,
     location: PropTypes.object
-  };
-
-  Switch.prototype.componentDidUpdate = function(prevProps) {
-    warning(
-      !(this.props.location && !prevProps.location),
-      '<Switch> elements should not change from uncontrolled to controlled (or vice versa). You initially used no "location" prop and then provided one on a subsequent render.'
-    );
-
-    warning(
-      !(!this.props.location && prevProps.location),
-      '<Switch> elements should not change from controlled to uncontrolled (or vice versa). You provided a "location" prop initially but omitted it on a subsequent render.'
-    );
   };
 }
 

--- a/packages/react-router/modules/index.js
+++ b/packages/react-router/modules/index.js
@@ -10,3 +10,4 @@ export { default as matchPath } from "./matchPath";
 export { default as withRouter } from "./withRouter";
 
 export { default as __RouterContext } from "./RouterContext";
+export { default as __Lifecycle } from "./Lifecycle";

--- a/packages/react-router/package-lock.json
+++ b/packages/react-router/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "react-router",
-	"version": "4.4.0-beta.5",
+	"version": "4.4.0-beta.6",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {


### PR DESCRIPTION
In this diff I converted all (except Router and Route) class components to functions with Lifecycle util.

As a result `react-router-dom` bundle is reduced with 1kB and the bundle with the following entry point is reduced from 16.5kB to 13.9kB.
```
import { Route } from 'react-router-dom';
console.log(Route);
```

Eye analyses of prettified result shows the following artifacts
- webpack runtime
- path-to-regexp
- create-react-context
- react-is
- Router.js
- matchPath.js
- Route.js
- RouterContext.js

So Route.js and Router.js are components which always appear in user code. There's no reason to treeshake them. All other modules are their dependencies.

v5 optimisation strategy
- remove create-react-context
- try to convert path-to-regexp to esm
- remove React.createContext checks in Route and Router
- convert Route and Router to function components

This should make project fully treeshakable and quite small.

What do you think guys? Will this work for you?

/cc @mjackson @billyjanitsch 