### PR TITLE
pass routing props to children of <Route />

### DIFF
--- a/packages/react-router/modules/Route.js
+++ b/packages/react-router/modules/Route.js
@@ -11,6 +11,16 @@ function isEmptyChildren(children) {
   return React.Children.count(children) === 0;
 }
 
+function addRouterPropsToChildren(children, routerProps) {
+  return React.Children.map(children, child => {
+    if (React.isValidElement(child)) {
+      return React.cloneElement(child, { ...routerProps, ...child.props });
+    } else {
+      return child;
+    }
+  });
+}
+
 function evalChildrenDev(children, props, path) {
   const value = children(props);
 
@@ -38,8 +48,8 @@ class Route extends React.Component {
           const match = this.props.computedMatch
             ? this.props.computedMatch // <Switch> already computed the match for us
             : this.props.path
-            ? matchPath(location.pathname, this.props)
-            : context.match;
+              ? matchPath(location.pathname, this.props)
+              : context.match;
 
           const props = { ...context, location, match };
 
@@ -59,17 +69,17 @@ class Route extends React.Component {
                     ? __DEV__
                       ? evalChildrenDev(children, props, this.props.path)
                       : children(props)
-                    : children
+                    : addRouterPropsToChildren(children, props)
                   : component
-                  ? React.createElement(component, props)
-                  : render
-                  ? render(props)
-                  : null
+                    ? React.createElement(component, props)
+                    : render
+                      ? render(props)
+                      : null
                 : typeof children === "function"
-                ? __DEV__
-                  ? evalChildrenDev(children, props, this.props.path)
-                  : children(props)
-                : null}
+                  ? __DEV__
+                    ? evalChildrenDev(children, props, this.props.path)
+                    : children(props)
+                  : null}
             </RouterContext.Provider>
           );
         }}

--- a/packages/react-router/modules/Route.js
+++ b/packages/react-router/modules/Route.js
@@ -13,7 +13,7 @@ function isEmptyChildren(children) {
 
 function addRouterPropsToChildren(children, routerProps) {
   return React.Children.map(children, child => {
-    if (React.isValidElement(child)) {
+    if (React.isValidElement(child) && typeof child.type !== "string") {
       return React.cloneElement(child, { ...routerProps, ...child.props });
     } else {
       return child;
@@ -48,8 +48,8 @@ class Route extends React.Component {
           const match = this.props.computedMatch
             ? this.props.computedMatch // <Switch> already computed the match for us
             : this.props.path
-              ? matchPath(location.pathname, this.props)
-              : context.match;
+            ? matchPath(location.pathname, this.props)
+            : context.match;
 
           const props = { ...context, location, match };
 
@@ -71,15 +71,15 @@ class Route extends React.Component {
                       : children(props)
                     : addRouterPropsToChildren(children, props)
                   : component
-                    ? React.createElement(component, props)
-                    : render
-                      ? render(props)
-                      : null
+                  ? React.createElement(component, props)
+                  : render
+                  ? render(props)
+                  : null
                 : typeof children === "function"
-                  ? __DEV__
-                    ? evalChildrenDev(children, props, this.props.path)
-                    : children(props)
-                  : null}
+                ? __DEV__
+                  ? evalChildrenDev(children, props, this.props.path)
+                  : children(props)
+                : null}
             </RouterContext.Provider>
           );
         }}

--- a/packages/react-router/modules/__tests__/Route-test.js
+++ b/packages/react-router/modules/__tests__/Route-test.js
@@ -68,7 +68,7 @@ describe("A <Route>", () => {
       expect(node.innerHTML).not.toContain(text);
     });
 
-    it("receives { history, location, match } props", () => {
+    it("passes routing props to composite components", () => {
       const history = createHistory();
 
       let props = null;

--- a/packages/react-router/modules/__tests__/Route-test.js
+++ b/packages/react-router/modules/__tests__/Route-test.js
@@ -67,6 +67,30 @@ describe("A <Route>", () => {
 
       expect(node.innerHTML).not.toContain(text);
     });
+
+    it("receives { history, location, match } props", () => {
+      const history = createHistory();
+
+      let props = null;
+      const Component = p => {
+        props = p;
+        return null;
+      };
+
+      renderStrict(
+        <Router history={history}>
+          <Route path="/">
+            <Component />
+          </Route>
+        </Router>,
+        node
+      );
+
+      expect(props).not.toBe(null);
+      expect(props.history).toBe(history);
+      expect(typeof props.location).toBe("object");
+      expect(typeof props.match).toBe("object");
+    });
   });
 
   describe("with a children function", () => {


### PR DESCRIPTION
In the API description on https://reacttraining.com/react-router/web/guides/quick-start/2nd-example-nested-routing there is this example where `<Topics />` gets passed the `match` prop from the `<Route />` component above. Currently this behaviour is only defined for `component` prop, but it should also work for components passed via `children` prop to a `<Route />`. Especially if we want to drop `render` and `component` props in an upcoming major release of RR. This PR fixes this.

Btw: we should think about a better way than the massive use of ternary operators in this case. It's not only ugly but also a mess to read. 