### PR TITLE
simplify code contributions by automating the dev setup with gitpod

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,0 +1,11 @@
+tasks:
+  - init: > 
+      yarn install &&  
+      yarn build &&
+      cd website && 
+      yarn install && 
+      cd .. 
+    command: yarn run start
+ports: 
+  - port: 8080
+    onOpen: open-preview

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -69,6 +69,12 @@ yarn install
 yarn build
 ```
 
+## Online one-click setup
+
+You can use gitpod(a free online VS Code like IDE) for contributing. With a single click it will launch a ready to code workspace with all the dependencies pre-installed, build finished & web server in /site directory running so that you can start coding straight away without wasting time on the setup.
+
+[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/ReactTraining/react-router)
+
 <a name="dev"/></a>
 
 ## Development

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@
   <a href="https://www.npmjs.com/package/react-router"><img src="https://img.shields.io/npm/v/react-router?style=flat-square"></a>
   <a href="https://www.npmjs.com/package/react-router"><img src="https://img.shields.io/npm/dm/react-router?style=flat-square"></a>
   <a href="https://travis-ci.com/ReactTraining/react-router"><img src="https://img.shields.io/travis/com/ReactTraining/react-router/master?style=flat-square"></a>
+  <a href="https://gitpod.io/#https://github.com/ReactTraining/react-router"><img src="https://img.shields.io/badge/Gitpod-Ready--to--Code-blue?logo=gitpod" alt="Gitpod Ready-to-Code"></a>
 </p>
 
 ## Docs

--- a/website/webpack.config.js
+++ b/website/webpack.config.js
@@ -144,6 +144,8 @@ module.exports = {
     quiet: false,
     noInfo: false,
     publicPath: "/",
+    host: "0.0.0.0",
+    disableHostCheck: true,
     stats: {
       assets: true,
       version: false,


### PR DESCRIPTION
Hello :slightly_smiling_face: 

This Pr simplifies code contributions by fully automating the dev setup with Gitpod(A free online VS Code like IDE). 

With a single click, it allows anyone to have a ready to code workspace where:

- `react-router` repo is already cloned.
- dependencies are already installed.
- build finished
- webpackDevServer is /website directory running.

So that anyone interested in contributing can start coding straight away without wasting time on the setup.

You can give it a try on my fork of the repo via the link below:

https://gitpod.io/#https://github.com/nisarhassan12/react-router

![image](https://user-images.githubusercontent.com/46004116/73646292-f5be0380-469a-11ea-877f-315b34c1841d.png)

