### PR TITLE
fix(react-router): Allow string and object refs in withRouter

### DIFF
--- a/packages/react-router/modules/withRouter.js
+++ b/packages/react-router/modules/withRouter.js
@@ -29,7 +29,11 @@ function withRouter(Component) {
 
   if (__DEV__) {
     C.propTypes = {
-      wrappedComponentRef: PropTypes.oneOfType([PropTypes.func, PropTypes.object])
+      wrappedComponentRef: PropTypes.oneOfType([
+        PropTypes.string,
+        PropTypes.func,
+        PropTypes.object
+      ])
     };
   }
 

--- a/packages/react-router/modules/withRouter.js
+++ b/packages/react-router/modules/withRouter.js
@@ -29,7 +29,7 @@ function withRouter(Component) {
 
   if (__DEV__) {
     C.propTypes = {
-      wrappedComponentRef: PropTypes.func
+      wrappedComponentRef: PropTypes.oneOfType([PropTypes.func, PropTypes.object])
     };
   }
 


### PR DESCRIPTION
Doesn't warn about `createRef` or `useRef` values in `wrappedComponentRef`