### PR TITLE
add noMatchedParams prop to Redirect

### DIFF
--- a/packages/react-router/.size-snapshot.json
+++ b/packages/react-router/.size-snapshot.json
@@ -1,8 +1,8 @@
 {
   "esm/react-router.js": {
-    "bundled": 23391,
-    "minified": 13245,
-    "gzipped": 3676,
+    "bundled": 23606,
+    "minified": 13324,
+    "gzipped": 3704,
     "treeshaked": {
       "rollup": {
         "code": 2209,
@@ -14,13 +14,13 @@
     }
   },
   "umd/react-router.js": {
-    "bundled": 102432,
-    "minified": 36295,
-    "gzipped": 11538
+    "bundled": 102653,
+    "minified": 36366,
+    "gzipped": 11562
   },
   "umd/react-router.min.js": {
-    "bundled": 63974,
-    "minified": 22277,
-    "gzipped": 7899
+    "bundled": 64152,
+    "minified": 22321,
+    "gzipped": 7918
   }
 }

--- a/packages/react-router/docs/api/Redirect.md
+++ b/packages/react-router/docs/api/Redirect.md
@@ -67,6 +67,20 @@ This can only be used to match a location when rendering a `<Redirect>` inside o
 </Switch>
 ```
 
+## noMatchedParams: bool
+
+Opt-out of generating a path based on the matched URL parameters described above.
+This is useful if your redirect to includes characters used for [`path-to-regexp@^1.7.0`](https://github.com/pillarjs/path-to-regexp/tree/v1.7.0) (not recommended).
+
+```jsx
+// redirect without matched paramters
+<Switch>
+  <Route path="/:id(user:\d+)" component={User} />
+  <Route path="/:id(task:\d+)" component={Task} />
+  <Redirect to="/user:1" noMatchedParams />
+</Switch>
+```
+
 ## exact: bool
 
 Match `from` exactly; equivalent to [Route.exact](./Route.md#exact-bool).

--- a/packages/react-router/modules/Redirect.js
+++ b/packages/react-router/modules/Redirect.js
@@ -10,7 +10,12 @@ import generatePath from "./generatePath";
 /**
  * The public API for navigating programmatically with a component.
  */
-function Redirect({ computedMatch, to, push = false }) {
+function Redirect({
+  computedMatch,
+  to,
+  push = false,
+  noMatchedParams = false
+}) {
   return (
     <RouterContext.Consumer>
       {context => {
@@ -20,7 +25,7 @@ function Redirect({ computedMatch, to, push = false }) {
 
         const method = push ? history.push : history.replace;
         const location = createLocation(
-          computedMatch
+          computedMatch && !noMatchedParams
             ? typeof to === "string"
               ? generatePath(to, computedMatch.params)
               : {
@@ -66,6 +71,7 @@ function Redirect({ computedMatch, to, push = false }) {
 
 if (__DEV__) {
   Redirect.propTypes = {
+    noMatchedParams: PropTypes.bool,
     push: PropTypes.bool,
     from: PropTypes.string,
     to: PropTypes.oneOfType([PropTypes.string, PropTypes.object]).isRequired

--- a/packages/react-router/modules/__tests__/Redirect-test.js
+++ b/packages/react-router/modules/__tests__/Redirect-test.js
@@ -64,5 +64,29 @@ describe("A <Redirect>", () => {
         messageId: "123"
       });
     });
+
+    it("opts-out of automatically interpolated params", () => {
+      let params;
+
+      renderStrict(
+        <MemoryRouter initialEntries={["/"]}>
+          <Switch>
+            <Redirect from="/" exact to="/user:1" noMatchedParams />
+            <Route
+              path="/:userId(user:\d+)"
+              render={({ match }) => {
+                params = match.params;
+                return null;
+              }}
+            />
+          </Switch>
+        </MemoryRouter>,
+        node
+      );
+
+      expect(params).toMatchObject({
+        userId: "user:1"
+      });
+    });
   });
 });


### PR DESCRIPTION
### The issue
When updating from 4.2.2 to 4.3.1 or 5.0.0, our redirects are throwing an error like
```
index.js:179 Uncaught TypeError: Expected "1234" to be defined
    at eval (index.js:179)
    at generatePath (react-router.js:292)
    at eval (react-router.js:311)
```

### The problem
The interpolated redirect params added in #5209 conflict with literal URLs that contains `':'` like
```jsx
<Switch>
  <Redirect to="/users/user:1234"/>
</Switch>
```

### The fix
This PR adds a `noMatchedParams` prop to the Redirect component that opts out of this behavior.
I supposed there could also be a way to escape URLs containing this character added to `path-to-regex` which would require updating that package in `react-router` anyway.

Please let me know if there is another way we can address this.