### PR TITLE
Fixed maximum update depth exceeded caused by Redirect.

### DIFF
--- a/packages/react-router/modules/Redirect.js
+++ b/packages/react-router/modules/Redirect.js
@@ -47,7 +47,12 @@ function Redirect({ computedMatch, to, push = false }) {
                 typeof prevProps.to === "string"
                   ? createLocation(prevProps.to)
                   : prevProps.to;
-              if (!locationsAreEqual(prevLocation, location)) {
+              if (
+                !locationsAreEqual(prevLocation, {
+                  ...location,
+                  key: prevLocation.key
+                })
+              ) {
                 method(location);
               }
             }}

--- a/packages/react-router/modules/Redirect.js
+++ b/packages/react-router/modules/Redirect.js
@@ -1,6 +1,6 @@
 import React from "react";
 import PropTypes from "prop-types";
-import { createLocation, locationsAreEqual } from "history";
+import { createLocation } from "history";
 import invariant from "tiny-invariant";
 
 import Lifecycle from "./Lifecycle";
@@ -43,7 +43,11 @@ function Redirect({ computedMatch, to, push = false }) {
               method(location);
             }}
             onUpdate={(self, prevProps) => {
-              if (!locationsAreEqual(prevProps.to, location)) {
+              if (typeof prevProps.to === "string") {
+                if (prevProps.to !== location.pathname) {
+                  method(location);
+                }
+              } else if (!locationsAreEqual(prevProps.to, location)) {
                 method(location);
               }
             }}

--- a/packages/react-router/modules/Redirect.js
+++ b/packages/react-router/modules/Redirect.js
@@ -1,6 +1,6 @@
 import React from "react";
 import PropTypes from "prop-types";
-import { createLocation } from "history";
+import { createLocation, locationsAreEqual } from "history";
 import invariant from "tiny-invariant";
 
 import Lifecycle from "./Lifecycle";
@@ -43,11 +43,11 @@ function Redirect({ computedMatch, to, push = false }) {
               method(location);
             }}
             onUpdate={(self, prevProps) => {
-              if (typeof prevProps.to === "string") {
-                if (prevProps.to !== location.pathname) {
-                  method(location);
-                }
-              } else if (!locationsAreEqual(prevProps.to, location)) {
+              const prevLocation =
+                typeof prevProps.to === "string"
+                  ? createLocation(prevProps.to)
+                  : prevProps.to;
+              if (!locationsAreEqual(prevLocation, location)) {
                 method(location);
               }
             }}

--- a/packages/react-router/modules/__tests__/Redirect-test.js
+++ b/packages/react-router/modules/__tests__/Redirect-test.js
@@ -11,6 +11,27 @@ describe("A <Redirect>", () => {
     ReactDOM.unmountComponentAtNode(node);
   });
 
+  describe("inside a functional component", () => {
+    const Stateless = props => {
+      if (props.flag === 1) {
+        return <Redirect to="/go-out" />;
+      }
+
+      return <b>Stateless!</b>;
+    };
+
+    it("doesn't break / throw when rendered", () => {
+      expect(() => {
+        renderStrict(
+          <MemoryRouter>
+            <Stateless flag={1} />
+          </MemoryRouter>,
+          node
+        );
+      }).not.toThrow();
+    });
+  });
+
   describe("inside a <Switch>", () => {
     it("automatically interpolates params", () => {
       let params;

--- a/packages/react-router/modules/__tests__/Redirect-test.js
+++ b/packages/react-router/modules/__tests__/Redirect-test.js
@@ -11,20 +11,12 @@ describe("A <Redirect>", () => {
     ReactDOM.unmountComponentAtNode(node);
   });
 
-  describe("inside a functional component", () => {
-    const Stateless = props => {
-      if (props.flag === 1) {
-        return <Redirect to={props.to} />;
-      }
-
-      return <b>Stateless!</b>;
-    };
-
+  describe("that always renders", () => {
     it("doesn't break / throw when rendered with string `to`", () => {
       expect(() => {
         renderStrict(
           <MemoryRouter>
-            <Stateless flag={1} to="go-out" />
+            <Redirect to="go-out" />
           </MemoryRouter>,
           node
         );
@@ -36,7 +28,7 @@ describe("A <Redirect>", () => {
       expect(() => {
         renderStrict(
           <MemoryRouter>
-            <Stateless flag={1} to={to} />
+            <Redirect to={to} />
           </MemoryRouter>,
           node
         );

--- a/packages/react-router/modules/__tests__/Redirect-test.js
+++ b/packages/react-router/modules/__tests__/Redirect-test.js
@@ -1,7 +1,7 @@
 import React from "react";
 import ReactDOM from "react-dom";
 import { MemoryRouter, Redirect, Route, Switch } from "react-router";
-
+import { createLocation } from "history";
 import renderStrict from "./utils/renderStrict";
 
 describe("A <Redirect>", () => {
@@ -14,17 +14,29 @@ describe("A <Redirect>", () => {
   describe("inside a functional component", () => {
     const Stateless = props => {
       if (props.flag === 1) {
-        return <Redirect to="/go-out" />;
+        return <Redirect to={props.to} />;
       }
 
       return <b>Stateless!</b>;
     };
 
-    it("doesn't break / throw when rendered", () => {
+    it("doesn't break / throw when rendered with string `to`", () => {
       expect(() => {
         renderStrict(
           <MemoryRouter>
-            <Stateless flag={1} />
+            <Stateless flag={1} to="go-out" />
+          </MemoryRouter>,
+          node
+        );
+      }).not.toThrow();
+    });
+
+    it("doesn't break / throw when rendered with location `to`", () => {
+      const to = createLocation("/go-out?search=foo#hash");
+      expect(() => {
+        renderStrict(
+          <MemoryRouter>
+            <Stateless flag={1} to={to} />
           </MemoryRouter>,
           node
         );


### PR DESCRIPTION
Fixes #6673

Basically, "to" can be a string or a location object. But only the case for objects was covered, hence the infinite loop in cases where the <Redirect/> is still being rendered after the location change.