### PR TITLE
export explicitly from react-dom to avoid cjs __esModule read only prop

### DIFF
--- a/packages/react-router-dom/modules/index.js
+++ b/packages/react-router-dom/modules/index.js
@@ -1,4 +1,15 @@
-export * from "react-router";
+export {
+  MemoryRouter,
+  Prompt,
+  Redirect,
+  Route,
+  Router,
+  StaticRouter,
+  Switch,
+  generatePath,
+  matchPath,
+  withRouter
+} from "react-router";
 
 export { default as BrowserRouter } from "./BrowserRouter";
 export { default as HashRouter } from "./HashRouter";

--- a/packages/react-router-native/main.js
+++ b/packages/react-router-native/main.js
@@ -1,4 +1,15 @@
-export * from "react-router";
+export {
+  MemoryRouter,
+  Prompt,
+  Redirect,
+  Route,
+  Router,
+  StaticRouter,
+  Switch,
+  generatePath,
+  matchPath,
+  withRouter
+} from "react-router";
 
 import BackButton from "./BackButton";
 import DeepLinking from "./DeepLinking";


### PR DESCRIPTION
Fixes a problem with transpiled code in CJS modules:

`export * from 'react-router'`

to

`Object.keys(reactRouter).forEach(function (key) { exports[key] = reactRouter[key]; });`

This was surfaced from Jest tests failing when updating to v5(uses CJS). When react-router-dom cjs attempts to create its exports, `Object.defineProperty(exports, '__esModule', { value: true });` in react-router CSJ module has created a readonly `__esModule` prop via `Object.defineProperty(exports, '__esModule', { value: true });` which gets mutated in the above code. 

The best solution I could think of was to just explicitly state what you want from react-router in react-router-dom. I noticed react-router-native was doing the same and updated that as well as I have used jest for react-native applications.
