### PR TITLE
Fix code example in testing guide

### DIFF
--- a/packages/react-router/docs/guides/testing.md
+++ b/packages/react-router/docs/guides/testing.md
@@ -146,7 +146,7 @@ test('clicking filter links updates product query params', () => {
   render(
     <MemoryRouter initialEntries={['/my/initial/route']}>
       <App />
-      <Route path="*" render={({ location, location }) => {
+      <Route path="*" render={({ history, location }) => {
         history = history;
         location = location;
         return null;


### PR DESCRIPTION
Fix a duplicated variable definition and missing one in a testing guide code example.