### PR TITLE
Improve documentation readability for matchPath

### DIFF
--- a/packages/react-router/docs/api/matchPath.md
+++ b/packages/react-router/docs/api/matchPath.md
@@ -33,14 +33,14 @@ an array of strings as shortcut for `{ path }`:
 
 ## returns
 
-It returns an object when provided pathname does match `path` prop or `null` otherwise.
+It returns an object when provided pathname does match `path` prop.
 
-```
+```js
 matchPath("/users/2", {
-      path: "/users/:id",
-      exact: true,
-      strict: true
-    })
+  path: "/users/:id",
+  exact: true,
+  strict: true
+});
 
 //  {
 //    isExact: true
@@ -52,12 +52,14 @@ matchPath("/users/2", {
 //  }
 ```
 
-```
+It returns `null` when provided pathname does not match `path` prop.
+
+```js
 matchPath("/users", {
-      path: "/users/:id",
-      exact: true,
-      strict: true
-    })
+  path: "/users/:id",
+  exact: true,
+  strict: true
+});
 
 //  null
 ```


### PR DESCRIPTION
Hi,

I have noticed that there are small styling problems for [matchPath returns](https://reacttraining.com/react-router/web/api/matchPath/returns) documentation.

### Fix
Small PR for updating the markdown readme with _JS code blocks_ and splitting **object** and **null** return examples. 

