### PR TITLE
call createLocation on 'to' regardless of type

### DIFF
--- a/packages/react-router/modules/Redirect.js
+++ b/packages/react-router/modules/Redirect.js
@@ -43,10 +43,7 @@ function Redirect({ computedMatch, to, push = false }) {
               method(location);
             }}
             onUpdate={(self, prevProps) => {
-              const prevLocation =
-                typeof prevProps.to === "string"
-                  ? createLocation(prevProps.to)
-                  : prevProps.to;
+              const prevLocation = createLocation(prevProps.to);
               if (
                 !locationsAreEqual(prevLocation, {
                   ...location,

--- a/packages/react-router/modules/__tests__/Redirect-test.js
+++ b/packages/react-router/modules/__tests__/Redirect-test.js
@@ -23,8 +23,42 @@ describe("A <Redirect>", () => {
       }).not.toThrow();
     });
 
-    it("doesn't break / throw when rendered with location `to`", () => {
+    it("doesn't break / throw when rendered with location `to` created from string", () => {
       const to = createLocation("/go-out?search=foo#hash");
+      expect(() => {
+        renderStrict(
+          <MemoryRouter>
+            <Redirect to={to} />
+          </MemoryRouter>,
+          node
+        );
+      }).not.toThrow();
+    });
+
+    it("doesn't break / throw when rendered with object `to`", () => {
+      const to = {
+        pathname: "/path",
+        state: {
+          someState: "state"
+        }
+      };
+      expect(() => {
+        renderStrict(
+          <MemoryRouter>
+            <Redirect to={to} />
+          </MemoryRouter>,
+          node
+        );
+      }).not.toThrow();
+    });
+
+    it("doesn't break / throw when rendered with location `to` created from object", () => {
+      const to = createLocation({
+        pathname: "/path",
+        state: {
+          someState: "state"
+        }
+      });
       expect(() => {
         renderStrict(
           <MemoryRouter>


### PR DESCRIPTION
Piggybacking off https://github.com/ReactTraining/react-router/pull/6674 to also handle object.

Resolves https://github.com/ReactTraining/react-router/issues/6689