### PR TITLE
Use forwardRef on Link, NavLink

### DIFF
--- a/packages/react-router-dom/modules/__tests__/Link-test.js
+++ b/packages/react-router-dom/modules/__tests__/Link-test.js
@@ -107,7 +107,26 @@ describe("A <Link>", () => {
     });
   });
 
-  it("exposes its ref via an innerRef callbar prop", () => {
+  it("forwards a ref", () => {
+    let refNode;
+    function refCallback(n) {
+      refNode = n;
+    }
+
+    renderStrict(
+      <MemoryRouter>
+        <Link to="/" ref={refCallback}>
+          link
+        </Link>
+      </MemoryRouter>,
+      node
+    );
+
+    expect(refNode).not.toBe(undefined);
+    expect(refNode.tagName).toEqual("A");
+  });
+
+  it("exposes its ref via an innerRef callback prop", () => {
     let refNode;
     function refCallback(n) {
       refNode = n;
@@ -116,6 +135,31 @@ describe("A <Link>", () => {
     renderStrict(
       <MemoryRouter>
         <Link to="/" innerRef={refCallback}>
+          link
+        </Link>
+      </MemoryRouter>,
+      node
+    );
+
+    expect(refNode).not.toBe(undefined);
+    expect(refNode.tagName).toEqual("A");
+  });
+
+  it("prefers forwardRef over innerRef", () => {
+    let refNode;
+    function refCallback(n) {
+      refNode = n;
+    }
+
+    renderStrict(
+      <MemoryRouter>
+        <Link
+          to="/"
+          ref={refCallback}
+          innerRef={() => {
+            throw new Error("wrong ref, champ");
+          }}
+        >
           link
         </Link>
       </MemoryRouter>,

--- a/packages/react-router-dom/modules/__tests__/NavLink-test.js
+++ b/packages/react-router-dom/modules/__tests__/NavLink-test.js
@@ -11,6 +11,25 @@ describe("A <NavLink>", () => {
     ReactDOM.unmountComponentAtNode(node);
   });
 
+  it("forwards a ref", () => {
+    let refNode;
+    function refCallback(n) {
+      refNode = n;
+    }
+
+    renderStrict(
+      <MemoryRouter>
+        <NavLink to="/" ref={refCallback}>
+          link
+        </NavLink>
+      </MemoryRouter>,
+      node
+    );
+
+    expect(refNode).not.toBe(undefined);
+    expect(refNode.tagName).toEqual("A");
+  });
+
   describe("when active", () => {
     it("applies its default activeClassName", () => {
       renderStrict(
@@ -490,7 +509,11 @@ describe("A <NavLink>", () => {
     it("overrides the current location for isActive", () => {
       renderStrict(
         <MemoryRouter initialEntries={["/pizza"]}>
-          <NavLink to="/pasta" isActive={(_, location) => location.pathname === '/pasta'} location={{ pathname: "/pasta" }}>
+          <NavLink
+            to="/pasta"
+            isActive={(_, location) => location.pathname === "/pasta"}
+            location={{ pathname: "/pasta" }}
+          >
             Pasta!
           </NavLink>
         </MemoryRouter>,


### PR DESCRIPTION
This allows components like @reach/menu-button to manage focus or do anything else they need to with the underlying DOM element.

This prefers the forwarded ref, but `innerRef` will still work too.

Related: reach/reach-ui#54