### PR TITLE
Make react-router exports explicit

### DIFF
--- a/packages/react-router-dom/modules/index.js
+++ b/packages/react-router-dom/modules/index.js
@@ -1,4 +1,19 @@
-export * from "react-router";
+export {
+  MemoryRouter,
+  Prompt,
+  Redirect,
+  Route,
+  Router,
+  StaticRouter,
+  Switch,
+  generatePath,
+  matchPath,
+  withRouter,
+  useHistory,
+  useLocation,
+  useParams,
+  useRouteMatch
+} from "react-router";
 
 export { default as BrowserRouter } from "./BrowserRouter.js";
 export { default as HashRouter } from "./HashRouter.js";

--- a/packages/react-router-native/main.js
+++ b/packages/react-router-native/main.js
@@ -1,14 +1,22 @@
-export * from "react-router";
-
-import BackButton from "./BackButton.js";
-import DeepLinking from "./DeepLinking.js";
-import Link from "./Link.js";
-import NativeRouter from "./NativeRouter.js";
-
 export {
-  BackButton,
-  BackButton as AndroidBackButton,
-  DeepLinking,
-  Link,
-  NativeRouter
-};
+  MemoryRouter,
+  Prompt,
+  Redirect,
+  Route,
+  Router,
+  StaticRouter,
+  Switch,
+  generatePath,
+  matchPath,
+  withRouter,
+  useHistory,
+  useLocation,
+  useParams,
+  useRouteMatch
+} from "react-router";
+
+export { default as BackButton } from "./BackButton.js";
+export { default as AndroidBackButton } from "./BackButton.js";
+export { default as DeepLinking } from "./DeepLinking.js";
+export { default as Link } from "./Link.js";
+export { default as NativeRouter } from "./NativeRouter.js";


### PR DESCRIPTION
Instead of using `export * from "react-router"` in react-router-dom and react-router-native, this PR changes it so we export everything explicitly, which makes it easier for static code analysis tools to know which names are actually exported from that module.