### PR TITLE
fix: set DisplayName correctly for Named Context

### DIFF
--- a/packages/react-router/modules/RouterContext.js
+++ b/packages/react-router/modules/RouterContext.js
@@ -3,8 +3,8 @@ import createContext from "create-react-context";
 
 const createNamedContext = name => {
   const context = createContext();
-  context.Provider.displayName = `${name}.Provider`;
-  context.Consumer.displayName = `${name}.Consumer`;
+  context.displayName = name;
+
   return context;
 }
 


### PR DESCRIPTION
I wasn't seeing these named correctly in DevTools. Looking at https://github.com/facebook/react-devtools/pull/1031#issuecomment-423288506 this seems to be the way to do it. Thanks!