### PR TITLE
docs: Fix missing comma in docs/api/location.md

### DIFF
--- a/packages/react-router/docs/api/location.md
+++ b/packages/react-router/docs/api/location.md
@@ -6,7 +6,7 @@ even where it was. It looks like this:
 ```js
 {
   key: 'ac3df4', // not with HashHistory!
-  pathname: '/somewhere'
+  pathname: '/somewhere',
   search: '?some=search-string',
   hash: '#howdy',
   state: {


### PR DESCRIPTION
Noticed this when I copied and pasted the location structure into REPL to test some code.