### PR TITLE
Added RefObject as valid Link innerRef

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,9 +1,3 @@
-## [Unreleased]
-
-- Add `React.createRef()` as valid for `Link`'s `innerRef` prop ([#6567] by @gcangussu)
-
-[#6567]: https://github.com/ReactTraining/react-router/pull/6567
-
 ## [v4.3.0](https://github.com/ReactTraining/react-router/compare/v4.2.0...v4.3.0)
 
 > Jun 6, 2018

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,9 @@
+## [Unreleased]
+
+- Add `React.createRef()` as valid for `Link`'s `innerRef` prop ([#6567] by @gcangussu)
+
+[#6567]: https://github.com/ReactTraining/react-router/pull/6567
+
 ## [v4.3.0](https://github.com/ReactTraining/react-router/compare/v4.2.0...v4.3.0)
 
 > Jun 6, 2018

--- a/packages/react-router-dom/.size-snapshot.json
+++ b/packages/react-router-dom/.size-snapshot.json
@@ -1,8 +1,8 @@
 {
   "esm/react-router-dom.js": {
-    "bundled": 8025,
-    "minified": 4824,
-    "gzipped": 1611,
+    "bundled": 8092,
+    "minified": 4881,
+    "gzipped": 1633,
     "treeshaked": {
       "rollup": {
         "code": 453,
@@ -14,9 +14,9 @@
     }
   },
   "umd/react-router-dom.js": {
-    "bundled": 161252,
-    "minified": 57435,
-    "gzipped": 16465
+    "bundled": 161325,
+    "minified": 57478,
+    "gzipped": 16483
   },
   "umd/react-router-dom.min.js": {
     "bundled": 97926,

--- a/packages/react-router-dom/docs/api/Link.md
+++ b/packages/react-router-dom/docs/api/Link.md
@@ -56,6 +56,16 @@ const refCallback = node => {
 <Link to="/" innerRef={refCallback} />
 ```
 
+## innerRef: RefObject
+
+Get the underlying `ref` of the component with `React.createRef()`
+
+```jsx
+const anchorRef = React.createRef()
+
+<Link to="/" innerRef={anchorRef} />
+```
+
 ## others
 
 You can also pass props you'd like to be on the `<a>` such as a `title`, `id`, `className`, etc.

--- a/packages/react-router-dom/modules/Link.js
+++ b/packages/react-router-dom/modules/Link.js
@@ -59,7 +59,11 @@ class Link extends React.Component {
 
 if (__DEV__) {
   const toType = PropTypes.oneOfType([PropTypes.string, PropTypes.object]);
-  const innerRefType = PropTypes.oneOfType([PropTypes.string, PropTypes.func]);
+  const innerRefType = PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.func,
+    PropTypes.shape({ current: PropTypes.instanceOf(Element) })
+  ]);
 
   Link.propTypes = {
     innerRef: innerRefType,

--- a/packages/react-router-dom/modules/__tests__/Link-test.js
+++ b/packages/react-router-dom/modules/__tests__/Link-test.js
@@ -91,7 +91,7 @@ describe("A <Link>", () => {
     });
   });
 
-  it("exposes its ref via an innerRef prop", done => {
+  it("exposes its ref via an innerRef callback prop", done => {
     function refCallback(n) {
       if (n) {
         expect(n.tagName).toEqual("A");
@@ -102,6 +102,29 @@ describe("A <Link>", () => {
     renderStrict(
       <MemoryRouter>
         <Link to="/" innerRef={refCallback}>
+          link
+        </Link>
+      </MemoryRouter>,
+      node
+    );
+  });
+
+  it("exposes its ref via an innerRef RefObject prop", done => {
+    const refObject = {
+      get current() {
+        return null;
+      },
+      set current(n) {
+        if (n) {
+          expect(n.tagName).toEqual("A");
+          done();
+        }
+      }
+    };
+
+    renderStrict(
+      <MemoryRouter>
+        <Link to="/" innerRef={refObject}>
           link
         </Link>
       </MemoryRouter>,


### PR DESCRIPTION
When using [`React.createRef()`](https://reactjs.org/docs/react-api.html#reactcreateref) with the `innerRef` prop of a `Link`, a false positive prop-types error appears. But it works perfectly.

This PR adds the shape of a `RefObject` (name for `React.createRef()` return type) as a valid prop type for `Link`'s `innerRef`.