### PR TITLE
Pin create-react-context to 0.2.2

### DIFF
--- a/packages/react-router/package-lock.json
+++ b/packages/react-router/package-lock.json
@@ -3809,9 +3809,9 @@
 			}
 		},
 		"create-react-context": {
-			"version": "0.2.3",
-			"resolved": "https://registry.npmjs.org/create-react-context/-/create-react-context-0.2.3.tgz",
-			"integrity": "sha512-CQBmD0+QGgTaxDL3OX1IDXYqjkp2It4RIbcb99jS6AEg27Ga+a9G3JtK6SIu0HBwPLZlmwt9F7UwWA4Bn92Rag==",
+			"version": "0.2.2",
+			"resolved": "https://registry.npmjs.org/create-react-context/-/create-react-context-0.2.2.tgz",
+			"integrity": "sha512-KkpaLARMhsTsgp0d2NA/R94F/eDLbhXERdIq3LvX2biCAXcDvHYoOqHfWCHf1+OLj+HKBotLG3KqaOOf+C1C+A==",
 			"requires": {
 				"fbjs": "^0.8.0",
 				"gud": "^1.0.0"
@@ -11495,9 +11495,9 @@
 			"dev": true
 		},
 		"ua-parser-js": {
-			"version": "0.7.18",
-			"resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.18.tgz",
-			"integrity": "sha512-LtzwHlVHwFGTptfNSgezHp7WUlwiqb0gA9AALRbKaERfxwJoiX0A73QbTToxteIAuIaFshhgIZfqK8s7clqgnA=="
+			"version": "0.7.19",
+			"resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.19.tgz",
+			"integrity": "sha512-T3PVJ6uz8i0HzPxOF9SWzWAlfN/DavlpQqepn22xgve/5QecC+XMCAtmUNnY7C9StehaV6exjUCI801lOI7QlQ=="
 		},
 		"uglify-js": {
 			"version": "3.4.9",

--- a/packages/react-router/package.json
+++ b/packages/react-router/package.json
@@ -40,7 +40,7 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.1.2",
-    "create-react-context": "^0.2.2",
+    "create-react-context": "0.2.2",
     "history": "^4.9.0",
     "hoist-non-react-statics": "^3.1.0",
     "loose-envify": "^1.3.1",


### PR DESCRIPTION
`0.2.2` uses the [MIT license](https://unpkg.com/create-react-context@0.2.2/LICENSE) while `0.2.3` uses a  [custom license](https://unpkg.com/create-react-context@0.2.3/LICENSE).