### PR TITLE
Add a default value for context in StaticRouter.navigateTo

### DIFF
--- a/packages/react-router/modules/StaticRouter.js
+++ b/packages/react-router/modules/StaticRouter.js
@@ -52,7 +52,7 @@ function noop() {}
  */
 class StaticRouter extends React.Component {
   navigateTo(location, action) {
-    const { basename = "", context } = this.props;
+    const { basename = "", context = {} } = this.props;
     context.action = action;
     context.location = addBasename(basename, createLocation(location));
     context.url = createURL(context.location);


### PR DESCRIPTION
If you instantiate StaticRouter without providing a context object and attempt to render e.g. a Redirect, an error is thrown because context will be undefined.