### PR TITLE
matchPath: Fixed exception thrown if `path` is undefined

### DIFF
--- a/packages/react-router/modules/__tests__/matchPath-test.js
+++ b/packages/react-router/modules/__tests__/matchPath-test.js
@@ -1,6 +1,14 @@
 import { matchPath } from "react-router";
 
 describe("matchPath", () => {
+  describe("without path property on params", () => {
+    it("doesn't throw an exception", () => {
+      expect(() => {
+        matchPath("/milkyway/eridani", { hash: "foo" });
+      }).not.toThrow();
+    });
+  });
+
   describe('with path="/"', () => {
     it('returns correct url at "/"', () => {
       const path = "/";

--- a/packages/react-router/modules/matchPath.js
+++ b/packages/react-router/modules/matchPath.js
@@ -33,6 +33,9 @@ function matchPath(pathname, options = {}) {
   const paths = [].concat(path);
 
   return paths.reduce((matched, path) => {
+    if (!path) {
+      return null;
+    }
     if (matched) return matched;
     const { regexp, keys } = compilePath(path, {
       end: exact,

--- a/packages/react-router/modules/matchPath.js
+++ b/packages/react-router/modules/matchPath.js
@@ -33,10 +33,9 @@ function matchPath(pathname, options = {}) {
   const paths = [].concat(path);
 
   return paths.reduce((matched, path) => {
-    if (!path) {
-      return null;
-    }
+    if (!path) return null;
     if (matched) return matched;
+
     const { regexp, keys } = compilePath(path, {
       end: exact,
       strict,


### PR DESCRIPTION
Fixes #6714