### PR TITLE
docs: fix typo in docs/guides/code-splitting.md

### DIFF
--- a/packages/react-router-dom/docs/guides/code-splitting.md
+++ b/packages/react-router-dom/docs/guides/code-splitting.md
@@ -18,7 +18,7 @@ import loadable from '@loadable/component'
 import Loading from "./Loading";
 
 const LoadableComponent = loadable(() => import('./Dashboard'), {
-  fallback: Loading,
+  fallback: <Loading />,
 })
 
 export default class LoadableDashboard extends React.Component {


### PR DESCRIPTION
I think there is a typo in the docs. I was getting a warning from react-dom before the below change.
It took me a while to figure out this was the issue.