### PR TITLE
Switch to mini-create-router-context

### DIFF
--- a/packages/react-router-dom/.size-snapshot.json
+++ b/packages/react-router-dom/.size-snapshot.json
@@ -14,13 +14,13 @@
     }
   },
   "umd/react-router-dom.js": {
-    "bundled": 162277,
-    "minified": 57870,
-    "gzipped": 16689
+    "bundled": 158978,
+    "minified": 56593,
+    "gzipped": 16361
   },
   "umd/react-router-dom.min.js": {
-    "bundled": 98089,
-    "minified": 34473,
-    "gzipped": 10230
+    "bundled": 95833,
+    "minified": 33613,
+    "gzipped": 9925
   }
 }

--- a/packages/react-router/.size-snapshot.json
+++ b/packages/react-router/.size-snapshot.json
@@ -1,26 +1,26 @@
 {
   "esm/react-router.js": {
-    "bundled": 23391,
-    "minified": 13245,
-    "gzipped": 3676,
+    "bundled": 23396,
+    "minified": 13250,
+    "gzipped": 3680,
     "treeshaked": {
       "rollup": {
-        "code": 2209,
-        "import_statements": 465
+        "code": 2214,
+        "import_statements": 470
       },
       "webpack": {
-        "code": 3572
+        "code": 3577
       }
     }
   },
   "umd/react-router.js": {
-    "bundled": 102432,
-    "minified": 36295,
-    "gzipped": 11538
+    "bundled": 98991,
+    "minified": 35022,
+    "gzipped": 11227
   },
   "umd/react-router.min.js": {
-    "bundled": 63974,
-    "minified": 22277,
-    "gzipped": 7899
+    "bundled": 61594,
+    "minified": 21423,
+    "gzipped": 7606
   }
 }

--- a/packages/react-router/modules/RouterContext.js
+++ b/packages/react-router/modules/RouterContext.js
@@ -1,12 +1,12 @@
 // TODO: Replace with React.createContext once we can assume React 16+
-import createContext from "create-react-context";
+import createContext from "mini-create-react-context";
 
 const createNamedContext = name => {
   const context = createContext();
   context.displayName = name;
 
   return context;
-}
+};
 
-const context = /*#__PURE__*/ createNamedContext('Router');
+const context = /*#__PURE__*/ createNamedContext("Router");
 export default context;

--- a/packages/react-router/package-lock.json
+++ b/packages/react-router/package-lock.json
@@ -2709,11 +2709,6 @@
 			"integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
 			"dev": true
 		},
-		"asap": {
-			"version": "2.0.6",
-			"resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
-			"integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY="
-		},
 		"asn1": {
 			"version": "0.2.4",
 			"resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz",
@@ -3760,11 +3755,6 @@
 			"integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=",
 			"dev": true
 		},
-		"core-js": {
-			"version": "1.2.7",
-			"resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
-			"integrity": "sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY="
-		},
 		"core-util-is": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
@@ -3806,15 +3796,6 @@
 				"ripemd160": "^2.0.0",
 				"safe-buffer": "^5.0.1",
 				"sha.js": "^2.4.8"
-			}
-		},
-		"create-react-context": {
-			"version": "0.2.2",
-			"resolved": "https://registry.npmjs.org/create-react-context/-/create-react-context-0.2.2.tgz",
-			"integrity": "sha512-KkpaLARMhsTsgp0d2NA/R94F/eDLbhXERdIq3LvX2biCAXcDvHYoOqHfWCHf1+OLj+HKBotLG3KqaOOf+C1C+A==",
-			"requires": {
-				"fbjs": "^0.8.0",
-				"gud": "^1.0.0"
 			}
 		},
 		"cross-spawn": {
@@ -4139,14 +4120,6 @@
 			"resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-2.1.0.tgz",
 			"integrity": "sha1-TapNnbAPmBmIDHn6RXrlsJof04k=",
 			"dev": true
-		},
-		"encoding": {
-			"version": "0.1.12",
-			"resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
-			"integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
-			"requires": {
-				"iconv-lite": "~0.4.13"
-			}
 		},
 		"end-of-stream": {
 			"version": "1.4.1",
@@ -4776,20 +4749,6 @@
 			"dev": true,
 			"requires": {
 				"bser": "^2.0.0"
-			}
-		},
-		"fbjs": {
-			"version": "0.8.17",
-			"resolved": "https://registry.npmjs.org/fbjs/-/fbjs-0.8.17.tgz",
-			"integrity": "sha1-xNWY6taUkRJlPWWIsBpc3Nn5D90=",
-			"requires": {
-				"core-js": "^1.0.0",
-				"isomorphic-fetch": "^2.1.1",
-				"loose-envify": "^1.0.0",
-				"object-assign": "^4.1.0",
-				"promise": "^7.1.1",
-				"setimmediate": "^1.0.5",
-				"ua-parser-js": "^0.7.18"
 			}
 		},
 		"figures": {
@@ -5839,6 +5798,7 @@
 			"version": "0.4.24",
 			"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
 			"integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+			"dev": true,
 			"requires": {
 				"safer-buffer": ">= 2.1.2 < 3"
 			}
@@ -6263,7 +6223,8 @@
 		"is-stream": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
-			"integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
+			"integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
+			"dev": true
 		},
 		"is-symbol": {
 			"version": "1.0.2",
@@ -6318,15 +6279,6 @@
 					"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
 					"dev": true
 				}
-			}
-		},
-		"isomorphic-fetch": {
-			"version": "2.2.1",
-			"resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz",
-			"integrity": "sha1-YRrhrPFPXoH3KVB0coGf6XM1WKk=",
-			"requires": {
-				"node-fetch": "^1.0.1",
-				"whatwg-fetch": ">=0.10.0"
 			}
 		},
 		"isstream": {
@@ -8456,6 +8408,22 @@
 			"integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==",
 			"dev": true
 		},
+		"mini-create-react-context": {
+			"version": "0.3.0",
+			"resolved": "https://registry.npmjs.org/mini-create-react-context/-/mini-create-react-context-0.3.0.tgz",
+			"integrity": "sha512-5GSHaS5QlOrofQD5itzD7SWzeG2hmUBvOiumVUzYTEQow0nuTiBHRt+0M/GDgXxeGFFd5RTO7IPe53Qr1hUFCw==",
+			"requires": {
+				"gud": "^1.0.0",
+				"tiny-warning": "^1.0.2"
+			},
+			"dependencies": {
+				"tiny-warning": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/tiny-warning/-/tiny-warning-1.0.2.tgz",
+					"integrity": "sha512-rru86D9CpQRLvsFG5XFdy0KdLAvjdQDyZCsRcuu60WtzFylDM3eAWSxEVz5kzL2Gp544XiUvPbVKtOA/txLi9Q=="
+				}
+			}
+		},
 		"minimalistic-assert": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
@@ -8620,15 +8588,6 @@
 			"resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
 			"integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
 			"dev": true
-		},
-		"node-fetch": {
-			"version": "1.7.3",
-			"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
-			"integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
-			"requires": {
-				"encoding": "^0.1.11",
-				"is-stream": "^1.0.1"
-			}
 		},
 		"node-int64": {
 			"version": "0.4.0",
@@ -9257,14 +9216,6 @@
 			"resolved": "https://registry.npmjs.org/progress/-/progress-2.0.1.tgz",
 			"integrity": "sha512-OE+a6vzqazc+K6LxJrX5UPyKFvGnL5CYmq2jFGNIBWHpc4QyE49/YOumcrpQFJpfejmvRtbJzgO1zPmMCqlbBg==",
 			"dev": true
-		},
-		"promise": {
-			"version": "7.3.1",
-			"resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
-			"integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==",
-			"requires": {
-				"asap": "~2.0.3"
-			}
 		},
 		"promise-inflight": {
 			"version": "1.0.1",
@@ -10351,7 +10302,8 @@
 		"safer-buffer": {
 			"version": "2.1.2",
 			"resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-			"integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+			"integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+			"dev": true
 		},
 		"sane": {
 			"version": "4.1.0",
@@ -10646,7 +10598,7 @@
 				},
 				"minimist": {
 					"version": "1.2.0",
-					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+					"resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
 					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
 					"dev": true
 				}
@@ -10753,7 +10705,8 @@
 		"setimmediate": {
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
-			"integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU="
+			"integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU=",
+			"dev": true
 		},
 		"sha.js": {
 			"version": "2.4.11",
@@ -11494,11 +11447,6 @@
 			"integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
 			"dev": true
 		},
-		"ua-parser-js": {
-			"version": "0.7.19",
-			"resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.19.tgz",
-			"integrity": "sha512-T3PVJ6uz8i0HzPxOF9SWzWAlfN/DavlpQqepn22xgve/5QecC+XMCAtmUNnY7C9StehaV6exjUCI801lOI7QlQ=="
-		},
 		"uglify-js": {
 			"version": "3.4.9",
 			"resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.4.9.tgz",
@@ -12217,11 +12165,6 @@
 				"iconv-lite": "0.4.24"
 			}
 		},
-		"whatwg-fetch": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.0.0.tgz",
-			"integrity": "sha512-9GSJUgz1D4MfyKU7KRqwOjXCXTqWdFNvEr7eUBYchQiVc744mqK/MzXPNR2WsPkmkOa4ywfg8C2n8h+13Bey1Q=="
-		},
 		"whatwg-mimetype": {
 			"version": "2.3.0",
 			"resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-2.3.0.tgz",
@@ -12271,7 +12214,7 @@
 		},
 		"wrap-ansi": {
 			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
+			"resolved": "http://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
 			"integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
 			"dev": true,
 			"requires": {

--- a/packages/react-router/package.json
+++ b/packages/react-router/package.json
@@ -40,10 +40,10 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.1.2",
-    "create-react-context": "0.2.2",
     "history": "^4.9.0",
     "hoist-non-react-statics": "^3.1.0",
     "loose-envify": "^1.3.1",
+    "mini-create-react-context": "^0.3.0",
     "path-to-regexp": "^1.7.0",
     "prop-types": "^15.6.2",
     "react-is": "^16.6.0",


### PR DESCRIPTION
I forked create-router-context because I saw that the package didn't see much activity anymore and had some obvious tweaks to be made.

| | original | mini
|---|---|---|
| bundled sized | [1.4kB minzip](https://bundlephobia.com/result?p=create-react-context@0.2.3) | [1.2kB minzip](https://bundlephobia.com/result?p=mini-create-react-context@0.3.0)
| install size | [**2.45 mB**](https://packagephobia.now.sh/result?p=create-react-context)  | [32kB](https://packagephobia.now.sh/result?p=mini-create-react-context)

See also the [install-size of RR.](https://packagephobia.now.sh/result?p=react-router-dom) and how it's gone *way* up with 5.0
