### PR TITLE
Link: Add caveat doc about invariant

### DIFF
--- a/packages/react-router-dom/docs/api/Link.md
+++ b/packages/react-router-dom/docs/api/Link.md
@@ -1,6 +1,6 @@
 # &lt;Link>
 
-Provides declarative, accessible navigation around your application.
+Provides declarative, accessible navigation around your application. `<Link>` should only be rendered as a descendant of one of the `<Router>` elements.
 
 ```jsx
 <Link to="/about">About</Link>


### PR DESCRIPTION
When `Link` is rendered outside `Router`, the following error is
reported:

  You should not use `<Link>` outside a `<Router>`