### PR TITLE
Remove extraneous 'prop-types' import, optimize size

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "@typescript-eslint/parser": "2.x",
     "babel-eslint": "10.x",
     "babel-plugin-dev-expression": "^0.2.2",
+    "babel-plugin-transform-react-remove-prop-types": "^0.4.24",
     "chalk": "^3.0.0",
     "eslint": "6.x",
     "eslint-config-react-app": "^5.1.0",

--- a/scripts/builds/react-router-dom.js
+++ b/scripts/builds/react-router-dom.js
@@ -75,11 +75,22 @@ const webModules = [
     },
     external: ['history', 'prop-types', 'react', 'react-router'],
     plugins: [
-      ignore(['prop-types']),
       babel({
         exclude: /node_modules/,
-        presets: ['@babel/preset-modules', '@babel/preset-react'],
-        plugins: ['babel-plugin-dev-expression']
+        presets: [
+          ['@babel/preset-modules', {
+            // Inference of Function.name is not being relied on for Arrow Functions:
+            loose: true
+          }],
+          ['@babel/preset-react', {
+            // compile spread to Object.assign():
+            useBuiltIns: true
+          }]
+        ],
+        plugins: [
+          'babel-plugin-dev-expression',
+          'babel-plugin-transform-react-remove-prop-types'
+        ]
       }),
       replace({ 'process.env.NODE_ENV': JSON.stringify('production') }),
       compiler(),
@@ -134,14 +145,16 @@ const globals = [
     },
     external: ['history', 'react', 'react-router'],
     plugins: [
-      ignore(['prop-types']),
       babel({
         exclude: /node_modules/,
         presets: [
           ['@babel/preset-env', { loose: true }],
           '@babel/preset-react'
         ],
-        plugins: ['babel-plugin-dev-expression']
+        plugins: [
+          'babel-plugin-dev-expression',
+          'babel-plugin-transform-react-remove-prop-types'
+        ]
       }),
       replace({ 'process.env.NODE_ENV': JSON.stringify('production') }),
       compiler(),

--- a/yarn.lock
+++ b/yarn.lock
@@ -2060,6 +2060,11 @@ babel-plugin-syntax-trailing-function-commas@^7.0.0-beta.0:
   resolved "https://registry.yarnpkg.com/babel-plugin-syntax-trailing-function-commas/-/babel-plugin-syntax-trailing-function-commas-7.0.0-beta.0.tgz#aa213c1435e2bffeb6fca842287ef534ad05d5cf"
   integrity sha512-Xj9XuRuz3nTSbaTXWv3itLOcxyF4oPD8douBBmj7U9BBC6nEBYfyOJYQMf/8PJAFotC62UY5dFfIGEPr7WswzQ==
 
+babel-plugin-transform-react-remove-prop-types@^0.4.24:
+  version "0.4.24"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-react-remove-prop-types/-/babel-plugin-transform-react-remove-prop-types-0.4.24.tgz#f2edaf9b4c6a5fbe5c1d678bfb531078c1555f3a"
+  integrity sha512-eqj0hVcJUR57/Ug2zE1Yswsw4LhuqqHhD+8v120T1cl3kjg76QwtyBrdIk4WVwK+lAhBJVYCd/v+4nc4y+8JsA==
+
 babel-preset-fbjs@^3.1.2, babel-preset-fbjs@^3.2.0:
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/babel-preset-fbjs/-/babel-preset-fbjs-3.3.0.tgz#a6024764ea86c8e06a22d794ca8b69534d263541"


### PR DESCRIPTION
This enables a couple optimizations that reduce the size of react-router-dom by 30%.

I know there was some stuff for prop-types currently in the rollup configurations, but it actually was preserving the side-effecting prop-types import, as you can see here:
https://unpkg.com/browse/react-router-dom@6.0.0-alpha.2/react-router-dom.production.min.js