### PR TITLE
Add support for exact route matching in `matchRoutes`

### DIFF
--- a/packages/react-router-config/.size-snapshot.json
+++ b/packages/react-router-config/.size-snapshot.json
@@ -1,8 +1,8 @@
 {
   "esm/react-router-config.js": {
-    "bundled": 1467,
-    "minified": 765,
-    "gzipped": 384,
+    "bundled": 1934,
+    "minified": 982,
+    "gzipped": 522,
     "treeshaked": {
       "rollup": {
         "code": 78,
@@ -14,13 +14,13 @@
     }
   },
   "umd/react-router-config.js": {
-    "bundled": 2457,
-    "minified": 1163,
-    "gzipped": 588
+    "bundled": 2948,
+    "minified": 1380,
+    "gzipped": 712
   },
   "umd/react-router-config.min.js": {
-    "bundled": 2457,
-    "minified": 1163,
-    "gzipped": 588
+    "bundled": 2948,
+    "minified": 1380,
+    "gzipped": 712
   }
 }

--- a/packages/react-router-config/modules/__tests__/matchRoutes-test.js
+++ b/packages/react-router-config/modules/__tests__/matchRoutes-test.js
@@ -88,3 +88,57 @@ describe("pathless routes", () => {
     });
   });
 });
+
+describe("exact matching", () => {
+  it("matches only exact routes", () => {
+    const routes = [
+      {
+        path: "/"
+      },
+      {
+        path: "/anaheim",
+        exact: true
+      }
+    ];
+
+    const branch = matchRoutes(routes, "/anaheim", true);
+    expect(branch.length).toEqual(1);
+    expect(branch[0].route).toEqual(routes[1]);
+  });
+
+  it("fails when no exact route is found", () => {
+    const routes = [
+      {
+        path: "/"
+      }
+    ];
+
+    const branch = matchRoutes(routes, "/anaheim", true);
+    expect(branch.length).toEqual(0);
+  });
+
+  it("matches the first exact route", () => {
+    const routes = [
+      {
+        path: "/"
+      },
+      {
+        path: "/pepper",
+        routes: [
+          {
+            path: "/pepper/jalepeno",
+            exact: true
+          }
+        ]
+      },
+      {
+        path: "/pepper/jalepeno",
+        exact: true
+      }
+    ];
+
+    const branch = matchRoutes(routes, "/pepper/jalepeno", true);
+    expect(branch.length).toEqual(2);
+    expect(branch[0].route).toEqual(routes[1]);
+  });
+});

--- a/packages/react-router-config/modules/matchRoutes.js
+++ b/packages/react-router-config/modules/matchRoutes.js
@@ -1,25 +1,31 @@
 import { matchPath, Router } from "react-router";
 
-function matchRoutes(routes, pathname, /*not public API*/ branch = []) {
-  routes.some(route => {
+function matchRoutes(
+  routes,
+  pathname,
+  exact = false,
+  /*not public API*/ parent = []
+) {
+  for (const route of routes) {
     const match = route.path
       ? matchPath(pathname, route)
-      : branch.length
-        ? branch[branch.length - 1].match // use parent match
+      : parent.length
+        ? parent[parent.length - 1].match // use parent match
         : Router.computeRootMatch(pathname); // use default "root" match
 
     if (match) {
-      branch.push({ route, match });
+      const node = [...parent, { route, match }];
+      const res =
+        (route.routes && matchRoutes(route.routes, pathname, exact, node)) ||
+        node;
 
-      if (route.routes) {
-        matchRoutes(route.routes, pathname, branch);
+      if (!exact || (res && res[res.length - 1].match.isExact)) {
+        return res;
       }
     }
+  }
 
-    return match;
-  });
-
-  return branch;
+  return parent;
 }
 
 export default matchRoutes;


### PR DESCRIPTION
Hi,

I would like to see support for matching only exact routes in `matchRoutes` (react-router-config), which works similar to other static routing libraries (such as Angular) and allows for functionality such as pathless routes for layout components. Old behavior can still be obtained by using wildcards.

An example use-case might be:
```js
[
   {
       component: DefaultLayout,
       routes: [
            {
                path: "/home",
                component: Home
                exact: true,
            },
            {
                path: "/pepper/*", // Obtain non-exact matching behavior
                component: Pepper,
            }
       ],
   },
   {
       component: AlternativeLayout,
       routes: [
             {
                  path: "/login",
                  component: Login
                  exact: true,
             }
       ]
   }
]
```
When using non-exact matching, this route map will always resolve to first route (or one of its children). Exact matching allows it to also resolve the second route.

Issues #5939 and #5429 are related.

I have provided a sample implementation of this feature which adds a parameter to `matchRoutes` for only matching exact routes.