### PR TITLE
 Add support `toLocation` to <NavLink /> method isActive

### DIFF
--- a/packages/react-router-dom/.size-snapshot.json
+++ b/packages/react-router-dom/.size-snapshot.json
@@ -1,8 +1,8 @@
 {
   "esm/react-router-dom.js": {
-    "bundled": 8793,
-    "minified": 5220,
-    "gzipped": 1681,
+    "bundled": 8805,
+    "minified": 5222,
+    "gzipped": 1683,
     "treeshaked": {
       "rollup": {
         "code": 379,
@@ -14,13 +14,13 @@
     }
   },
   "umd/react-router-dom.js": {
-    "bundled": 159885,
-    "minified": 56828,
-    "gzipped": 16427
+    "bundled": 159897,
+    "minified": 56830,
+    "gzipped": 16429
   },
   "umd/react-router-dom.min.js": {
-    "bundled": 96633,
-    "minified": 33776,
-    "gzipped": 9994
+    "bundled": 96645,
+    "minified": 33778,
+    "gzipped": 9996
   }
 }

--- a/packages/react-router-dom/docs/api/NavLink.md
+++ b/packages/react-router-dom/docs/api/NavLink.md
@@ -3,9 +3,9 @@
 A special version of the [`<Link>`](Link.md) that will add styling attributes to the rendered element when it matches the current URL.
 
 ```jsx
-import { NavLink } from 'react-router-dom'
+import { NavLink } from "react-router-dom";
 
-<NavLink to="/about">About</NavLink>
+<NavLink to="/about">About</NavLink>;
 ```
 
 ## activeClassName: string
@@ -60,18 +60,17 @@ A function to add extra logic for determining whether the link is active. This s
 
 ```jsx
 // only consider an event active if its event id is an odd number
-const oddEvent = (match, location) => {
+const oddEvent = (match, currentLocation, toLocation) => {
   if (!match) {
-    return false
+    return false;
   }
-  const eventID = parseInt(match.params.eventID)
-  return !isNaN(eventID) && eventID % 2 === 1
-}
+  const eventID = parseInt(match.params.eventID);
+  return !isNaN(eventID) && eventID % 2 === 1;
+};
 
-<NavLink
-  to="/events/123"
-  isActive={oddEvent}
->Event 123</NavLink>
+<NavLink to="/events/123" isActive={oddEvent}>
+  Event 123
+</NavLink>;
 ```
 
 ## location: object

--- a/packages/react-router-dom/modules/NavLink.js
+++ b/packages/react-router-dom/modules/NavLink.js
@@ -45,7 +45,7 @@ function NavLink({
           ? matchPath(pathToMatch, { path: escapedPath, exact, strict })
           : null;
         const isActive = !!(isActiveProp
-          ? isActiveProp(match, context.location)
+          ? isActiveProp(match, context.location, toLocation)
           : match);
 
         const className = isActive

--- a/packages/react-router-dom/modules/__tests__/NavLink-test.js
+++ b/packages/react-router-dom/modules/__tests__/NavLink-test.js
@@ -317,6 +317,31 @@ describe("A <NavLink>", () => {
       expect(a.className).not.toContain("active");
       expect(a.className).not.toContain("selected");
     });
+
+    it("applies active default props when isActive returns true due to toLocation custom logic", () => {
+      const isNavLinkActive = (match, current, to) => {
+        const baseLink = "/pizza";
+        const currentLink = current.pathname;
+        const toLink = to.pathname;
+
+        return !!(
+          currentLink.indexOf(baseLink) >= 0 && toLink.indexOf(baseLink) >= 0
+        );
+      };
+
+      renderStrict(
+        <MemoryRouter initialEntries={["/pizza/quattro-stagioni"]}>
+          <NavLink to="/pizza/funghi" isActive={isNavLinkActive}>
+            Pizza!
+          </NavLink>
+        </MemoryRouter>,
+        node
+      );
+
+      const a = node.querySelector("a");
+
+      expect(a.className).toContain("active");
+    });
   });
 
   it("does not do exact matching by default", () => {


### PR DESCRIPTION
Hello everyone,
I would like to offer support of an extra (third) parameter to the props function `isActive` of the component `<NavLink />`.
Currently the parameters available are

- _match_
- _context.location_ 

In some projects I was working at, I found the extra need to access also the `to` props of `<NavLink />` within the method `isActive`

Does this make sense to you? Thanks a lot. Any feedback is welcome.