### PR TITLE
add more detail to useRouteMatch hook documentation

### DIFF
--- a/packages/react-router/docs/api/hooks.md
+++ b/packages/react-router/docs/api/hooks.md
@@ -140,3 +140,13 @@ function BlogPost() {
   return <div />;
 }
 ```
+
+The `useRouteMatch` hook takes a single argument, which is identical to [props argument of matchPath](./matchPath.md#props). It can be either a pathname as a string (like the example above) or an object with the matching props that `Route` accepts, like this:
+
+```jsx
+const match = useRouteMatch({
+  path: "/BLOG/:slug/",
+  strict: true,
+  sensitive: true
+});
+```


### PR DESCRIPTION
I found the [blog post introducing the react router hooks](https://reacttraining.com/blog/react-router-v5-1) to have a bit more [information on `useRouteMatch`](https://reacttraining.com/blog/react-router-v5-1/#useroutematch) than the [website's documentation](https://reacttraining.com/react-router/web/api/Hooks/useroutematch).

I just added a little bit about how you can also pass in an object, not just a string and used the example from the blog post.


I actually ran into an issue getting the website to run locally, so I couldn't exactly test it. I thought about raising a new issue, but it looks like #5830 was closed saying you don't support running the website.