### PR TITLE
Shorten Route matching logic

### DIFF
--- a/packages/react-router/modules/Route.js
+++ b/packages/react-router/modules/Route.js
@@ -53,22 +53,18 @@ class Route extends React.Component {
 
           return (
             <RouterContext.Provider value={props}>
-              {props.match
+              {typeof children === "function"
+                ? __DEV__
+                  ? evalChildrenDev(children, props, this.props.path)
+                  : children(props)
+                : props.match
                 ? children
-                  ? typeof children === "function"
-                    ? __DEV__
-                      ? evalChildrenDev(children, props, this.props.path)
-                      : children(props)
-                    : children
+                  ? children
                   : component
                   ? React.createElement(component, props)
                   : render
                   ? render(props)
                   : null
-                : typeof children === "function"
-                ? __DEV__
-                  ? evalChildrenDev(children, props, this.props.path)
-                  : children(props)
                 : null}
             </RouterContext.Provider>
           );


### PR DESCRIPTION
A very small change to shorten the route matching logic code in `Route` component.

It makes the code a little easier to read, and shaves a full 21 bytes off the minified `react-router` build!

Performance:

* Route does not match => performance the same.
* Matching Route with a `children` prop which is a function => marginally faster.
* Matching Route with element(s) as `children` => same.
* Matching Route using `render` or `component` prop => marginally slower (one more `children ? ...` conditional on code path)

Since using `children` is now the recommended usage, I think the marginal performance hit for `render` and `component` props is outweighed by the (also marginal) bytes saving.

Either way, performance difference is *extremely* marginal, and more readable code is my main thrust here. I spent quite a while puzzling over the nested `?` conditionals before I understood it.

If you don't agree, or indeed just can't be bothered with such a minor change, that's totally understandable. Feel free to close - no problem.