### PR TITLE
remove clever example in testing guide

### DIFF
--- a/packages/react-router/docs/guides/testing.md
+++ b/packages/react-router/docs/guides/testing.md
@@ -115,7 +115,7 @@ it("navigates home when you click the logo", async => {
   document.body.appendChild(root);
   
   // Set initial location
-  window.location.href = '/my/initial/route';
+  window.history.pushState({}, '', '/my/initial/route');
   
   // Render app
   render(

--- a/packages/react-router/docs/guides/testing.md
+++ b/packages/react-router/docs/guides/testing.md
@@ -135,6 +135,8 @@ it("navigates home when you click the logo", async => {
   
   // Assert about new location
   expect(window.location.pathname).toBe('/homepage');
-  expect()
+  
+  // Check correct page content showed up
+  expect(document.body.textContent).toBe('Home')
 });
 ```

--- a/packages/react-router/docs/guides/testing.md
+++ b/packages/react-router/docs/guides/testing.md
@@ -74,6 +74,7 @@ We have a lot of tests that the routes work when the location changes, so you pr
 > and any other testing environment that includes [JSDOM](https://github.com/jsdom/jsdom).
 
 ```jsx
+// app.js (a component file)
 import React from "react";
 import { Route, Link, BrowserRouter } from "react-router-dom";
 // you can also use a renderer like "@testing-library/react" or "enzyme/mount" here
@@ -106,8 +107,10 @@ const App = () => (
     />
   </div>
 );
+```
 
-// the actual test!
+```jsx
+// app.test.js
 it("navigates home when you click the logo", async => {
   // in a real test a renderer like "@testing-library/react"
   // would take care of setting up the DOM elements
@@ -140,3 +143,7 @@ it("navigates home when you click the logo", async => {
   expect(document.body.textContent).toBe('Home')
 });
 ```
+
+## React Testing Library
+
+See an example in the official documentation: [Testing React Router with React Testing Library](https://testing-library.com/docs/example-react-router)


### PR DESCRIPTION
The creation of a custom navigation-specific testing harness seems a bit too purpose-built for most people. Change to an integration test that leverage JSDOM's browser globals to use BrowserRouter directly.

cc @kentcdodds for 👀 