### PR TITLE
matchPath() accepts an array of paths as 2nd argument

### DIFF
--- a/packages/react-router-dom/.size-snapshot.json
+++ b/packages/react-router-dom/.size-snapshot.json
@@ -1,8 +1,8 @@
 {
   "esm/react-router-dom.js": {
-    "bundled": 8700,
-    "minified": 5180,
-    "gzipped": 1664,
+    "bundled": 8793,
+    "minified": 5220,
+    "gzipped": 1681,
     "treeshaked": {
       "rollup": {
         "code": 379,
@@ -14,13 +14,13 @@
     }
   },
   "umd/react-router-dom.js": {
-    "bundled": 159744,
-    "minified": 56768,
-    "gzipped": 16411
+    "bundled": 159885,
+    "minified": 56828,
+    "gzipped": 16427
   },
   "umd/react-router-dom.min.js": {
-    "bundled": 96492,
-    "minified": 33716,
-    "gzipped": 9979
+    "bundled": 96633,
+    "minified": 33776,
+    "gzipped": 9994
   }
 }

--- a/packages/react-router/.size-snapshot.json
+++ b/packages/react-router/.size-snapshot.json
@@ -1,26 +1,26 @@
 {
   "esm/react-router.js": {
-    "bundled": 23522,
-    "minified": 13316,
-    "gzipped": 3688,
+    "bundled": 23563,
+    "minified": 13336,
+    "gzipped": 3696,
     "treeshaked": {
       "rollup": {
-        "code": 2356,
+        "code": 2376,
         "import_statements": 470
       },
       "webpack": {
-        "code": 3721
+        "code": 3741
       }
     }
   },
   "umd/react-router.js": {
-    "bundled": 99173,
-    "minified": 35111,
-    "gzipped": 11242
+    "bundled": 99218,
+    "minified": 35131,
+    "gzipped": 11249
   },
   "umd/react-router.min.js": {
-    "bundled": 61717,
-    "minified": 21479,
-    "gzipped": 7614
+    "bundled": 61762,
+    "minified": 21499,
+    "gzipped": 7619
   }
 }

--- a/packages/react-router/docs/api/matchPath.md
+++ b/packages/react-router/docs/api/matchPath.md
@@ -20,7 +20,8 @@ this on the server with Node.js, it would be `req.path`.
 ## props
 
 The second argument are the props to match against, they are identical
-to the matching props `Route` accepts:
+to the matching props `Route` accepts. It could also be a string or
+an array of strings as shortcut for `{ path }`:
 
 ```js
 {
@@ -40,7 +41,7 @@ matchPath("/users/2", {
       exact: true,
       strict: true
     })
-    
+
 //  {
 //    isExact: true
 //    params: {
@@ -48,7 +49,7 @@ matchPath("/users/2", {
 //    }
 //    path: "/users/:id"
 //    url: "/users/2"
-//  } 
+//  }
 ```
 
 ```
@@ -57,6 +58,6 @@ matchPath("/users", {
       exact: true,
       strict: true
     })
-    
+
 //  null
 ```

--- a/packages/react-router/modules/__tests__/matchPath-test.js
+++ b/packages/react-router/modules/__tests__/matchPath-test.js
@@ -42,6 +42,13 @@ describe("matchPath", () => {
   });
 
   describe("with an array of paths", () => {
+    it("accepts an array as 2nd argument", () => {
+      const path = ["/somewhere", "/elsewhere"];
+      const pathname = "/elsewhere";
+      const match = matchPath(pathname, path);
+      expect(match.url).toBe("/elsewhere");
+    });
+
     it('return the correct url at "/elsewhere"', () => {
       const path = ["/somewhere", "/elsewhere"];
       const pathname = "/elsewhere";

--- a/packages/react-router/modules/matchPath.js
+++ b/packages/react-router/modules/matchPath.js
@@ -26,7 +26,9 @@ function compilePath(path, options) {
  * Public API for matching a URL pathname to a path.
  */
 function matchPath(pathname, options = {}) {
-  if (typeof options === "string") options = { path: options };
+  if (typeof options === "string" || Array.isArray(options)) {
+    options = { path: options };
+  }
 
   const { path, exact = false, strict = false, sensitive = false } = options;
 


### PR DESCRIPTION
Currently `matchPath()` accepts a string as 2nd argument as shortcut for `{ path }`. Since path could also be an array, I recommend a shortcut for this too.

```javascript
matchPath("/foobar", [ "/foobar", "/hello-world" ])

```