### PR TITLE
Make to prop for Links optional

### DIFF
--- a/packages/react-router-dom/modules/Link.js
+++ b/packages/react-router-dom/modules/Link.js
@@ -9,7 +9,7 @@ function isModifiedEvent(event) {
 }
 
 function LinkAnchor({ innerRef, navigate, onClick, ...rest }) {
-  const { target } = rest;
+  const { target, href } = rest;
 
   return (
     <a
@@ -17,7 +17,7 @@ function LinkAnchor({ innerRef, navigate, onClick, ...rest }) {
       ref={innerRef} // TODO: Use forwardRef instead
       onClick={event => {
         try {
-          if (onClick) onClick(event);
+          if (href && onClick) onClick(event);
         } catch (ex) {
           event.preventDefault();
           throw ex;
@@ -47,18 +47,22 @@ function Link({ component = LinkAnchor, replace, to, ...rest }) {
         invariant(context, "You should not use <Link> outside a <Router>");
 
         const { history } = context;
+    
+        let href;
+        if (to) {
+          const location = normalizeToLocation(
+            resolveToLocation(to, context.location),
+            context.location
+          );
 
-        const location = normalizeToLocation(
-          resolveToLocation(to, context.location),
-          context.location
-        );
-
-        const href = location ? history.createHref(location) : "";
+          href = location ? history.createHref(location) : "";
+        }
 
         return React.createElement(component, {
           ...rest,
           href,
           navigate() {
+            if (!to) return;
             const location = resolveToLocation(to, context.location);
             const method = replace ? history.replace : history.push;
 
@@ -87,7 +91,7 @@ if (__DEV__) {
     onClick: PropTypes.func,
     replace: PropTypes.bool,
     target: PropTypes.string,
-    to: toType.isRequired
+    to: toType
   };
 }
 


### PR DESCRIPTION
`href` is not required for `<a>` tags in the HTML spec: https://html.spec.whatwg.org/multipage/links.html#attr-hyperlink-href

This allows easy disabling of `<Link>` because as the spec says "when those elements do not have href attributes they do not create hyperlinks". For example:
```js
const MyLink = ({ to, disabled, children }) => <Link to={disabled ? null : to}>{children}</Link>;
```

Note when `<a>some disabled link</a>` is rendered in the DOM the browser removes it from the tab order, etc, so it doesn't appear as a link for accessibility purposes, which is good.

Note there is the possibility of the anti-pattern where `onClick` prop is provided but not a `to` prop, which is why I changed it so `onClick` is only called if a `to` prop is provided (alternatively we could not do this check).

Alternatively, we could implement a `disabled` prop (which would cause it to not set an `href` in the DOM) and still make `to` required.

Thoughts?