### PR TITLE
export default renderToStringStrict

### DIFF
--- a/packages/react-router-config/modules/__tests__/utils/renderToStringStrict.js
+++ b/packages/react-router-config/modules/__tests__/utils/renderToStringStrict.js
@@ -7,4 +7,4 @@ function renderToStringStrict(element) {
   return ReactDOMServer.renderToString(<StrictMode>{element}</StrictMode>);
 }
 
-module.exports = renderToStringStrict;
+export default renderToStringStrict;


### PR DESCRIPTION
This fixes issue #6854 because you were using es6 import to find the default export, but in renderToStringStrict.js you were still using the old export