### PR TITLE
Replace onClick event listener

### DIFF
--- a/packages/react-router-dom/modules/Link.js
+++ b/packages/react-router-dom/modules/Link.js
@@ -48,14 +48,7 @@ class Link extends React.Component {
           };
 
           Object.keys(attrs).forEach(key => {
-            if (
-              [
-                "onMouseDown",
-                "onMouseUp",
-                "onPointerDown",
-                "onPointerUp"
-              ].includes(key)
-            ) {
+            if (["onMouseDown", "onMouseUp"].includes(key)) {
               delete attrs.onClick;
               attrs[key] = event =>
                 this.handleClick(event, context.history, this.props[key]);

--- a/packages/react-router-dom/modules/Link.js
+++ b/packages/react-router-dom/modules/Link.js
@@ -15,12 +15,10 @@ class Link extends React.Component {
   handleClick(event, history, handler) {
     try {
       if (handler) handler(event);
-    } catch(ex) {
+    } catch (ex) {
       event.preventDefault();
       throw ex;
     }
-    if (handler) handler(event);
-
 
     if (
       !event.defaultPrevented && // onClick prevented default

--- a/packages/react-router-dom/modules/__tests__/Link-test.js
+++ b/packages/react-router-dom/modules/__tests__/Link-test.js
@@ -218,6 +218,54 @@ describe("A <Link>", () => {
       expect(memoryHistory.push).toBeCalledWith(to);
     });
 
+    it("calls mouseDown eventhandler and history.push", () => {
+      const mouseDownHandler = jest.fn();
+      const to = "/the/path?the=query#the-hash";
+
+      renderStrict(
+        <Router history={memoryHistory}>
+          <Link to={to} onMouseDown={mouseDownHandler}>
+            link
+          </Link>
+        </Router>,
+        node
+      );
+
+      const a = node.querySelector("a");
+      ReactTestUtils.Simulate.mouseDown(a, {
+        defaultPrevented: false,
+        button: 0
+      });
+
+      expect(mouseDownHandler).toBeCalledTimes(1);
+      expect(memoryHistory.push).toBeCalledTimes(1);
+      expect(memoryHistory.push).toBeCalledWith(to);
+    });
+
+    it("calls mouseUp eventhandler and history.push", () => {
+      const mouseUpHandler = jest.fn();
+      const to = "/the/path?the=query#the-hash";
+
+      renderStrict(
+        <Router history={memoryHistory}>
+          <Link to={to} onMouseUp={mouseUpHandler}>
+            link
+          </Link>
+        </Router>,
+        node
+      );
+
+      const a = node.querySelector("a");
+      ReactTestUtils.Simulate.mouseUp(a, {
+        defaultPrevented: false,
+        button: 0
+      });
+
+      expect(mouseUpHandler).toBeCalledTimes(1);
+      expect(memoryHistory.push).toBeCalledTimes(1);
+      expect(memoryHistory.push).toBeCalledWith(to);
+    });
+
     it("does not call history.push on right click", () => {
       const to = "/the/path?the=query#the-hash";
 


### PR DESCRIPTION
allows you to replace the onClick event listener for links to be onMouseUp or onMouseDown so there is not a double click if they want to change behavior.