### PR TITLE
Fixes link on web quick start docs.

### DIFF
--- a/packages/react-router-dom/docs/guides/quick-start.md
+++ b/packages/react-router-dom/docs/guides/quick-start.md
@@ -181,4 +181,4 @@ function Topic() {
 
 ## Keep Going!
 
-Hopefully these examples give you a feel for what it's like to create a web app with React Router. Keep reading to learn more about [the primary components](./primary-components.md) in React Router!
+Hopefully these examples give you a feel for what it's like to create a web app with React Router. Keep reading to learn more about [the primary components](./primary-components) in React Router!


### PR DESCRIPTION
Repro: 
1. Navigate to https://reacttraining.com/react-router/web/guides/quick-start
2. Scroll to bottom.
3. Click "the primary components" link.

Outcome:
Taken to https://reacttraining.com/react-router/

Expected outcome:
Taken to https://reacttraining.com/react-router/web/guides/primary-components