### PR TITLE
Update quick-start.md

### DIFF
--- a/packages/react-router-dom/docs/guides/quick-start.md
+++ b/packages/react-router-dom/docs/guides/quick-start.md
@@ -95,7 +95,9 @@ function About() {
   return <h2>About</h2>;
 }
 
-function Topics({ match }) {
+function Topics() {
+  const match = useRouteMatch();
+
   return (
     <div>
       <h2>Topics</h2>
@@ -125,7 +127,9 @@ function Topics({ match }) {
   );
 }
 
-function Topic({ match }) {
+function Topic() {
+  const match = useRouteMatch();
+
   return <h3>Requested topic ID: {match.params.topicId}</h3>;
 }
 


### PR DESCRIPTION
Was reading through docs again for a quick recap before starting to use hooks and I think the quick start is meant to look like this now?

As `App()` is written as follows:

```jsx
<Route path="/topics">
  <Topics />
</Route>
```