### PR TITLE
docs(hashrouter): correction on link example

### DIFF
--- a/packages/react-router-dom/docs/api/HashRouter.md
+++ b/packages/react-router-dom/docs/api/HashRouter.md
@@ -20,7 +20,7 @@ The base URL for all locations. A properly formatted basename should have a lead
 
 ```jsx
 <HashRouter basename="/calendar"/>
-<Link to="/today"/> // renders <a href="#/calendar/today">
+<Link to="/today"/> // renders <a href="/calendar/#/today">
 ```
 
 ## getUserConfirmation: func


### PR DESCRIPTION
The given example is little bit misleading. So needs to be updated with the correct one.