### PR TITLE
change status to statusCode

### DIFF
--- a/packages/react-router-dom/docs/guides/server-rendering.md
+++ b/packages/react-router-dom/docs/guides/server-rendering.md
@@ -46,7 +46,7 @@ function RedirectWithStatus({ from, to, status }) {
       render={({ staticContext }) => {
         // there is no `staticContext` on the client, so
         // we need to guard against that here
-        if (staticContext) staticContext.status = status;
+        if (staticContext) staticContext.statusCode = status;
         return <Redirect from={from} to={to} />;
       }}
     />
@@ -89,7 +89,7 @@ function Status({ code, children }) {
   return (
     <Route
       render={({ staticContext }) => {
-        if (staticContext) staticContext.status = code;
+        if (staticContext) staticContext.statusCode = code;
         return children;
       }}
     />


### PR DESCRIPTION
in typescript definitions of [StaticRouterContext](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/react-router/index.d.ts#L66) there is no _**status**_ and they used _**statusCode**._
when a developer read the documentation and it's different from how they must implement it they get confused.