### PR TITLE
esModule: false fix read only TypeError in exports

### DIFF
--- a/packages/react-router-config/rollup.config.js
+++ b/packages/react-router-config/rollup.config.js
@@ -16,7 +16,7 @@ function isBareModuleId(id) {
 const cjs = [
   {
     input: "modules/index.js",
-    output: { file: `cjs/${pkg.name}.js`, format: "cjs" },
+    output: { file: `cjs/${pkg.name}.js`, format: "cjs", esModule: false },
     external: isBareModuleId,
     plugins: [
       babel({ exclude: /node_modules/ }),

--- a/packages/react-router-dom/rollup.config.js
+++ b/packages/react-router-dom/rollup.config.js
@@ -16,7 +16,7 @@ function isBareModuleId(id) {
 const cjs = [
   {
     input: "modules/index.js",
-    output: { file: `cjs/${pkg.name}.js`, format: "cjs" },
+    output: { file: `cjs/${pkg.name}.js`, format: "cjs", esModule: false },
     external: isBareModuleId,
     plugins: [
       babel({ exclude: /node_modules/ }),

--- a/packages/react-router/rollup.config.js
+++ b/packages/react-router/rollup.config.js
@@ -16,7 +16,7 @@ function isBareModuleId(id) {
 const cjs = [
   {
     input: "modules/index.js",
-    output: { file: `cjs/${pkg.name}.js`, format: "cjs" },
+    output: { file: `cjs/${pkg.name}.js`, format: "cjs", esModule: false },
     external: isBareModuleId,
     plugins: [
       babel({ exclude: /node_modules/ }),


### PR DESCRIPTION
As suggested from previous PR, any client exclusively using react-router-dom package via CommonJS modules will run into this problem:
```
    TypeError: Cannot assign to read only property '__esModule' of object '[object Object]'

      at node_modules/react-router-dom/cjs/react-router-dom.js:288:64
          at Array.forEach (<anonymous>)
      at Object.<anonymous> (node_modules/react-router-dom/cjs/react-router-dom.js:288:26)
      at Object.<anonymous> (node_modules/react-router-dom/index.js:6:20)
```

Changing rollup config to omit `Object.defineProperty(exports, '__esModule', { value: true });` will fix this, however my suggestion in https://github.com/ReactTraining/react-router/pull/6757 seems less heavy handed in that it doesn't break interop https://stackoverflow.com/a/55687758 

 