### PR TITLE
v3: fix React version detection for lifecycle renaming

### DIFF
--- a/modules/ContextUtils.js
+++ b/modules/ContextUtils.js
@@ -15,7 +15,7 @@ function makeContextName(name) {
   return `@@contextSubscriber/${name}`
 }
 
-const prefixUnsafeLifecycleMethods = parseFloat(React.version) >= 16.3
+const prefixUnsafeLifecycleMethods = typeof React.forwardRef !== 'undefined'
 
 export function ContextProvider(name) {
   const contextName = makeContextName(name)

--- a/modules/Router.js
+++ b/modules/Router.js
@@ -23,7 +23,7 @@ const propTypes = {
   matchContext: object
 }
 
-const prefixUnsafeLifecycleMethods = parseFloat(React.version) >= 16.3
+const prefixUnsafeLifecycleMethods = typeof React.forwardRef !== 'undefined'
 
 /**
  * A <Router> is a high-level API for automatically setting up


### PR DESCRIPTION
The existing version detection was broken because `parseFloat('16.10.1')` results in `16.1`. Solution borrowed from https://github.com/reduxjs/react-redux/pull/1407

We still have several dozen apps using `react-router@3` and this fix would be useful for us. Thanks!