### PR TITLE
Fix documentation for nested routing

### DIFF
--- a/packages/react-router-dom/docs/guides/quick-start.md
+++ b/packages/react-router-dom/docs/guides/quick-start.md
@@ -152,15 +152,9 @@ export default function App() {
         <Navigation />
 
         <Switch>
-          <Route path="/about">
-            <About />
-          </Route>
-          <Route path="/topics">
-            <Topics />
-          </Route>
-          <Route path="/">
-            <Home />
-          </Route>
+          <Route path="/about" component={About} />
+          <Route path="/topics" component={Topics} />
+          <Route path="/" component={Home} />
         </Switch>
       </div>
     </Router>


### PR DESCRIPTION
You need to use `component={xxx}` syntax, otherwise match will be `undefined`.