### PR TITLE
Add useRouter(), useParams() and useLocation() hooks

### DIFF
--- a/packages/react-router-dom/.size-snapshot.json
+++ b/packages/react-router-dom/.size-snapshot.json
@@ -14,13 +14,13 @@
     }
   },
   "umd/react-router-dom.js": {
-    "bundled": 159885,
-    "minified": 56828,
-    "gzipped": 16427
+    "bundled": 161108,
+    "minified": 57320,
+    "gzipped": 16602
   },
   "umd/react-router-dom.min.js": {
-    "bundled": 96633,
-    "minified": 33776,
-    "gzipped": 9994
+    "bundled": 97676,
+    "minified": 34105,
+    "gzipped": 10100
   }
 }

--- a/packages/react-router/.size-snapshot.json
+++ b/packages/react-router/.size-snapshot.json
@@ -1,26 +1,26 @@
 {
   "esm/react-router.js": {
-    "bundled": 23563,
-    "minified": 13336,
-    "gzipped": 3696,
+    "bundled": 24807,
+    "minified": 14028,
+    "gzipped": 3883,
     "treeshaked": {
       "rollup": {
         "code": 2376,
         "import_statements": 470
       },
       "webpack": {
-        "code": 3741
+        "code": 3754
       }
     }
   },
   "umd/react-router.js": {
-    "bundled": 99218,
-    "minified": 35131,
-    "gzipped": 11249
+    "bundled": 100466,
+    "minified": 35607,
+    "gzipped": 11409
   },
   "umd/react-router.min.js": {
-    "bundled": 61762,
-    "minified": 21499,
-    "gzipped": 7619
+    "bundled": 62845,
+    "minified": 21827,
+    "gzipped": 7721
   }
 }

--- a/packages/react-router/.size-snapshot.json
+++ b/packages/react-router/.size-snapshot.json
@@ -1,8 +1,8 @@
 {
   "esm/react-router.js": {
-    "bundled": 24807,
-    "minified": 14028,
-    "gzipped": 3883,
+    "bundled": 24822,
+    "minified": 14043,
+    "gzipped": 3891,
     "treeshaked": {
       "rollup": {
         "code": 2376,
@@ -14,9 +14,9 @@
     }
   },
   "umd/react-router.js": {
-    "bundled": 100466,
-    "minified": 35607,
-    "gzipped": 11409
+    "bundled": 100481,
+    "minified": 35622,
+    "gzipped": 11419
   },
   "umd/react-router.min.js": {
     "bundled": 62845,

--- a/packages/react-router/docs/api/useLocation.md
+++ b/packages/react-router/docs/api/useLocation.md
@@ -1,0 +1,36 @@
+# useLocation
+
+Lets you access the current location of the nearest `<Route>`.
+This mean, that you can only use `useLocation()` inside of `<Router>`. Otherwise you will get an error.
+It returns an object containing the current `location` object and a function `navigate`
+for navigation inside of the routing context.
+
+Be aware of that you can use `useLocation()` only with React version 16.8.0 or later.
+In earlier versions of React you will get an error noticing you about this.
+
+```js
+import { useLocation } from "react-router";
+
+function MyComponent() {
+  const { navigate, location } = useLOcation();
+
+  // navigate to /foobar/baz and add it to the history
+  navigate("/foobar/baz");
+
+  // navigate to /foobar/baz and replace the last history entry
+  navigate("/foobar/baz", { replace: true });
+
+  location;
+  // {
+  //   pathname: ...,
+  //   search: ...,
+  //   hash: ...,
+  //   state: ...,
+  //   key: ...,
+  // }
+}
+```
+
+## arguments
+
+`useLocation()` does not accept any arguments.

--- a/packages/react-router/docs/api/useLocation.md
+++ b/packages/react-router/docs/api/useLocation.md
@@ -12,7 +12,7 @@ In earlier versions of React you will get an error noticing you about this.
 import { useLocation } from "react-router";
 
 function MyComponent() {
-  const { navigate, location } = useLOcation();
+  const { navigate, location } = useLocation();
 
   // navigate to /foobar/baz and add it to the history
   navigate("/foobar/baz");

--- a/packages/react-router/docs/api/useParams.md
+++ b/packages/react-router/docs/api/useParams.md
@@ -1,0 +1,25 @@
+# useParams
+
+Lets you access the current parsed parameters of the nearest `<Route>`.
+This mean, that you can only use `useParams()` inside of `<Router>`. Otherwise you will get an error.
+
+Be aware of that you can use `useParams()` only with React version 16.8.0 or later.
+In earlier versions of React you will get an error noticing you about this.
+
+```js
+import { useParams } from "react-router";
+
+<Route path="/foobar/:id" component={MyComponent} />;
+
+function MyComponent() {
+  const params = useParams();
+
+  // {
+  //   id: ...,
+  // }
+}
+```
+
+## arguments
+
+`useParams()` does not accept any arguments.

--- a/packages/react-router/docs/api/useRouter.md
+++ b/packages/react-router/docs/api/useRouter.md
@@ -1,0 +1,26 @@
+# useRouter
+
+Lets you access the current value of the nearest `<Route>`.
+This mean, that you can only use `useRouter()` inside of `<Router>`. Otherwise you will get an error.
+
+Be aware of that you can use `useRouter()` only with React version 16.8.0 or later.
+In earlier versions of React you will get an error noticing you about this.
+
+```js
+import { useRouter } from "react-router";
+
+function MyComponent() {
+  const context = useRouter();
+
+  // {
+  //   history: ...,
+  //   location: ...,
+  //   match: ...,
+  //   staticContext: ...,
+  // }
+}
+```
+
+## arguments
+
+`useRouter()` does not accept any arguments.

--- a/packages/react-router/modules/__tests__/useLocation-test.js
+++ b/packages/react-router/modules/__tests__/useLocation-test.js
@@ -1,0 +1,175 @@
+import React, { version as REACT_VERSION } from "react";
+import ReactDOM from "react-dom";
+import { createMemoryHistory as createHistory } from "history";
+import { useLocation, Route, MemoryRouter, Router } from "react-router";
+
+import renderStrict from "./utils/renderStrict";
+import compareVersions from "./utils/compareVersions";
+
+function noop() {}
+
+describe("useParams()", () => {
+  const node = document.createElement("div");
+
+  afterEach(() => {
+    ReactDOM.unmountComponentAtNode(node);
+  });
+
+  describe("with React version 16.8.0 or later", () => {
+    if (compareVersions("16.8.0", REACT_VERSION) === 1) {
+      it.skip("returns the current parameters", noop);
+
+      describe("without a <Router>", () => {
+        it.skip("throws an error", noop);
+      });
+
+      describe("the `location` return value", () => {
+        it.skip("returns the current location", noop);
+      });
+
+      describe("the `navigate` return value", () => {
+        it.skip("returns a function", noop);
+        it.skip("uses the passed path", noop);
+
+        describe("without 2nd argument / with 2nd argument is { replace: false }", () => {
+          it.skip("uses history.push()", noop);
+        });
+
+        describe("with 2nd argument is { replace: true }", () => {
+          it.skip("uses history.replace()", noop);
+        });
+      });
+
+      return;
+    }
+
+    describe("without a <Router>", () => {
+      it("throws an error", () => {
+        jest.spyOn(console, "error").mockImplementation(() => {});
+
+        function TestComponent() {
+          useLocation();
+        }
+
+        expect(() => {
+          renderStrict(<TestComponent />, node);
+        }).toThrow(/You should not use useRouter\(\) outside a <Router>/);
+      });
+    });
+
+    describe("the `location` return value", () => {
+      it("returns the current location", () => {
+        function TestComponent(args) {
+          const { location: locationFromRoute } = args;
+          const { location: locationFromHook } = useLocation();
+          expect(locationFromHook).toBe(locationFromRoute);
+          return null;
+        }
+
+        renderStrict(
+          <MemoryRouter initialEntries={["/cupcakes"]}>
+            <Route path="/cupcakes" component={TestComponent} />
+          </MemoryRouter>,
+          node
+        );
+      });
+    });
+
+    describe("the `navigate` return value", () => {
+      it("returns a function", () => {
+        function TestComponent() {
+          const { navigate } = useLocation();
+          expect(typeof navigate).toBe("function");
+          return null;
+        }
+
+        renderStrict(
+          <MemoryRouter initialEntries={["/cupcakes"]}>
+            <Route path="/cupcakes" component={TestComponent} />
+          </MemoryRouter>,
+          node
+        );
+      });
+
+      it("uses the passed path", () => {
+        const history = createHistory({
+          initialEntries: ["/cupcakes"]
+        });
+
+        history.push = jest.spyOn(history, "push");
+
+        function TestComponent() {
+          const { navigate } = useLocation();
+          navigate("/foobar");
+          return null;
+        }
+
+        renderStrict(
+          <Router history={history}>
+            <Route path="/cupcakes" component={TestComponent} />
+          </Router>,
+          node
+        );
+
+        expect(history.push).toHaveBeenCalledTimes(1);
+        expect(history.push).toHaveBeenCalledWith("/foobar");
+      });
+
+      describe("without 2nd argument / with 2nd argument is { replace: false }", () => {
+        it("uses history.push()", () => {
+          const history = createHistory({
+            initialEntries: ["/cupcakes"]
+          });
+
+          history.push = jest.spyOn(history, "push");
+          history.replace = jest.spyOn(history, "replace");
+
+          function TestComponent() {
+            const { navigate } = useLocation();
+            navigate("/foobar", { replace: false });
+            return null;
+          }
+
+          renderStrict(
+            <Router history={history}>
+              <Route path="/cupcakes" component={TestComponent} />
+            </Router>,
+            node
+          );
+
+          expect(history.push).toHaveBeenCalledTimes(1);
+          expect(history.push).toHaveBeenCalledWith("/foobar");
+          expect(history.replace).toHaveBeenCalledTimes(0);
+        });
+      });
+
+      describe("with 2nd argument is { replace: true }", () => {
+        it("uses history.replace()", () => {
+          const history = createHistory({
+            initialEntries: ["/cupcakes"]
+          });
+
+          history.push = jest.spyOn(history, "push");
+          history.replace = jest.spyOn(history, "replace");
+
+          function TestComponent() {
+            const { navigate } = useLocation();
+            navigate("/foobar", { replace: true });
+            return null;
+          }
+
+          renderStrict(
+            <Router history={history}>
+              <Route path="/cupcakes" component={TestComponent} />
+            </Router>,
+            node
+          );
+
+          expect(history.replace).toHaveBeenCalledTimes(1);
+          expect(history.replace).toHaveBeenCalledWith("/foobar");
+          expect(history.push).toHaveBeenCalledTimes(0);
+        });
+      });
+    });
+  });
+});

--- a/packages/react-router/modules/__tests__/useLocation-test.js
+++ b/packages/react-router/modules/__tests__/useLocation-test.js
@@ -53,7 +53,9 @@ describe("useParams()", () => {
 
         expect(() => {
           renderStrict(<TestComponent />, node);
-        }).toThrow(/You should not use useRouter\(\) outside a <Router>/);
+        }).toThrow(
+          /You should not use useRouter\(\) or other hooks outside a <Router>/
+        );
       });
     });
 

--- a/packages/react-router/modules/__tests__/useParams-test.js
+++ b/packages/react-router/modules/__tests__/useParams-test.js
@@ -1,0 +1,57 @@
+import React, { version as REACT_VERSION } from "react";
+import ReactDOM from "react-dom";
+import { useParams, Route, MemoryRouter } from "react-router";
+
+import renderStrict from "./utils/renderStrict";
+import compareVersions from "./utils/compareVersions";
+
+function noop() {}
+
+describe("useParams()", () => {
+  const node = document.createElement("div");
+
+  afterEach(() => {
+    ReactDOM.unmountComponentAtNode(node);
+  });
+
+  describe("with React version 16.8.0 or later", () => {
+    if (compareVersions("16.8.0", REACT_VERSION) === 1) {
+      it.skip("returns the current parameters", noop);
+
+      describe("without a <Router>", () => {
+        it.skip("throws an error", noop);
+      });
+
+      return;
+    }
+
+    describe("without a <Router>", () => {
+      it("throws an error", () => {
+        jest.spyOn(console, "error").mockImplementation(() => {});
+
+        function TestComponent() {
+          useParams();
+        }
+
+        expect(() => {
+          renderStrict(<TestComponent />, node);
+        }).toThrow(/You should not use useRouter\(\) outside a <Router>/);
+      });
+    });
+
+    it("returns the current parameters", () => {
+      function TestComponent() {
+        const { foobar } = useParams();
+        expect(foobar).toEqual("barbaz");
+        return null;
+      }
+
+      renderStrict(
+        <MemoryRouter initialEntries={["/cupcakes/barbaz"]}>
+          <Route path="/cupcakes/:foobar" component={TestComponent} />
+        </MemoryRouter>,
+        node
+      );
+    });
+  });
+});

--- a/packages/react-router/modules/__tests__/useParams-test.js
+++ b/packages/react-router/modules/__tests__/useParams-test.js
@@ -35,7 +35,9 @@ describe("useParams()", () => {
 
         expect(() => {
           renderStrict(<TestComponent />, node);
-        }).toThrow(/You should not use useRouter\(\) outside a <Router>/);
+        }).toThrow(
+          /You should not use useRouter\(\) or other hooks outside a <Router>/
+        );
       });
     });
 

--- a/packages/react-router/modules/__tests__/useRouter-test.js
+++ b/packages/react-router/modules/__tests__/useRouter-test.js
@@ -1,0 +1,63 @@
+import React, { version as REACT_VERSION } from "react";
+import ReactDOM from "react-dom";
+import { useRouter, __RouterContext as RouterContext } from "react-router";
+
+import renderStrict from "./utils/renderStrict";
+import compareVersions from "./utils/compareVersions";
+
+function noop() {}
+
+describe("useRouter()", () => {
+  const node = document.createElement("div");
+
+  afterEach(() => {
+    ReactDOM.unmountComponentAtNode(node);
+  });
+
+  describe("with React version 16.8.0 or later", () => {
+    if (compareVersions("16.8.0", REACT_VERSION) === 1) {
+      it.skip("returns the current context value", noop);
+
+      describe("without a <Router>", () => {
+        it.skip("throws an error", noop);
+      });
+
+      return;
+    }
+
+    describe("without a <Router>", () => {
+      it("throws an error", () => {
+        jest.spyOn(console, "error").mockImplementation(() => {});
+
+        function TestComponent() {
+          useRouter();
+        }
+
+        expect(() => {
+          renderStrict(<TestComponent />, node);
+        }).toThrow(/You should not use useRouter\(\) outside a <Router>/);
+      });
+    });
+
+    it("returns the current context value", () => {
+      function TestComponent() {
+        const context = useRouter();
+
+        return (
+          <RouterContext.Consumer>
+            {children => {
+              expect(children).toBe(context);
+            }}
+          </RouterContext.Consumer>
+        );
+      }
+
+      renderStrict(
+        <RouterContext.Provider value={{ foobar: "barbaz" }}>
+          <TestComponent />
+        </RouterContext.Provider>,
+        node
+      );
+    });
+  });
+});

--- a/packages/react-router/modules/__tests__/useRouter-test.js
+++ b/packages/react-router/modules/__tests__/useRouter-test.js
@@ -35,7 +35,9 @@ describe("useRouter()", () => {
 
         expect(() => {
           renderStrict(<TestComponent />, node);
-        }).toThrow(/You should not use useRouter\(\) outside a <Router>/);
+        }).toThrow(
+          /You should not use useRouter\(\) or other hooks outside a <Router>/
+        );
       });
     });
 

--- a/packages/react-router/modules/__tests__/utils/compareVersions.js
+++ b/packages/react-router/modules/__tests__/utils/compareVersions.js
@@ -1,0 +1,16 @@
+function compareVersions(a, b) {
+  const aparts = a.split(".").map(part => parseInt(part));
+  const bparts = b.split(".").map(part => parseInt(part));
+
+  return aparts.reduce((ret, apart, index) => {
+    const bpart = bparts[index] || 0;
+
+    if (ret !== 0) {
+      return ret;
+    }
+
+    return Math.sign(apart - bpart);
+  }, 0);
+}
+
+export default compareVersions;

--- a/packages/react-router/modules/index.js
+++ b/packages/react-router/modules/index.js
@@ -31,5 +31,8 @@ export { default as Switch } from "./Switch";
 export { default as generatePath } from "./generatePath";
 export { default as matchPath } from "./matchPath";
 export { default as withRouter } from "./withRouter";
+export { default as useRouter } from "./useRouter";
+export { default as useParams } from "./useParams";
+export { default as useLocation } from "./useLocation";
 
 export { default as __RouterContext } from "./RouterContext";

--- a/packages/react-router/modules/useLocation.js
+++ b/packages/react-router/modules/useLocation.js
@@ -1,0 +1,20 @@
+import useRouter from "./useRouter";
+
+function useLocation() {
+  const { location, history } = useRouter();
+
+  function navigate(to, { replace = false } = {}) {
+    if (replace) {
+      history.replace(to);
+    } else {
+      history.push(to);
+    }
+  }
+
+  return {
+    location,
+    navigate
+  };
+}
+
+export default useLocation;

--- a/packages/react-router/modules/useParams.js
+++ b/packages/react-router/modules/useParams.js
@@ -1,0 +1,8 @@
+import useRouter from "./useRouter";
+
+function useParams() {
+  const { match } = useRouter();
+  return match.params;
+}
+
+export default useParams;

--- a/packages/react-router/modules/useRouter.js
+++ b/packages/react-router/modules/useRouter.js
@@ -1,0 +1,25 @@
+import { useContext, version as REACT_VERSION } from "react";
+import invariant from "tiny-invariant";
+
+import RouterContext from "./RouterContext";
+
+// needed for ESM builds
+let useRouter = null;
+
+if (useContext) {
+  useRouter = function useRouter() {
+    const context = useContext(RouterContext);
+    invariant(context, "You should not use useRouter() outside a <Router>");
+    return context;
+  };
+} else {
+  useRouter = function useRouter() {
+    invariant(
+      false,
+      "React Hooks require at least React version 16.8.0. " +
+        `You are using React version ${REACT_VERSION}.`
+    );
+  };
+}
+
+export default useRouter;

--- a/packages/react-router/modules/useRouter.js
+++ b/packages/react-router/modules/useRouter.js
@@ -9,7 +9,10 @@ let useRouter = null;
 if (useContext) {
   useRouter = function useRouter() {
     const context = useContext(RouterContext);
-    invariant(context, "You should not use useRouter() outside a <Router>");
+    invariant(
+      context,
+      "You should not use useRouter() or other hooks outside a <Router>"
+    );
     return context;
   };
 } else {


### PR DESCRIPTION
This PR adds three functions to React Router, that work as "described" by Ryan Florence [in the blog](https://reacttraining.com/blog/reach-react-router-future/). While we are supporting React version before 16.8.0 ([the one with the hooks](https://reactjs.org/docs/hooks-intro.html)), we need a way to walk around the older versions. Everyone who wants to use the hooks in an earlier version of React will get an error message. Therefore an erroneous usage of the hook functions is impossible / fails.

* `useRouter()`: returns the value of `<ReactRouter.Provider value />`
* `useParams()`: returns the value of `context.match.params`
* `useLocation()`: returns 1) the value of `context.location`, 2) a wrapper function (`navigate`) around `context.history.push` and `context.history.replace`. `navigate` takes two argument, where the 2nd one is optional. The 1st argument is a path, the 2nd argument could be either `{ replace: false }` (default value) or `{ replace: true }`. If `replace = true` then `history.replace` will be used, otherwise `history.push`.