### PR TITLE
docs: Fix links to reactjs docs

### DIFF
--- a/packages/react-router-dom/docs/api/BrowserRouter.md
+++ b/packages/react-router-dom/docs/api/BrowserRouter.md
@@ -57,4 +57,4 @@ The length of `location.key`. Defaults to 6.
 
 ## children: node
 
-A [single child element](https://facebook.github.io/react/docs/react-api.html#react.children.only) to render.
+A [single child element](https://facebook.github.io/react/docs/react-api.html#reactchildrenonly) to render.

--- a/packages/react-router-dom/docs/api/HashRouter.md
+++ b/packages/react-router-dom/docs/api/HashRouter.md
@@ -47,4 +47,4 @@ Defaults to `"slash"`.
 
 ## children: node
 
-A [single child element](https://facebook.github.io/react/docs/react-api.html#react.children.only) to render.
+A [single child element](https://facebook.github.io/react/docs/react-api.html#reactchildrenonly) to render.

--- a/packages/react-router-native/docs/api/NativeRouter.md
+++ b/packages/react-router-native/docs/api/NativeRouter.md
@@ -38,4 +38,4 @@ The length of `location.key`. Defaults to 6.
 
 ## children: node
 
-A [single child element](https://facebook.github.io/react/docs/react-api.html#react.children.only) to render.
+A [single child element](https://facebook.github.io/react/docs/react-api.html#reactchildrenonly) to render.

--- a/packages/react-router/docs/api/MemoryRouter.md
+++ b/packages/react-router/docs/api/MemoryRouter.md
@@ -41,4 +41,4 @@ The length of `location.key`. Defaults to 6.
 
 ## children: node
 
-A [single child element](https://facebook.github.io/react/docs/react-api.html#react.children.only) to render.
+A [single child element](https://facebook.github.io/react/docs/react-api.html#reactchildrenonly) to render.

--- a/packages/react-router/docs/api/Router.md
+++ b/packages/react-router/docs/api/Router.md
@@ -36,7 +36,7 @@ const customHistory = createBrowserHistory();
 
 ## children: node
 
-A [single child element](https://facebook.github.io/react/docs/react-api.html#react.children.only) to render.
+A [single child element](https://facebook.github.io/react/docs/react-api.html#reactchildrenonly) to render.
 
 ```jsx
 <Router>

--- a/packages/react-router/docs/api/StaticRouter.md
+++ b/packages/react-router/docs/api/StaticRouter.md
@@ -88,4 +88,4 @@ if (context.status === "404") {
 
 ## children: node
 
-A [single child element](https://facebook.github.io/react/docs/react-api.html#react.children.only) to render.
+A [single child element](https://facebook.github.io/react/docs/react-api.html#reactchildrenonly) to render.


### PR DESCRIPTION
Hi!

The correct link to the `React.Children.only` API doc is `https://facebook.github.io/react/docs/react-api.html#reactchildrenonly`, not `https://facebook.github.io/react/docs/react-api.html#react.children.only`. This PR fixes that.

Cheers!