### PR TITLE
Fixing Acceptable <Route> Prop Type in Docs

### DIFF
--- a/packages/react-router/docs/api/Route.md
+++ b/packages/react-router/docs/api/Route.md
@@ -133,16 +133,12 @@ This could also be useful for animations:
 
 **Warning:** Both `<Route component>` and `<Route render>` take precedence over `<Route children>` so don't use more than one in the same `<Route>`.
 
-## path: string | string[]
+## path: string
 
-Any valid URL path or array of paths that [`path-to-regexp@^1.7.0`](https://github.com/pillarjs/path-to-regexp/tree/v1.7.0) understands.
+Any valid URL path that [`path-to-regexp@^1.7.0`](https://github.com/pillarjs/path-to-regexp/tree/v1.7.0) understands.
 
 ```jsx
 <Route path="/users/:id" component={User} />
-```
-
-```jsx
-<Route path={["/users/:id", "/profile/:id"]} component={User} />
 ```
 
 Routes without a `path` _always_ match.


### PR DESCRIPTION
`<Route>` does not currently accept an array of paths, only a single one.

Also acknowledged by a @pshrmn: https://github.com/ReactTraining/react-router/issues/6270#issuecomment-408534917

cc @mjackson 