### PR TITLE
add hooks option to scroll restoration docs

### DIFF
--- a/packages/react-router-dom/docs/guides/scroll-restoration.md
+++ b/packages/react-router-dom/docs/guides/scroll-restoration.md
@@ -26,6 +26,20 @@ class ScrollToTop extends Component {
 export default withRouter(ScrollToTop);
 ```
 
+Or if you are running React 16.8 and above, you can use hooks:
+
+```jsx
+const ScrollToTop = ({ children, location: { pathname } }) => {
+  useEffect(() => {
+    window.scrollTo(0, 0);
+  }, [pathname]);
+
+  return children;
+};
+
+export default withRouter(ScrollToTop);
+```
+
 Then render it at the top of your app, but below Router
 
 ```jsx


### PR DESCRIPTION
While using the scroll restoration example I rewrote it using hooks and I thought it'd be useful to add it to the docs, as I'm sure others will want to as well and it'll save everyone time.