### PR TITLE
Remove basename before pushing internal links

### DIFF
--- a/website/modules/basename.js
+++ b/website/modules/basename.js
@@ -1,0 +1,5 @@
+const base = document.querySelector("base");
+const baseHref = base ? base.getAttribute("href") : "/";
+const basename = baseHref.replace(/\/$/, "");
+
+export default basename;

--- a/website/modules/components/App.js
+++ b/website/modules/components/App.js
@@ -10,13 +10,11 @@ import { Switch, Route } from "react-router-dom";
 import DelegateMarkdownLinks from "./DelegateMarkdownLinks";
 import Home from "./Home";
 import Environment from "./Environment";
-
-const base = document.querySelector("base");
-const baseHref = base ? base.getAttribute("href") : "/";
+import basename from "../basename";
 
 function App() {
   return (
-    <BrowserRouter basename={baseHref.replace(/\/$/, "")}>
+    <BrowserRouter basename={basename}>
       <DelegateMarkdownLinks>
         <Switch>
           <Route path="/" exact={true} component={Home} />

--- a/website/modules/components/DelegateMarkdownLinks.js
+++ b/website/modules/components/DelegateMarkdownLinks.js
@@ -2,6 +2,14 @@ import { Component } from "react";
 import PropTypes from "prop-types";
 import { withRouter } from "react-router-dom";
 
+import basename from "../basename";
+
+const matchBase = new RegExp(`^${basename}`);
+
+function removeBase(href) {
+  return href.replace(matchBase, "");
+}
+
 let delegate = history => {
   document.body.addEventListener("click", e => {
     let node = e.target;
@@ -10,7 +18,7 @@ let delegate = history => {
       if (typeof node.className === "string") {
         if (node.className.match(/internal-link/)) {
           e.preventDefault();
-          const href = node.getAttribute("href");
+          const href = removeBase(node.getAttribute("href"));
           history.push(href);
           break;
         }


### PR DESCRIPTION
Currently, the "internal links" (the ones in markdown) manually push themselves. However, the URLs that the push include the `/react-router` basename. history doesn't do any basename removal with its `push`/`replace` methods, so the basename ends up in the location object that it emits to its listeners This, in turn, causes issues with the router which fails to match a location that begins with `/react-router` and forces a redirect to the home page.

I've tested that the replace function works and that the site runs locally, but I don't have a convenient way to test the site running with the basename.

Hopefully at some point the documentation will switch to something like MDX so that all of these markdown hacks can go away :smile:.