### PR TITLE
Separate history object to its own context

### DIFF
--- a/packages/react-router-dom/modules/Link.js
+++ b/packages/react-router-dom/modules/Link.js
@@ -1,5 +1,5 @@
 import React from "react";
-import { __RouterContext as RouterContext } from "react-router";
+import { __HistoryContext as HistoryContext } from "react-router";
 import PropTypes from "prop-types";
 import invariant from "tiny-invariant";
 import {
@@ -83,11 +83,9 @@ const Link = forwardRef(
     forwardedRef
   ) => {
     return (
-      <RouterContext.Consumer>
-        {context => {
-          invariant(context, "You should not use <Link> outside a <Router>");
-
-          const { history } = context;
+      <HistoryContext.Consumer>
+        {history => {
+          invariant(history, "You should not use <Link> outside a <Router>");
 
           const location = normalizeToLocation(
             resolveToLocation(to, context.location),
@@ -115,7 +113,7 @@ const Link = forwardRef(
 
           return React.createElement(component, props);
         }}
-      </RouterContext.Consumer>
+      </HistoryContext.Consumer>
     );
   }
 );

--- a/packages/react-router-dom/modules/Link.js
+++ b/packages/react-router-dom/modules/Link.js
@@ -1,5 +1,5 @@
 import React from "react";
-import { __HistoryContext as HistoryContext } from "react-router";
+import { __RouterContext as RouterContext } from "react-router";
 import PropTypes from "prop-types";
 import invariant from "tiny-invariant";
 import {
@@ -83,9 +83,11 @@ const Link = forwardRef(
     forwardedRef
   ) => {
     return (
-      <HistoryContext.Consumer>
-        {history => {
-          invariant(history, "You should not use <Link> outside a <Router>");
+      <RouterContext.Consumer>
+        {context => {
+          invariant(context, "You should not use <Link> outside a <Router>");
+
+          const { history } = context;
 
           const location = normalizeToLocation(
             resolveToLocation(to, context.location),
@@ -113,7 +115,7 @@ const Link = forwardRef(
 
           return React.createElement(component, props);
         }}
-      </HistoryContext.Consumer>
+      </RouterContext.Consumer>
     );
   }
 );

--- a/packages/react-router-native/BackButton.js
+++ b/packages/react-router-native/BackButton.js
@@ -1,7 +1,7 @@
 import React from "react";
 import { BackHandler } from "react-native";
 
-import { __RouterContext as RouterContext } from "react-router";
+import { __HistoryContext as HistoryContext } from "react-router";
 
 class BackButton extends React.Component {
   handleBack = () => {
@@ -23,12 +23,12 @@ class BackButton extends React.Component {
 
   render() {
     return (
-      <RouterContext.Consumer>
-        {context => {
-          this.history = context.history;
+      <HistoryContext.Consumer>
+        {history => {
+          this.history = history;
           return this.props.children || null;
         }}
-      </RouterContext.Consumer>
+      </HistoryContext.Consumer>
     );
   }
 }

--- a/packages/react-router-native/DeepLinking.js
+++ b/packages/react-router-native/DeepLinking.js
@@ -1,7 +1,7 @@
 import React from "react";
 import { Linking } from "react-native";
 
-import { __RouterContext as RouterContext } from "react-router";
+import { __HistoryContext as HistoryContext } from "react-router";
 
 const protocolAndSlashes = /.*?:\/\//g;
 
@@ -27,12 +27,12 @@ class DeepLinking extends React.Component {
 
   render() {
     return (
-      <RouterContext.Consumer>
-        {context => {
-          this.history = context.history;
+      <HistoryContext.Consumer>
+        {history => {
+          this.history = history;
           return this.props.children || null;
         }}
-      </RouterContext.Consumer>
+      </HistoryContext.Consumer>
     );
   }
 }

--- a/packages/react-router-native/Link.js
+++ b/packages/react-router-native/Link.js
@@ -2,7 +2,7 @@ import React from "react";
 import { TouchableHighlight } from "react-native";
 import PropTypes from "prop-types";
 
-import { __RouterContext as RouterContext } from "react-router";
+import { __HistoryContext as HistoryContext } from "react-router";
 
 export default class Link extends React.Component {
   static defaultProps = {
@@ -28,14 +28,14 @@ export default class Link extends React.Component {
     const { component: Component, to, replace, ...rest } = this.props;
 
     return (
-      <RouterContext.Consumer>
-        {context => (
+      <HistoryContext.Consumer>
+        {history => (
           <Component
             {...rest}
-            onPress={event => this.handlePress(event, context.history)}
+            onPress={event => this.handlePress(event, history)}
           />
         )}
-      </RouterContext.Consumer>
+      </HistoryContext.Consumer>
     );
   }
 }

--- a/packages/react-router/modules/HistoryContext.js
+++ b/packages/react-router/modules/HistoryContext.js
@@ -1,0 +1,4 @@
+import createNamedContext from "./createNameContext";
+
+const historyContext = /*#__PURE__*/ createNamedContext("Router-History");
+export default historyContext;

--- a/packages/react-router/modules/Router.js
+++ b/packages/react-router/modules/Router.js
@@ -2,6 +2,7 @@ import React from "react";
 import PropTypes from "prop-types";
 import warning from "tiny-warning";
 
+import HistoryContext from "./HistoryContext.js";
 import RouterContext from "./RouterContext.js";
 
 /**
@@ -53,14 +54,18 @@ class Router extends React.Component {
   render() {
     return (
       <RouterContext.Provider
-        children={this.props.children || null}
         value={{
           history: this.props.history,
           location: this.state.location,
           match: Router.computeRootMatch(this.state.location.pathname),
           staticContext: this.props.staticContext
         }}
-      />
+      >
+        <HistoryContext.Provider
+          children={this.props.children || null}
+          value={this.props.history}
+        />
+      </RouterContext.Provider>
     );
   }
 }

--- a/packages/react-router/modules/createNameContext.js
+++ b/packages/react-router/modules/createNameContext.js
@@ -1,0 +1,11 @@
+// TODO: Replace with React.createContext once we can assume React 16+
+import createContext from "mini-create-react-context";
+
+const createNamedContext = name => {
+  const context = createContext();
+  context.displayName = name;
+
+  return context;
+};
+
+export default createNamedContext;

--- a/packages/react-router/modules/hooks.js
+++ b/packages/react-router/modules/hooks.js
@@ -2,6 +2,7 @@ import React from "react";
 import invariant from "tiny-invariant";
 
 import Context from "./RouterContext.js";
+import HstoryContext from "./HistoryContext.js";
 import matchPath from "./matchPath.js";
 
 const useContext = React.useContext;
@@ -14,7 +15,7 @@ export function useHistory() {
     );
   }
 
-  return useContext(Context).history;
+  return useContext(HstoryContext);
 }
 
 export function useLocation() {

--- a/packages/react-router/modules/hooks.js
+++ b/packages/react-router/modules/hooks.js
@@ -2,7 +2,7 @@ import React from "react";
 import invariant from "tiny-invariant";
 
 import Context from "./RouterContext.js";
-import HstoryContext from "./HistoryContext.js";
+import HistoryContext from "./HistoryContext.js";
 import matchPath from "./matchPath.js";
 
 const useContext = React.useContext;
@@ -15,7 +15,7 @@ export function useHistory() {
     );
   }
 
-  return useContext(HstoryContext);
+  return useContext(HistoryContext);
 }
 
 export function useLocation() {

--- a/packages/react-router/modules/index.js
+++ b/packages/react-router/modules/index.js
@@ -35,4 +35,5 @@ export { default as withRouter } from "./withRouter.js";
 import { useHistory, useLocation, useParams, useRouteMatch } from "./hooks.js";
 export { useHistory, useLocation, useParams, useRouteMatch };
 
+export { default as __HistoryContext } from "./HistoryContext.js";
 export { default as __RouterContext } from "./RouterContext.js";


### PR DESCRIPTION
Reference #6999 

As a suggestion from @MeiKatz . I added a new context for history object only to be used for useHistory hook and prevent the hooks from getting update triggerred by the original context.

The original context still has all the same properties without any change, the history object is also in the original context.

Tested with my project and it reduced rerendering greatly.