### PR TITLE
[dev] Fix code example in the guide for migrating 5 to 6

### DIFF
--- a/docs/advanced-guides/migrating-5-to-6.md
+++ b/docs/advanced-guides/migrating-5-to-6.md
@@ -631,7 +631,7 @@ function SomeForm() {
       // you can build up the URL yourself
       navigate(`/stuff/${newRecord.id}`)
       // or navigate relative, just like Link
-      navigate(newRecord.id)
+      navigate(`${newRecord.id}`)
     }}>{/* ... */}</form>
   )
 }


### PR DESCRIPTION
Stringify argument of `navigate` because
`history.go` is called if the argument is a number.

<https://github.com/ReactTraining/react-router/blob/92502f2f6769dbf5ce4c7b154b1f6e1d27af6d07/packages/react-router/index.js#L398-L399>

Demo: <https://stackblitz.com/edit/react-router-fix-migrating-5-to-6-code-example>