### PR TITLE
Refactor `renderRoutes` to use `matchRoutes`

### DIFF
--- a/packages/react-router-config/modules/renderRoutes.js
+++ b/packages/react-router-config/modules/renderRoutes.js
@@ -1,26 +1,34 @@
 import React from "react";
-import { Switch, Route } from "react-router";
+import { Route } from "react-router";
+import matchRoutes from "./matchRoutes";
 
-function renderRoutes(routes, extraProps = {}, switchProps = {}) {
-  return routes ? (
-    <Switch {...switchProps}>
-      {routes.map((route, i) => (
-        <Route
-          key={route.key || i}
-          path={route.path}
-          exact={route.exact}
-          strict={route.strict}
-          render={props =>
+function renderRoutes(routes, extraProps = {}) {
+  if (!routes) {
+    return null;
+  }
+
+  return (
+    <Route
+      render={({ location }) => {
+        const branches = matchRoutes(routes, location.pathname);
+
+        return branches.reduceRight(
+          (children, { route, match }) =>
             route.render ? (
-              route.render({ ...props, ...extraProps, route: route })
+              route.render({ ...extraProps, route, match, children })
             ) : (
-              <route.component {...props} {...extraProps} route={route} />
-            )
-          }
-        />
-      ))}
-    </Switch>
-  ) : null;
+              <route.component
+                {...extraProps}
+                route={route}
+                match={match}
+                children={children}
+              />
+            ),
+          null
+        );
+      }}
+    />
+  );
 }
 
 export default renderRoutes;


### PR DESCRIPTION
Hi again,

In relation to #6575 and as suggested in #5939, I would like to update `renderRoutes` to use `matchRoutes` instead of the `Switch` component.

This pull request contains an implementation of such an approach and also updates `renderRoutes` to render the whole tree (instead of only the first level), which removes the need for `renderRoutes` calls in child routes. 

I have left the tests as it is for now, until it clear what the behavior of `renderRoutes` should be.
- [ ] Tests
- [ ] Documentation