### PR TITLE
Add modifier usage tests to generatePath

### DIFF
--- a/packages/react-router/modules/__tests__/generatePath-test.js
+++ b/packages/react-router/modules/__tests__/generatePath-test.js
@@ -65,4 +65,89 @@ describe("generatePath", () => {
       );
     });
   });
+
+  describe("with optional params=/posts/:id?", () => {
+    it("returns correct url with optional params", () => {
+      const pattern = "/posts/:id?";
+      const params = { id: "post-id" };
+
+      const generated = generatePath(pattern, params);
+      expect(generated).toBe("/posts/post-id");
+    });
+
+    it("returns correct url without optional params", () => {
+      const pattern = "/posts/:id?";
+
+      const generated = generatePath(pattern);
+      expect(generated).toBe("/posts");
+    });
+  });
+
+  describe("with zero or more params modifier=/some/:path*", () => {
+    it("returns correct url without params", () => {
+      const pattern = "/some/:path*";
+
+      const generated = generatePath(pattern);
+      expect(generated).toBe("/some");
+    });
+
+    it("returns correct url with empty array", () => {
+      const pattern = "/some/:path*";
+      const params = { path: [] };
+
+      const generated = generatePath(pattern, params);
+      expect(generated).toBe("/some");
+    });
+
+    it("returns correct url with primitive params", () => {
+      const pattern = "/some/:path*";
+      const params = { path: "primitive" };
+
+      const generated = generatePath(pattern, params);
+      expect(generated).toBe("/some/primitive");
+    });
+
+    it("returns correct url with array of params", () => {
+      const pattern = "/some/:path*";
+      const params = { path: ["array", "of", "params"] };
+
+      const generated = generatePath(pattern, params);
+      expect(generated).toBe("/some/array/of/params");
+    });
+  });
+
+  describe("with one or more params modifier=/some/:path+", () => {
+    it("throws error without params", () => {
+      const pattern = "/some/:path+";
+
+      expect(() => {
+        generatePath(pattern);
+      }).toThrow();
+    });
+
+    it("throws error with empty array", () => {
+      const pattern = "/some/:path+";
+      const params = { path: [] };
+
+      expect(() => {
+        generatePath(pattern, params);
+      }).toThrow();
+    });
+
+    it("returns correct url with primitive params", () => {
+      const pattern = "/some/:path+";
+      const params = { path: "primitive" };
+
+      const generated = generatePath(pattern, params);
+      expect(generated).toBe("/some/primitive");
+    });
+
+    it("returns correct url with array of params", () => {
+      const pattern = "/some/:path+";
+      const params = { path: ["array", "of", "params"] };
+
+      const generated = generatePath(pattern, params);
+      expect(generated).toBe("/some/array/of/params");
+    });
+  });
 });


### PR DESCRIPTION
I found out that some functions of generatePath function are not documented clearly and its TypeScript definitions are not fully correct. So, I've opened this PR at DefinitelyTyped/DefinitelyTyped/pull/40901 to correct its types accordingly. However, I need to first confirm that these features are officially supported by the library. Therefore, I'm opening this pull request to make sure that usage of modifiers and array typed params are supported. I add some tests to cover such usage.

This PR covers some use cases of "Optional", "Zero or more", and "One or more" modifiers.