### PR TITLE
withRouter: Directly use RouterContext instead of Route.

### DIFF
--- a/packages/react-router-dom/.size-snapshot.json
+++ b/packages/react-router-dom/.size-snapshot.json
@@ -14,13 +14,13 @@
     }
   },
   "umd/react-router-dom.js": {
-    "bundled": 162079,
-    "minified": 57806,
-    "gzipped": 16662
+    "bundled": 162277,
+    "minified": 57870,
+    "gzipped": 16689
   },
   "umd/react-router-dom.min.js": {
-    "bundled": 97956,
-    "minified": 34459,
-    "gzipped": 10224
+    "bundled": 98089,
+    "minified": 34473,
+    "gzipped": 10230
   }
 }

--- a/packages/react-router/.size-snapshot.json
+++ b/packages/react-router/.size-snapshot.json
@@ -1,26 +1,26 @@
 {
   "esm/react-router.js": {
-    "bundled": 23136,
-    "minified": 13099,
-    "gzipped": 3654,
+    "bundled": 23391,
+    "minified": 13245,
+    "gzipped": 3676,
     "treeshaked": {
       "rollup": {
-        "code": 2267,
+        "code": 2209,
         "import_statements": 465
       },
       "webpack": {
-        "code": 3630
+        "code": 3572
       }
     }
   },
   "umd/react-router.js": {
-    "bundled": 102232,
-    "minified": 36232,
-    "gzipped": 11519
+    "bundled": 102432,
+    "minified": 36295,
+    "gzipped": 11538
   },
   "umd/react-router.min.js": {
-    "bundled": 63839,
-    "minified": 22264,
-    "gzipped": 7893
+    "bundled": 63974,
+    "minified": 22277,
+    "gzipped": 7899
   }
 }

--- a/packages/react-router/modules/withRouter.js
+++ b/packages/react-router/modules/withRouter.js
@@ -1,30 +1,37 @@
 import React from "react";
 import PropTypes from "prop-types";
+import RouterContext from "./RouterContext";
 import hoistStatics from "hoist-non-react-statics";
-
-import Route from "./Route";
+import invariant from "tiny-invariant";
 
 /**
  * A public higher-order component to access the imperative API
  */
 function withRouter(Component) {
+  const displayName = `withRouter(${Component.displayName || Component.name})`;
   const C = props => {
     const { wrappedComponentRef, ...remainingProps } = props;
 
     return (
-      <Route
-        children={routeComponentProps => (
-          <Component
-            {...remainingProps}
-            {...routeComponentProps}
-            ref={wrappedComponentRef}
-          />
-        )}
-      />
+      <RouterContext.Consumer>
+        {context => {
+          invariant(
+            context,
+            `You should not use <${displayName} /> outside a <Router>`
+          );
+          return (
+            <Component
+              {...remainingProps}
+              {...context}
+              ref={wrappedComponentRef}
+            />
+          );
+        }}
+      </RouterContext.Consumer>
     );
   };
 
-  C.displayName = `withRouter(${Component.displayName || Component.name})`;
+  C.displayName = displayName;
   C.WrappedComponent = Component;
 
   if (__DEV__) {


### PR DESCRIPTION
Currently, withRouter(Foo) would render with 5 levels:

```jsx
<withRouter(Foo)>
  <Route>
    <ContextConsumer>
      <ContextProvider>
        <Foo/>
      </ContextProvider>
    </ContextConsumer>
  </Route>
</withRouter(Foo)>
```

With this PR, it's only 3 levels:

```jsx 
<withRouter(Foo)>
  <ContextConsumer>
    <Foo/>
  </ContextConsumer>
</withRouter(Foo)>
```

I also took the opportunity to clarify the warning. Previously, using withRouter(Foo) would have yielded ```"You should not use <Route> outside a <Router>"```. I've ran into that warning a couple of times myself and it's particularly unhelpful.