### PR TITLE
Fix typo in docs for location API

### DIFF
--- a/packages/react-router/docs/api/location.md
+++ b/packages/react-router/docs/api/location.md
@@ -22,7 +22,7 @@ The router will provide you with a location object in a few places:
 - [Route children](./Route.md#children-func) as `({ location }) => ()`
 - [withRouter](./withRouter.md) as `this.props.location`
 
-It is also found on `history.location` but you shouldn't use that because its mutable. You can read more about that in the [history](./history.md) doc.
+It is also found on `history.location` but you shouldn't use that because it's mutable. You can read more about that in the [history](./history.md) doc.
 
 A location object is never mutated so you can use it in the lifecycle hooks to determine when navigation happens, this is really useful for data fetching and animation.
 


### PR DESCRIPTION
Incorrect usage "its"; "it's" is correct here, a contraction for "it is"