### PR TITLE
NavLink.propTypes should extend Link.propTypes

### DIFF
--- a/packages/react-router-dom/.size-snapshot.json
+++ b/packages/react-router-dom/.size-snapshot.json
@@ -1,8 +1,8 @@
 {
   "esm/react-router-dom.js": {
-    "bundled": 8022,
-    "minified": 4817,
-    "gzipped": 1612,
+    "bundled": 8025,
+    "minified": 4824,
+    "gzipped": 1611,
     "treeshaked": {
       "rollup": {
         "code": 453,
@@ -14,9 +14,9 @@
     }
   },
   "umd/react-router-dom.js": {
-    "bundled": 161248,
-    "minified": 57434,
-    "gzipped": 16466
+    "bundled": 161252,
+    "minified": 57435,
+    "gzipped": 16465
   },
   "umd/react-router-dom.min.js": {
     "bundled": 97926,

--- a/packages/react-router-dom/modules/NavLink.js
+++ b/packages/react-router-dom/modules/NavLink.js
@@ -70,6 +70,7 @@ if (__DEV__) {
   ]);
 
   NavLink.propTypes = {
+    ...Link.propTypes,
     "aria-current": ariaCurrentType,
     activeClassName: PropTypes.string,
     activeStyle: PropTypes.object,
@@ -78,8 +79,7 @@ if (__DEV__) {
     isActive: PropTypes.func,
     location: PropTypes.object,
     strict: Route.propTypes.strict,
-    style: PropTypes.object,
-    to: Link.propTypes.to
+    style: PropTypes.object
   };
 }
 


### PR DESCRIPTION
Since `NavLink` returns a wrapped `Link` component and passed all of its props to the `Link`, this should also be reflected in `NavLink.propTypes`.