### PR TITLE
 Fix withRouter components being considered forwardRef types

### DIFF
--- a/packages/react-router/modules/__tests__/withRouter-test.js
+++ b/packages/react-router/modules/__tests__/withRouter-test.js
@@ -1,5 +1,6 @@
 import React from "react";
 import ReactDOM from "react-dom";
+import * as ReactIs from "react-is";
 import { MemoryRouter, StaticRouter, Route, withRouter } from "react-router";
 
 import renderStrict from "./utils/renderStrict";
@@ -154,4 +155,10 @@ describe("withRouter", () => {
     expect(typeof decorated.foo).toBe("function");
     expect(decorated.foo()).toBe("bar");
   });
+
+  it('does not allow ref forwarding', () => {
+    const WrappedComponent = React.forwardRef((props, ref) => <div {...props} ref={ref} />)
+    const Component = withRouter(WrappedComponent);
+    expect(ReactIs.isForwardRef(<Component />)).toBe(false);
+  })
 });

--- a/packages/react-router/package-lock.json
+++ b/packages/react-router/package-lock.json
@@ -5301,9 +5301,12 @@
 			}
 		},
 		"hoist-non-react-statics": {
-			"version": "2.5.5",
-			"resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-2.5.5.tgz",
-			"integrity": "sha512-rqcy4pJo55FTTLWt+bU8ukscqHeE/e9KWvsOW2b/a3afxQZhwkQdT1rPPCJ0rYXdj4vNcasY8zHTH+jF/qStxw=="
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.1.0.tgz",
+			"integrity": "sha512-MYcYuROh7SBM69xHGqXEwQqDux34s9tz+sCnxJmN18kgWh6JFdTw/5YdZtqsOdZJXddE/wUpCzfEdDrJj8p0Iw==",
+			"requires": {
+				"react-is": "^16.3.2"
+			}
 		},
 		"home-or-tmp": {
 			"version": "2.0.0",

--- a/packages/react-router/package.json
+++ b/packages/react-router/package.json
@@ -42,7 +42,7 @@
     "@babel/runtime": "^7.1.2",
     "create-react-context": "^0.2.2",
     "history": "^4.8.0-beta.0",
-    "hoist-non-react-statics": "^2.5.0",
+    "hoist-non-react-statics": "^3.1.0",
     "loose-envify": "^1.3.1",
     "path-to-regexp": "^1.7.0",
     "prop-types": "^15.6.2",


### PR DESCRIPTION
The fix was just a major bump of `hoist-non-react-statics` to include mridgway/hoist-non-react-statics#55. The breaking change was the hard dependency on `react-is` which is already included in `react-router`. Therefore this change is not breaking. As a side effect this will also prevent hoisting of [`contextType`].(https://reactjs.org/docs/context.html#classcontexttype)

The added test case will cover the change required for #6056.