### PR TITLE
change from ariaCurrent to aria-current

### DIFF
--- a/packages/react-router-dom/docs/api/NavLink.md
+++ b/packages/react-router-dom/docs/api/NavLink.md
@@ -79,7 +79,7 @@ const oddEvent = (match, location) => {
 The [`isActive`](#isactive-func) compares the current history location (usually the current browser URL).
 To compare to a different location, a [`location`](../../../react-router/docs/api/location.md) can be passed.
 
-## ariaCurrent: string
+## aria-current: string
 
 The value of the `aria-current` attribute used on an active link. Available values are:
 


### PR DESCRIPTION
Based on this line of code, we need either update the code or the doc.
https://github.com/ReactTraining/react-router/blob/4dc6e16b447191aedcac557a81ac26c307a0d9c7/packages/react-router-dom/modules/NavLink.js#L15

I updated the document, since all **aria-*** HTML attributes are fully supported in JSX based on
https://reactjs.org/docs/accessibility.html#wai-aria