### PR TITLE
Proposal: link recibe a function as "to" prop

### DIFF
--- a/packages/react-router-dom/modules/Link.js
+++ b/packages/react-router-dom/modules/Link.js
@@ -13,8 +13,12 @@ function isModifiedEvent(event) {
  */
 class Link extends React.Component {
   handleClick(event, history) {
-    if (this.props.onClick) this.props.onClick(event);
 
+    if (this.props.onClick) this.props.onClick(event);
+    
+    const {to} = this.props;
+    if (typeof to === 'function') to(event);
+    
     if (
       !event.defaultPrevented && // onClick prevented default
       event.button === 0 && // ignore everything but left clicks


### PR DESCRIPTION
Add support to send a function as "to" prop (like onClick but at the same prop)

```jsx
return <Link to={pathOrFunction} />
```
