### PR TITLE
docs: update scroll-restoration code example

### DIFF
--- a/packages/react-router-dom/docs/guides/scroll-restoration.md
+++ b/packages/react-router-dom/docs/guides/scroll-restoration.md
@@ -34,7 +34,7 @@ const ScrollToTop = ({ children, location: { pathname } }) => {
     window.scrollTo(0, 0);
   }, [pathname]);
 
-  return children;
+  return children || null;
 };
 
 export default withRouter(ScrollToTop);


### PR DESCRIPTION
In the example, use cases of `ScrollToTop` are presented with both a component with a children and a self-closing one. The component however did not handle the self-closing (childless) use case.