### PR TITLE
Implemented Match component.

### DIFF
--- a/packages/react-router-dom/.size-snapshot.json
+++ b/packages/react-router-dom/.size-snapshot.json
@@ -1,26 +1,26 @@
 {
-  "esm/react-router-dom.js": {
-    "bundled": 8076,
-    "minified": 4865,
-    "gzipped": 1626,
-    "treeshaked": {
-      "rollup": {
-        "code": 453,
-        "import_statements": 417
-      },
-      "webpack": {
-        "code": 1661
-      }
-    }
-  },
-  "umd/react-router-dom.js": {
-    "bundled": 162079,
-    "minified": 57806,
-    "gzipped": 16662
-  },
-  "umd/react-router-dom.min.js": {
-    "bundled": 97956,
-    "minified": 34459,
-    "gzipped": 10224
-  }
+	"esm/react-router-dom.js": {
+		"bundled": 8076,
+		"minified": 4865,
+		"gzipped": 1626,
+		"treeshaked": {
+			"rollup": {
+				"code": 453,
+				"import_statements": 417
+			},
+			"webpack": {
+				"code": 1661
+			}
+		}
+	},
+	"umd/react-router-dom.js": {
+		"bundled": 162079,
+		"minified": 57806,
+		"gzipped": 16662
+	},
+	"umd/react-router-dom.min.js": {
+		"bundled": 97956,
+		"minified": 34459,
+		"gzipped": 10224
+	}
 }

--- a/packages/react-router/.size-snapshot.json
+++ b/packages/react-router/.size-snapshot.json
@@ -1,26 +1,26 @@
 {
   "esm/react-router.js": {
-    "bundled": 23136,
-    "minified": 13099,
-    "gzipped": 3654,
+    "bundled": 26022,
+    "minified": 14892,
+    "gzipped": 3778,
     "treeshaked": {
       "rollup": {
-        "code": 2267,
+        "code": 2279,
         "import_statements": 465
       },
       "webpack": {
-        "code": 3630
+        "code": 3644
       }
     }
   },
   "umd/react-router.js": {
-    "bundled": 102232,
-    "minified": 36232,
-    "gzipped": 11519
+    "bundled": 104962,
+    "minified": 37615,
+    "gzipped": 11624
   },
   "umd/react-router.min.js": {
-    "bundled": 63839,
-    "minified": 22264,
-    "gzipped": 7893
+    "bundled": 65397,
+    "minified": 22820,
+    "gzipped": 7949
   }
 }

--- a/packages/react-router/modules/Match.js
+++ b/packages/react-router/modules/Match.js
@@ -55,6 +55,9 @@ class Match extends React.Component {
             }
           }
 
+          if (children === null) {
+            return null;
+          }
           return (
             <RouterContext.Provider value={props}>
               {children}

--- a/packages/react-router/modules/Match.js
+++ b/packages/react-router/modules/Match.js
@@ -1,0 +1,95 @@
+import React from "react";
+import PropTypes from "prop-types";
+import warning from "tiny-warning";
+import RouterContext from "./RouterContext";
+import matchPath from "./matchPath";
+
+/**
+ * The public API for matching a route and providing that match to children.
+ */
+class Match extends React.Component {
+  render() {
+    return (
+      <RouterContext.Consumer>
+        {context => {
+          if (!context) {
+            throw new Error(
+              __DEV__
+                ? "You should not use <Match> outside a <Router>"
+                : "Invariant failed"
+            );
+          }
+          const location = this.props.location || context.location;
+          let match = this.props.computedMatch
+            ? this.props.computedMatch // <Switch> already computed the match for us
+            : this.props.path
+              ? matchPath(location.pathname, this.props)
+              : context.match;
+
+          const props = { ...context, location, match };
+
+          let { children } = this.props;
+
+          // Preact uses an empty array as children by
+          // default, so use null if that's the case.
+          if (Array.isArray(children) && children.length === 0) {
+            children = null;
+          }
+
+          if (typeof children === "function") {
+            children = children(props);
+
+            if (children === undefined) {
+              if (__DEV__) {
+                const { path } = this.props;
+
+                warning(
+                  false,
+                  "You returned `undefined` from the `children` function of " +
+                    `<Match${path ? ` path="${path}"` : ""}>, but you ` +
+                    "should have returned a React element or `null`"
+                );
+              }
+
+              children = null;
+            }
+          }
+
+          return (
+            <RouterContext.Provider value={props}>
+              {children}
+            </RouterContext.Provider>
+          );
+        }}
+      </RouterContext.Consumer>
+    );
+  }
+}
+
+if (__DEV__) {
+  Match.propTypes = {
+    children: PropTypes.oneOfType([PropTypes.func, PropTypes.node]),
+    exact: PropTypes.bool,
+    location: PropTypes.object,
+    path: PropTypes.oneOfType([
+      PropTypes.string,
+      PropTypes.arrayOf(PropTypes.string)
+    ]),
+    sensitive: PropTypes.bool,
+    strict: PropTypes.bool
+  };
+
+  Match.prototype.componentDidUpdate = function(prevProps) {
+    warning(
+      !(this.props.location && !prevProps.location),
+      '<Match> elements should not change from uncontrolled to controlled (or vice versa). You initially used no "location" prop and then provided one on a subsequent render.'
+    );
+
+    warning(
+      !(!this.props.location && prevProps.location),
+      '<Match> elements should not change from controlled to uncontrolled (or vice versa). You provided a "location" prop initially but omitted it on a subsequent render.'
+    );
+  };
+}
+
+export default Match;

--- a/packages/react-router/modules/Match.js
+++ b/packages/react-router/modules/Match.js
@@ -53,6 +53,17 @@ class Match extends React.Component {
 
               children = null;
             }
+          } else if (!!children) {
+            return React.Children.map(children, child => {
+              if (
+                React.isValidElement(child) &&
+                typeof child.type !== "string"
+              ) {
+                return React.cloneElement(child, props);
+              } else {
+                return child;
+              }
+            });
           }
 
           if (children === null) {

--- a/packages/react-router/modules/__tests__/Match-test.js
+++ b/packages/react-router/modules/__tests__/Match-test.js
@@ -243,6 +243,63 @@ describe("A <Match>", () => {
       });
     });
 
+    describe("that is a functional component react child", () => {
+      it("receives { history, location, match } props", () => {
+        const history = createHistory();
+        let props = null;
+
+        const PropChecker = p => {
+          props = p;
+          return null;
+        };
+
+        renderStrict(
+          <Router history={history}>
+            <Match path="/">
+              <PropChecker />
+            </Match>
+          </Router>,
+          node
+        );
+
+        expect(props).not.toBe(null);
+        expect(props.history).toBe(history);
+        expect(typeof props.location).toBe("object");
+        expect(typeof props.match).toBe("object");
+      });
+    });
+
+    describe("that is a class component react child", () => {
+      it("receives { history, location, match } props", () => {
+        const history = createHistory();
+        let props = null;
+
+        class PropChecker extends React.Component {
+          componentDidMount() {
+            props = this.props;
+          }
+
+          render() {
+            return null;
+          }
+        }
+
+        renderStrict(
+          <Router history={history}>
+            <Match path="/">
+              <PropChecker />
+            </Match>
+          </Router>,
+          node
+        );
+
+        expect(props).not.toBe(null);
+        expect(props.history).toBe(history);
+        expect(typeof props.location).toBe("object");
+        expect(typeof props.match).toBe("object");
+      });
+    });
+
     describe("that is a function", () => {
       it("receives { history, location, match } props", () => {
         const history = createHistory();

--- a/packages/react-router/modules/__tests__/Match-test.js
+++ b/packages/react-router/modules/__tests__/Match-test.js
@@ -1,0 +1,286 @@
+import React from "react";
+import ReactDOM from "react-dom";
+import { createMemoryHistory as createHistory } from "history";
+import { MemoryRouter, Router, Match } from "react-router";
+
+import renderStrict from "./utils/renderStrict";
+
+describe("A <Match>", () => {
+  const node = document.createElement("div");
+
+  afterEach(() => {
+    ReactDOM.unmountComponentAtNode(node);
+  });
+
+  describe("without a <Router>", () => {
+    it("throws an error", () => {
+      jest.spyOn(console, "error").mockImplementation(() => {});
+
+      expect(() => {
+        renderStrict(<Match />, node);
+      }).toThrow(/You should not use <Match> outside a <Router>/);
+    });
+  });
+
+  it("renders when it matches", () => {
+    const text = "cupcakes";
+
+    renderStrict(
+      <MemoryRouter initialEntries={["/cupcakes"]}>
+        <Match path="/cupcakes">
+          {" "}
+          <h1>{text}</h1>{" "}
+        </Match>
+      </MemoryRouter>,
+      node
+    );
+
+    expect(node.innerHTML).toContain(text);
+  });
+
+  it("also renders when it does not match", () => {
+    const text = "bubblegum";
+
+    renderStrict(
+      <MemoryRouter initialEntries={["/bunnies"]}>
+        <Match path="/flowers">
+          {" "}
+          <h1>{text}</h1>}{" "}
+        </Match>
+      </MemoryRouter>,
+      node
+    );
+
+    expect(node.innerHTML).toContain(text);
+  });
+
+  it("matches using nextContext when updating", () => {
+    const history = createHistory({
+      initialEntries: ["/sushi/california"]
+    });
+
+    renderStrict(
+      <Router history={history}>
+        <Match path="/sushi/:roll">{({ match }) => <h1>{match.url}</h1>}</Match>
+      </Router>,
+      node
+    );
+
+    history.push("/sushi/spicy-tuna");
+
+    expect(node.innerHTML).toContain("/sushi/spicy-tuna");
+  });
+
+  describe("with dynamic segments in the path", () => {
+    it("decodes them", () => {
+      renderStrict(
+        <MemoryRouter initialEntries={["/a%20dynamic%20segment"]}>
+          <Match path="/:id">{({ match }) => <h1>{match.params.id}</h1>}</Match>
+        </MemoryRouter>,
+        node
+      );
+
+      expect(node.innerHTML).toContain("a dynamic segment");
+    });
+  });
+
+  describe("with an array of paths", () => {
+    it("matches the first provided path", () => {
+      const node = document.createElement("div");
+      ReactDOM.render(
+        <MemoryRouter initialEntries={["/hello"]}>
+          <Match path={["/hello", "/world"]}>
+            {() => <div>Hello World</div>}
+          </Match>
+        </MemoryRouter>,
+        node
+      );
+
+      expect(node.innerHTML).toContain("Hello World");
+    });
+
+    it("matches other provided paths", () => {
+      const node = document.createElement("div");
+      ReactDOM.render(
+        <MemoryRouter initialEntries={["/other", "/world"]} initialIndex={1}>
+          <Match path={["/hello", "/world"]}>
+            {() => <div>Hello World</div>}
+          </Match>
+        </MemoryRouter>,
+        node
+      );
+
+      expect(node.innerHTML).toContain("Hello World");
+    });
+
+    it("provides the matched path as a string", () => {
+      const node = document.createElement("div");
+      ReactDOM.render(
+        <MemoryRouter initialEntries={["/other", "/world"]} initialIndex={1}>
+          <Match path={["/hello", "/world"]}>
+            {({ match }) => <div>{match.path}</div>}
+          </Match>
+        </MemoryRouter>,
+        node
+      );
+
+      expect(node.innerHTML).toContain("/world");
+    });
+
+    it("doesn't remount when moving from one matching path to another", () => {
+      const node = document.createElement("div");
+      const history = createHistory();
+      const mount = jest.fn();
+      class MatchedRoute extends React.Component {
+        componentWillMount() {
+          mount();
+        }
+
+        render() {
+          return <div>Hello World</div>;
+        }
+      }
+      history.push("/hello");
+      ReactDOM.render(
+        <Router history={history}>
+          <Match path={["/hello", "/world"]}>
+            <MatchedRoute />
+          </Match>
+        </Router>,
+        node
+      );
+
+      expect(mount).toHaveBeenCalledTimes(1);
+      expect(node.innerHTML).toContain("Hello World");
+
+      history.push("/world/somewhere/else");
+
+      expect(mount).toHaveBeenCalledTimes(1);
+      expect(node.innerHTML).toContain("Hello World");
+    });
+  });
+
+  describe("with a unicode path", () => {
+    it("is able to match", () => {
+      renderStrict(
+        <MemoryRouter initialEntries={["/パス名"]}>
+          <Match path="/パス名">{({ match }) => <h1> {match.url} </h1>}</Match>
+        </MemoryRouter>,
+        node
+      );
+
+      expect(node.innerHTML).toContain("/パス名");
+    });
+  });
+
+  describe("with escaped special characters in the path", () => {
+    it("is able to match", () => {
+      renderStrict(
+        <MemoryRouter initialEntries={["/pizza (1)"]}>
+          <Match path="/pizza \(1\)">
+            {({ match }) => <h1>{match.url}</h1>}
+          </Match>
+          />
+        </MemoryRouter>,
+        node
+      );
+
+      expect(node.innerHTML).toContain("/pizza (1)");
+    });
+  });
+
+  describe("the `location` prop", () => {
+    it("overrides `context.location`", () => {
+      const text = "bubblegum";
+
+      renderStrict(
+        <MemoryRouter initialEntries={["/cupcakes"]}>
+          <Match location={{ pathname: "/bubblegum" }} path="/bubblegum">
+            {({ match }) => <h1>{match ? text : null}</h1>}
+          </Match>
+        </MemoryRouter>,
+        node
+      );
+
+      expect(node.innerHTML).toContain(text);
+    });
+  });
+
+  describe("the `children` prop", () => {
+    describe("that is an element", () => {
+      it("renders", () => {
+        const text = "bubblegum";
+
+        renderStrict(
+          <MemoryRouter initialEntries={["/"]}>
+            <Match path="/">
+              <h1>{text}</h1>
+            </Match>
+          </MemoryRouter>,
+          node
+        );
+
+        expect(node.innerHTML).toContain(text);
+      });
+    });
+
+    describe("that is a function", () => {
+      it("receives { history, location, match } props", () => {
+        const history = createHistory();
+
+        let props = null;
+        renderStrict(
+          <Router history={history}>
+            <Match
+              path="/"
+              children={p => {
+                props = p;
+                return null;
+              }}
+            />
+          </Router>,
+          node
+        );
+
+        expect(props).not.toBe(null);
+        expect(props.history).toBe(history);
+        expect(typeof props.location).toBe("object");
+        expect(typeof props.match).toBe("object");
+      });
+
+      it("renders", () => {
+        const text = "bubblegum";
+
+        renderStrict(
+          <MemoryRouter initialEntries={["/"]}>
+            <Match path="/" children={() => <h1>{text}</h1>} />
+          </MemoryRouter>,
+          node
+        );
+
+        expect(node.innerHTML).toContain(text);
+      });
+
+      describe("that returns `undefined`", () => {
+        it("logs a warning to the console and renders nothing", () => {
+          jest.spyOn(console, "warn").mockImplementation(() => {});
+
+          renderStrict(
+            <MemoryRouter initialEntries={["/"]}>
+              <Match path="/" children={() => undefined} />
+            </MemoryRouter>,
+            node
+          );
+
+          expect(node.innerHTML).toEqual("");
+
+          expect(console.warn).toHaveBeenCalledWith(
+            expect.stringContaining(
+              "You returned `undefined` from the `children` function"
+            )
+          );
+        });
+      });
+    });
+  });
+});

--- a/packages/react-router/modules/__tests__/Match-test.js
+++ b/packages/react-router/modules/__tests__/Match-test.js
@@ -12,6 +12,25 @@ describe("A <Match>", () => {
     ReactDOM.unmountComponentAtNode(node);
   });
 
+  it("passes props to class component child", () => {
+    class MatchedRoute extends React.Component {
+      render() {
+        return <div> {this.props.match && this.props.match.url} </div>;
+      }
+    }
+
+    renderStrict(
+      <MemoryRouter initialEntries={["/pizza"]}>
+        <Match path="/pizza">
+          <MatchedRoute />
+        </Match>
+      </MemoryRouter>,
+      node
+    );
+
+    expect(node.innerHTML).toContain("/pizza");
+  });
+
   describe("without a <Router>", () => {
     it("throws an error", () => {
       jest.spyOn(console, "error").mockImplementation(() => {});

--- a/packages/react-router/modules/index.js
+++ b/packages/react-router/modules/index.js
@@ -31,5 +31,6 @@ export { default as Switch } from "./Switch";
 export { default as generatePath } from "./generatePath";
 export { default as matchPath } from "./matchPath";
 export { default as withRouter } from "./withRouter";
+export { default as Match } from "./Match";
 
 export { default as __RouterContext } from "./RouterContext";


### PR DESCRIPTION
Meant as a base for discussion regarding the plans outlined in #6362 

```Match``` will act just like ```Route```, except that it always renders it's children and does not have a render or component prop. 

```jsx
<Match path="/about">
  {match => match ? <About /> : <NotFound />}
</Match>
```

Also, Match will pass the props to any and all "normal" children:

```jsx
<Match path="/About">
  <About>
  <NotFound>
</Match>
```


Regarding the unit tests: I copied the ```Route``` tests and poked at them for half an hour until they passed. With some guidance how to treat the now duplicated code across Route and Match, I'll figure out a more meaningful test-set.

**TODO:**

* [x] Sort out how props are passed to children
    * [x] Pass to class components yes / no?
    * [x] What to do when ```<Match/>``` has more than one child?
* [ ] Sort out the duplicate code
* [ ] Sort out unit tests
* [ ] Write documentation