### PR TITLE
Update Route.md

### DIFF
--- a/packages/react-router/docs/api/Route.md
+++ b/packages/react-router/docs/api/Route.md
@@ -64,8 +64,9 @@ rendered with [route props](#route-props).
 ```jsx
 <Route path="/user/:username" component={User} />;
 
-function User({ match }) {
-  return <h1>Hello {match.params.username}!</h1>;
+// All route props (match, location and history) are available to User
+function User(props) {
+  return <h1>Hello {props.match.params.username}!</h1>;
 }
 ```
 
@@ -75,17 +76,18 @@ When you use `component` (instead of `render` or `children`, below) the router u
 
 This allows for convenient inline rendering and wrapping without the undesired remounting explained above.
 
-Instead of having a new [React element](https://facebook.github.io/react/docs/rendering-elements.html) created for you using the [`component`](#component) prop, you can pass in a function to be called when the location matches. The `render` prop receives all the same [route props](#route-props) as the `component` render prop.
+Instead of having a new [React element](https://facebook.github.io/react/docs/rendering-elements.html) created for you using the [`component`](#component) prop, you can pass in a function to be called when the location matches. The `render` prop function has access to all the same [route props](#route-props) (match, location and history) as the `component` render prop.
 
 ```jsx
 // convenient inline rendering
 <Route path="/home" render={() => <div>Home</div>}/>
 
 // wrapping/composing
+// You can spread routeProps to make them available to your rendered Component
 const FadingRoute = ({ component: Component, ...rest }) => (
-  <Route {...rest} render={props => (
+  <Route {...rest} render={routeProps => (
     <FadeIn>
-      <Component {...props}/>
+      <Component {...routeProps}/>
     </FadeIn>
   )}/>
 )


### PR DESCRIPTION
Updated Route's component prop example to make it clear that the props object of the rendered component has access to all route props (match, location and history). Also updated Route's render prop description and example to make it clear that the render function has access to the route props and changed the respective example to name it routeProps instead of props, to avoid shadowing the parent component props object. This changes were proposed on the issue https://github.com/ReactTraining/react-router/issues/6786