### PR TITLE
Update Link.md

### DIFF
--- a/packages/react-router-dom/docs/api/Link.md
+++ b/packages/react-router-dom/docs/api/Link.md
@@ -10,7 +10,7 @@ import { Link } from 'react-router-dom'
 
 ## to: string
 
-A string representation of the link location, created by concatenating the location's pathname, search, and hash properties.
+A string representation of the Link location, created by concatenating the location's pathname, search, and hash properties.
 
 ```jsx
 <Link to="/courses?sort=name" />

--- a/packages/react-router-dom/docs/api/Link.md
+++ b/packages/react-router-dom/docs/api/Link.md
@@ -10,7 +10,7 @@ import { Link } from 'react-router-dom'
 
 ## to: string
 
-A string representation of the location to link to, created by concatenating the location's pathname, search, and hash properties.
+A string representation of the link location, created by concatenating the location's pathname, search, and hash properties.
 
 ```jsx
 <Link to="/courses?sort=name" />


### PR DESCRIPTION
There are two beneficial aspects to this proposed text change:

1. Syntax
2. Semantics

### Syntax

The previous version of this text reads weird since the word "to" is used twice in short order.

### Semantics

This updated version is easier to read and makes more sense semantically because it is changing the emphasis of the sentence. With the previous sentence structure, the **activity** of the link is being made predominant; this is redundant imo since the basic action of what a link does is implicit in the context. In other words, everyone knows what a link does - there is no reason to highlight this in the sentence structure. 

The new sentence structure instead highlights the link **location** as the predominant object of this sentence rather than the **action** of the link. Highlighting the **location** rather than **action** of the sentence is more fitting given the context of what this method does (i.e. accepts a location to match).