### PR TITLE
build: add sourcemaps

### DIFF
--- a/packages/react-router-config/package.json
+++ b/packages/react-router-config/package.json
@@ -13,6 +13,8 @@
     "esm",
     "index.js",
     "matchRoutes.js",
+    "modules/*.js",
+    "modules/utils/*.js",
     "renderRoutes.js",
     "warnAboutDeprecatedCJSRequire.js",
     "umd"

--- a/packages/react-router-config/rollup.config.js
+++ b/packages/react-router-config/rollup.config.js
@@ -16,19 +16,24 @@ function isBareModuleId(id) {
 const cjs = [
   {
     input: "modules/index.js",
-    output: { file: `cjs/${pkg.name}.js`, format: "cjs", esModule: false },
+    output: {
+      file: `cjs/${pkg.name}.js`,
+      sourcemap: true,
+      format: "cjs",
+      esModule: false
+    },
     external: isBareModuleId,
     plugins: [
-      babel({ exclude: /node_modules/ }),
+      babel({ exclude: /node_modules/, sourceMaps: true }),
       replace({ "process.env.NODE_ENV": JSON.stringify("development") })
     ]
   },
   {
     input: "modules/index.js",
-    output: { file: `cjs/${pkg.name}.min.js`, format: "cjs" },
+    output: { file: `cjs/${pkg.name}.min.js`, sourcemap: true, format: "cjs" },
     external: isBareModuleId,
     plugins: [
-      babel({ exclude: /node_modules/ }),
+      babel({ exclude: /node_modules/, sourceMaps: true }),
       replace({ "process.env.NODE_ENV": JSON.stringify("production") }),
       uglify()
     ]
@@ -38,11 +43,12 @@ const cjs = [
 const esm = [
   {
     input: "modules/index.js",
-    output: { file: `esm/${pkg.name}.js`, format: "esm" },
+    output: { file: `esm/${pkg.name}.js`, sourcemap: true, format: "esm" },
     external: isBareModuleId,
     plugins: [
       babel({
         exclude: /node_modules/,
+        sourceMaps: true,
         runtimeHelpers: true,
         plugins: [["@babel/transform-runtime", { useESModules: true }]]
       }),
@@ -58,6 +64,9 @@ const umd = [
     input: "modules/index.js",
     output: {
       file: `umd/${pkg.name}.js`,
+      sourcemap: true,
+      sourcemapPathTransform: relativePath =>
+        relativePath.replace(/^.*?\/node_modules/, "../../node_modules"),
       format: "umd",
       name: "ReactRouterConfig",
       globals
@@ -67,6 +76,7 @@ const umd = [
       babel({
         exclude: /node_modules/,
         runtimeHelpers: true,
+        sourceMaps: true,
         plugins: [["@babel/transform-runtime", { useESModules: true }]]
       }),
       nodeResolve(),
@@ -79,6 +89,9 @@ const umd = [
     input: "modules/index.js",
     output: {
       file: `umd/${pkg.name}.min.js`,
+      sourcemap: true,
+      sourcemapPathTransform: relativePath =>
+        relativePath.replace(/^.*?\/node_modules/, "../../node_modules"),
       format: "umd",
       name: "ReactRouterConfig",
       globals
@@ -88,6 +101,7 @@ const umd = [
       babel({
         exclude: /node_modules/,
         runtimeHelpers: true,
+        sourceMaps: true,
         plugins: [["@babel/transform-runtime", { useESModules: true }]]
       }),
       nodeResolve(),

--- a/packages/react-router-dom/package.json
+++ b/packages/react-router-dom/package.json
@@ -26,6 +26,8 @@
     "index.js",
     "generatePath.js",
     "matchPath.js",
+    "modules/*.js",
+    "modules/utils/*.js",
     "withRouter.js",
     "warnAboutDeprecatedCJSRequire.js",
     "umd"

--- a/packages/react-router-dom/rollup.config.js
+++ b/packages/react-router-dom/rollup.config.js
@@ -16,19 +16,24 @@ function isBareModuleId(id) {
 const cjs = [
   {
     input: "modules/index.js",
-    output: { file: `cjs/${pkg.name}.js`, format: "cjs", esModule: false },
+    output: {
+      file: `cjs/${pkg.name}.js`,
+      sourcemap: true,
+      format: "cjs",
+      esModule: false
+    },
     external: isBareModuleId,
     plugins: [
-      babel({ exclude: /node_modules/ }),
+      babel({ exclude: /node_modules/, sourceMaps: true }),
       replace({ "process.env.NODE_ENV": JSON.stringify("development") })
     ]
   },
   {
     input: "modules/index.js",
-    output: { file: `cjs/${pkg.name}.min.js`, format: "cjs" },
+    output: { file: `cjs/${pkg.name}.min.js`, sourcemap: true, format: "cjs" },
     external: isBareModuleId,
     plugins: [
-      babel({ exclude: /node_modules/ }),
+      babel({ exclude: /node_modules/, sourceMaps: true }),
       replace({ "process.env.NODE_ENV": JSON.stringify("production") }),
       uglify()
     ]
@@ -38,12 +43,13 @@ const cjs = [
 const esm = [
   {
     input: "modules/index.js",
-    output: { file: `esm/${pkg.name}.js`, format: "esm" },
+    output: { file: `esm/${pkg.name}.js`, sourcemap: true, format: "esm" },
     external: isBareModuleId,
     plugins: [
       babel({
         exclude: /node_modules/,
         runtimeHelpers: true,
+        sourceMaps: true,
         plugins: [["@babel/transform-runtime", { useESModules: true }]]
       }),
       sizeSnapshot()
@@ -58,6 +64,9 @@ const umd = [
     input: "modules/index.js",
     output: {
       file: `umd/${pkg.name}.js`,
+      sourcemap: true,
+      sourcemapPathTransform: relativePath =>
+        relativePath.replace(/^.*?\/node_modules/, "../../node_modules"),
       format: "umd",
       name: "ReactRouterDOM",
       globals
@@ -67,6 +76,7 @@ const umd = [
       babel({
         exclude: /node_modules/,
         runtimeHelpers: true,
+        sourceMaps: true,
         plugins: [["@babel/transform-runtime", { useESModules: true }]]
       }),
       nodeResolve(),
@@ -86,6 +96,9 @@ const umd = [
     input: "modules/index.js",
     output: {
       file: `umd/${pkg.name}.min.js`,
+      sourcemap: true,
+      sourcemapPathTransform: relativePath =>
+        relativePath.replace(/^.*?\/node_modules/, "../../node_modules"),
       format: "umd",
       name: "ReactRouterDOM",
       globals
@@ -95,6 +108,7 @@ const umd = [
       babel({
         exclude: /node_modules/,
         runtimeHelpers: true,
+        sourceMaps: true,
         plugins: [["@babel/transform-runtime", { useESModules: true }]]
       }),
       nodeResolve(),

--- a/packages/react-router/package.json
+++ b/packages/react-router/package.json
@@ -22,6 +22,8 @@
     "index.js",
     "generatePath.js",
     "matchPath.js",
+    "modules/*.js",
+    "modules/utils/*.js",
     "withRouter.js",
     "warnAboutDeprecatedCJSRequire.js",
     "umd"

--- a/packages/react-router/rollup.config.js
+++ b/packages/react-router/rollup.config.js
@@ -16,10 +16,15 @@ function isBareModuleId(id) {
 const cjs = [
   {
     input: "modules/index.js",
-    output: { file: `cjs/${pkg.name}.js`, format: "cjs", esModule: false },
+    output: {
+      file: `cjs/${pkg.name}.js`,
+      sourcemap: true,
+      format: "cjs",
+      esModule: false
+    },
     external: isBareModuleId,
     plugins: [
-      babel({ exclude: /node_modules/ }),
+      babel({ exclude: /node_modules/, sourceMaps: true }),
       replace({
         "process.env.NODE_ENV": JSON.stringify("development"),
         "process.env.BUILD_FORMAT": JSON.stringify("cjs")
@@ -28,10 +33,10 @@ const cjs = [
   },
   {
     input: "modules/index.js",
-    output: { file: `cjs/${pkg.name}.min.js`, format: "cjs" },
+    output: { file: `cjs/${pkg.name}.min.js`, sourcemap: true, format: "cjs" },
     external: isBareModuleId,
     plugins: [
-      babel({ exclude: /node_modules/ }),
+      babel({ exclude: /node_modules/, sourceMaps: true }),
       replace({
         "process.env.NODE_ENV": JSON.stringify("production"),
         "process.env.BUILD_FORMAT": JSON.stringify("cjs")
@@ -44,12 +49,13 @@ const cjs = [
 const esm = [
   {
     input: "modules/index.js",
-    output: { file: `esm/${pkg.name}.js`, format: "esm" },
+    output: { file: `esm/${pkg.name}.js`, sourcemap: true, format: "esm" },
     external: isBareModuleId,
     plugins: [
       babel({
         exclude: /node_modules/,
         runtimeHelpers: true,
+        sourceMaps: true,
         plugins: [["@babel/transform-runtime", { useESModules: true }]]
       }),
       replace({ "process.env.BUILD_FORMAT": JSON.stringify("esm") }),
@@ -65,6 +71,9 @@ const umd = [
     input: "modules/index.js",
     output: {
       file: `umd/${pkg.name}.js`,
+      sourcemap: true,
+      sourcemapPathTransform: relativePath =>
+        relativePath.replace(/^.*?\/node_modules/, "../../node_modules"),
       format: "umd",
       name: "ReactRouter",
       globals
@@ -74,6 +83,7 @@ const umd = [
       babel({
         exclude: /node_modules/,
         runtimeHelpers: true,
+        sourceMaps: true,
         plugins: [["@babel/transform-runtime", { useESModules: true }]]
       }),
       nodeResolve(),
@@ -94,6 +104,9 @@ const umd = [
     input: "modules/index.js",
     output: {
       file: `umd/${pkg.name}.min.js`,
+      sourcemap: true,
+      sourcemapPathTransform: relativePath =>
+        relativePath.replace(/^.*?\/node_modules/, "../../node_modules"),
       format: "umd",
       name: "ReactRouter",
       globals
@@ -103,6 +116,7 @@ const umd = [
       babel({
         exclude: /node_modules/,
         runtimeHelpers: true,
+        sourceMaps: true,
         plugins: [["@babel/transform-runtime", { useESModules: true }]]
       }),
       nodeResolve(),


### PR DESCRIPTION
Unless your idea of fun is mentally un-transpiling ES5 code into ES6 and JSX, you'll like this PR. It makes debugging easier by adding sourcemaps for the react-router, react-router-dom, and react-router-config packages.  The following build-time config changes are included: 
1. Add `sourceMaps: true` to babel config for each package 
2. Make a similar change to rollup `output` config, except it's called `sourcemap: true` here because, uh, diversity is good? ;-)
3. Added the source files in the `modules` folder to the `files` whitelist in each package's package.json, so that the original source will be installed by npm or yarn so that the sourcemaps have original source to point to.
4. Unlike the other module formats, UMD bundles all dependencies and therefore its sourcemaps include references to folders in `node_modules`. Unfortunately, the default paths to these folders are correct at build time but won't be correct when packages are installed on dev machines. This is a common problem, especially with monorepos. To fix, I added a one-line [`sourcemapPathTransform`](https://rollupjs.org/guide/en/#outputsourcemappathtransform) to rollup's output config (for UMD only). This transform replaces all variations of `node_modules` paths with a normalized path starting with `../../node_modules/` which is where these files are most likely to be installed by npm or yarn on a dev machine.

Note that this PR doesn't touch the react-router-native package because I am not familiar enough with React Native to know how to add sourcemaps there.

Using this PR, `npm pack`, and one of my apps that uses react-router, I verified that sourcemaps are now working with the VSCode and chrome devtools debuggers.  "Working" means: (in case you want to verify it too)
* Original source is installed in my app's `./node_modules/react-router*/modules` folders
* I can step from my code into react-router code and the original source is highlighted, not the transpiled source
* I can set a breakpoint on a line of original source in react-router or react-router-dom and the debugger will correctly break on that line when my app runs.

BTW, this PR is analogous to https://github.com/bvaughn/react-window/pull/275 which I recently filed to add sourcemaps to Brian Vaughn's [react-window](https://github.com/bvaughn/react-window) library. That library also uses rollup and babel, so the changes needed to add sourcemaps there were similar to this PR.  Slowly but surely I'm gonna try to fix sourcemaps of all my most important dependencies! ;-)
