### PR TITLE
Fix build on windows.

### DIFF
--- a/packages/react-router-config/rollup.config.js
+++ b/packages/react-router-config/rollup.config.js
@@ -4,11 +4,13 @@ const commonjs = require("rollup-plugin-commonjs");
 const nodeResolve = require("rollup-plugin-node-resolve");
 const { sizeSnapshot } = require("rollup-plugin-size-snapshot");
 const { uglify } = require("rollup-plugin-uglify");
-
+const path = require("path");
 const pkg = require("./package.json");
 
 function isBareModuleId(id) {
-  return !id.startsWith(".") && !id.startsWith("/");
+  return (
+    !id.startsWith(".") && !id.includes(path.join(process.cwd(), "modules"))
+  );
 }
 
 const cjs = [

--- a/packages/react-router-dom/.size-snapshot.json
+++ b/packages/react-router-dom/.size-snapshot.json
@@ -1,6 +1,6 @@
 {
   "esm/react-router-dom.js": {
-    "bundled": 8159,
+    "bundled": 8167,
     "minified": 4903,
     "gzipped": 1641,
     "treeshaked": {
@@ -14,13 +14,13 @@
     }
   },
   "umd/react-router-dom.js": {
-    "bundled": 159106,
-    "minified": 56622,
-    "gzipped": 16367
+    "bundled": 159166,
+    "minified": 56640,
+    "gzipped": 16373
   },
   "umd/react-router-dom.min.js": {
-    "bundled": 95961,
-    "minified": 33642,
-    "gzipped": 9929
+    "bundled": 96021,
+    "minified": 33660,
+    "gzipped": 9934
   }
 }

--- a/packages/react-router-dom/rollup.config.js
+++ b/packages/react-router-dom/rollup.config.js
@@ -4,11 +4,13 @@ const commonjs = require("rollup-plugin-commonjs");
 const nodeResolve = require("rollup-plugin-node-resolve");
 const { sizeSnapshot } = require("rollup-plugin-size-snapshot");
 const { uglify } = require("rollup-plugin-uglify");
-
+const path = require("path");
 const pkg = require("./package.json");
 
 function isBareModuleId(id) {
-  return !id.startsWith(".") && !id.startsWith("/");
+  return (
+    !id.startsWith(".") && !id.includes(path.join(process.cwd(), "modules"))
+  );
 }
 
 const cjs = [

--- a/packages/react-router/.size-snapshot.json
+++ b/packages/react-router/.size-snapshot.json
@@ -1,26 +1,26 @@
 {
   "esm/react-router.js": {
-    "bundled": 23435,
-    "minified": 13241,
-    "gzipped": 3679,
+    "bundled": 23486,
+    "minified": 13259,
+    "gzipped": 3684,
     "treeshaked": {
       "rollup": {
-        "code": 2214,
+        "code": 2232,
         "import_statements": 470
       },
       "webpack": {
-        "code": 3577
+        "code": 3595
       }
     }
   },
   "umd/react-router.js": {
-    "bundled": 99032,
-    "minified": 35013,
-    "gzipped": 11222
+    "bundled": 99085,
+    "minified": 35031,
+    "gzipped": 11229
   },
   "umd/react-router.min.js": {
-    "bundled": 61635,
-    "minified": 21414,
-    "gzipped": 7600
+    "bundled": 61688,
+    "minified": 21432,
+    "gzipped": 7606
   }
 }

--- a/packages/react-router/rollup.config.js
+++ b/packages/react-router/rollup.config.js
@@ -4,11 +4,13 @@ const commonjs = require("rollup-plugin-commonjs");
 const nodeResolve = require("rollup-plugin-node-resolve");
 const { sizeSnapshot } = require("rollup-plugin-size-snapshot");
 const { uglify } = require("rollup-plugin-uglify");
-
+const path = require("path");
 const pkg = require("./package.json");
 
 function isBareModuleId(id) {
-  return !id.startsWith(".") && !id.startsWith("/");
+  return (
+    !id.startsWith(".") && !id.includes(path.join(process.cwd(), "modules"))
+  );
 }
 
 const cjs = [

--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -2624,6 +2624,31 @@
 				"sha.js": "^2.4.8"
 			}
 		},
+		"cross-env": {
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/cross-env/-/cross-env-5.2.0.tgz",
+			"integrity": "sha512-jtdNFfFW1hB7sMhr/H6rW1Z45LFqyI431m3qU6bFXcQ3Eh7LtBuG3h74o7ohHZ3crrRkkqHlo4jYHFPcjroANg==",
+			"dev": true,
+			"requires": {
+				"cross-spawn": "^6.0.5",
+				"is-windows": "^1.0.0"
+			},
+			"dependencies": {
+				"cross-spawn": {
+					"version": "6.0.5",
+					"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
+					"integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
+					"dev": true,
+					"requires": {
+						"nice-try": "^1.0.4",
+						"path-key": "^2.0.1",
+						"semver": "^5.5.0",
+						"shebang-command": "^1.2.0",
+						"which": "^1.2.9"
+					}
+				}
+			}
+		},
 		"cross-spawn": {
 			"version": "5.1.0",
 			"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",

--- a/website/package.json
+++ b/website/package.json
@@ -3,7 +3,7 @@
   "name": "react-router-website",
   "version": "5.0.0",
   "scripts": {
-    "build": "NODE_ENV=production webpack -p",
+    "build": "cross-env NODE_ENV=production webpack -p",
     "start": "webpack-dev-server --inline --host 0.0.0.0"
   },
   "dependencies": {
@@ -37,6 +37,7 @@
     "bundle-loader": "^0.5.5",
     "cheerio": "^0.22.0",
     "copy-webpack-plugin": "^4.0.1",
+    "cross-env": "^5.2.0",
     "css-loader": "^0.28.7",
     "eslint": "^4.19.1",
     "eslint-plugin-import": "^2.12.0",


### PR DESCRIPTION
Fixes #6622 and hopefully allows more people to contribute.

The fix is relatively straightforward:

* In the rollup configs, I changed the check from starting at root ("/") to check if the <package>/modules path is referenced.
* I changed the `NODE_ENV=production webpack -p` command for building the website with to a cross-plattform way of setting the enviroment variable.

This should be just a one-time effort and not result in any additional maintenance overhead. 