### PR TITLE
Example references deprecated API

### DIFF
--- a/packages/react-router/docs/api/Router.md
+++ b/packages/react-router/docs/api/Router.md
@@ -13,7 +13,7 @@ synchronize a custom history with a state management lib like Redux or Mobx. Not
 
 ```jsx
 import { Router } from "react-router";
-import createBrowserHistory from "history/createBrowserHistory";
+import { createBrowserHistory } from "history";
 
 const history = createBrowserHistory()
 
@@ -27,7 +27,7 @@ const history = createBrowserHistory()
 A [`history`](https://github.com/ReactTraining/history) object to use for navigation.
 
 ```jsx
-import createBrowserHistory from "history/createBrowserHistory";
+import { createBrowserHistory } from "history";
 
 const customHistory = createBrowserHistory();
 


### PR DESCRIPTION
The example showing how to use a custom history object is referencing an outdated import path. Change it to a supported one.

Also see https://github.com/ReactTraining/history/blob/465288b91859244d401103c079c058c0a2be5cb0/createBrowserHistory.js#L2