### PR TITLE
[V6] fix navigate is called synchronously in render

### DIFF
--- a/packages/react-router-dom/__tests__/static-navigate-test.js
+++ b/packages/react-router-dom/__tests__/static-navigate-test.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import ReactDOMServer from 'react-dom/server';
+import { act, create as createTestRenderer } from 'react-test-renderer';
 import { Navigate, Routes, Route } from 'react-router-dom';
 import { StaticRouter as Router } from 'react-router-dom/server';
 
@@ -12,13 +12,15 @@ describe('A <Navigate> in a <StaticRouter>', () => {
         return <Navigate replace to="/somewhere-else?the=query" />;
       }
 
-      ReactDOMServer.renderToStaticMarkup(
-        <Router context={context} location="/home">
-          <Routes>
-            <Route path="/home" element={<Home />} />
-          </Routes>
-        </Router>
-      );
+      act(() => {
+        createTestRenderer(
+          <Router context={context} location="/home">
+            <Routes>
+              <Route path="/home" element={<Home />} />
+            </Routes>
+          </Router>
+        );
+      });
 
       expect(context).toMatchObject({
         url: '/somewhere-else?the=query',
@@ -39,13 +41,15 @@ describe('A <Navigate> in a <StaticRouter>', () => {
           );
         }
 
-        ReactDOMServer.renderToStaticMarkup(
-          <Router context={context} location="/home">
-            <Routes>
-              <Route path="/home" element={<Home />} />
-            </Routes>
-          </Router>
-        );
+        act(() => {
+          createTestRenderer(
+            <Router context={context} location="/home">
+              <Routes>
+                <Route path="/home" element={<Home />} />
+              </Routes>
+            </Router>
+          );
+        });
 
         expect(context).toMatchObject({
           url: '/somewhere-else?the=query',
@@ -61,13 +65,15 @@ describe('A <Navigate> in a <StaticRouter>', () => {
           return <Navigate replace to={{ search: '?the=query' }} />;
         }
 
-        ReactDOMServer.renderToStaticMarkup(
-          <Router context={context} location="/home">
-            <Routes>
-              <Route path="/home" element={<Home />} />
-            </Routes>
-          </Router>
-        );
+        act(() => {
+          createTestRenderer(
+            <Router context={context} location="/home">
+              <Routes>
+                <Route path="/home" element={<Home />} />
+              </Routes>
+            </Router>
+          );
+        });
 
         expect(context).toMatchObject({
           url: '/home?the=query',
@@ -94,13 +100,15 @@ describe('A <Navigate> in a <StaticRouter>', () => {
         return <Navigate push to="/somewhere-else?the=query" />;
       }
 
-      ReactDOMServer.renderToStaticMarkup(
-        <Router context={context} location="/home">
-          <Routes>
-            <Route path="/home" element={<Home />} />
-          </Routes>
-        </Router>
-      );
+      act(() => {
+        createTestRenderer(
+          <Router context={context} location="/home">
+            <Routes>
+              <Route path="/home" element={<Home />} />
+            </Routes>
+          </Router>
+        );
+      });
 
       expect(consoleWarn).toHaveBeenCalledWith(
         expect.stringContaining('cannot perform a PUSH with a <StaticRouter>')
@@ -114,13 +122,15 @@ describe('A <Navigate> in a <StaticRouter>', () => {
         return <Navigate push to="/somewhere-else?the=query" />;
       }
 
-      ReactDOMServer.renderToStaticMarkup(
-        <Router context={context} location="/home">
-          <Routes>
-            <Route path="/home" element={<Home />} />
-          </Routes>
-        </Router>
-      );
+      act(() => {
+        createTestRenderer(
+          <Router context={context} location="/home">
+            <Routes>
+              <Route path="/home" element={<Home />} />
+            </Routes>
+          </Router>
+        );
+      });
 
       expect(context).toMatchObject({
         url: '/somewhere-else?the=query',
@@ -141,13 +151,15 @@ describe('A <Navigate> in a <StaticRouter>', () => {
           );
         }
 
-        ReactDOMServer.renderToStaticMarkup(
-          <Router context={context} location="/home">
-            <Routes>
-              <Route path="/home" element={<Home />} />
-            </Routes>
-          </Router>
-        );
+        act(() => {
+          createTestRenderer(
+            <Router context={context} location="/home">
+              <Routes>
+                <Route path="/home" element={<Home />} />
+              </Routes>
+            </Router>
+          );
+        });
 
         expect(context).toMatchObject({
           url: '/somewhere-else?the=query',
@@ -163,13 +175,15 @@ describe('A <Navigate> in a <StaticRouter>', () => {
           return <Navigate push to={{ search: '?the=query' }} />;
         }
 
-        ReactDOMServer.renderToStaticMarkup(
-          <Router context={context} location="/home">
-            <Routes>
-              <Route path="/home" element={<Home />} />
-            </Routes>
-          </Router>
-        );
+        act(() => {
+          createTestRenderer(
+            <Router context={context} location="/home">
+              <Routes>
+                <Route path="/home" element={<Home />} />
+              </Routes>
+            </Router>
+          );
+        });
 
         expect(context).toMatchObject({
           url: '/home?the=query',

--- a/packages/react-router-dom/__tests__/static-redirect-test.js
+++ b/packages/react-router-dom/__tests__/static-redirect-test.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import ReactDOMServer from 'react-dom/server';
+import { act, create as createTestRenderer } from 'react-test-renderer';
 import { Redirect, Routes } from 'react-router-dom';
 import { StaticRouter as Router } from 'react-router-dom/server';
 
@@ -7,13 +7,15 @@ describe('A <Redirect> in a <StaticRouter>', () => {
   it('mutates the context object', () => {
     let context = {};
 
-    ReactDOMServer.renderToStaticMarkup(
-      <Router context={context}>
-        <Routes>
-          <Redirect to="/somewhere-else?the=query" />
-        </Routes>
-      </Router>
-    );
+    act(() => {
+      createTestRenderer(
+        <Router context={context}>
+          <Routes>
+            <Redirect to="/somewhere-else?the=query" />
+          </Routes>
+        </Router>
+      );
+    });
 
     expect(context).toMatchObject({
       url: '/somewhere-else?the=query',
@@ -25,15 +27,17 @@ describe('A <Redirect> in a <StaticRouter>', () => {
     it('works', () => {
       let context = {};
 
-      ReactDOMServer.renderToStaticMarkup(
-        <Router context={context}>
-          <Routes>
-            <Redirect
-              to={{ pathname: '/somewhere-else', search: '?the=query' }}
-            />
-          </Routes>
-        </Router>
-      );
+      act(() => {
+        createTestRenderer(
+          <Router context={context}>
+            <Routes>
+              <Redirect
+                to={{ pathname: '/somewhere-else', search: '?the=query' }}
+              />
+            </Routes>
+          </Router>
+        );
+      });
 
       expect(context).toMatchObject({
         url: '/somewhere-else?the=query',

--- a/packages/react-router/__tests__/routes-redirect-test.js
+++ b/packages/react-router/__tests__/routes-redirect-test.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { create as createTestRenderer } from 'react-test-renderer';
+import { create as createTestRenderer, act } from 'react-test-renderer';
 import {
   Redirect,
   MemoryRouter as Router,
@@ -14,14 +14,17 @@ describe('A <Redirect> in a route config', () => {
       return <h1>About</h1>;
     }
 
-    let renderer = createTestRenderer(
-      <Router initialEntries={['/contact-us']}>
-        <Routes>
-          <Route path="about" element={<About />} />
-          <Redirect from="contact-us" to="about" />
-        </Routes>
-      </Router>
-    );
+    let renderer;
+    act(() => {
+      renderer = createTestRenderer(
+        <Router initialEntries={['/contact-us']}>
+          <Routes>
+            <Route path="about" element={<About />} />
+            <Redirect from="contact-us" to="about" />
+          </Routes>
+        </Router>
+      );
+    });
 
     expect(renderer.toJSON()).toMatchInlineSnapshot(`
       <h1>
@@ -37,14 +40,17 @@ describe('A <Redirect> in a route config', () => {
         return <h1>User {id}</h1>;
       }
 
-      let renderer = createTestRenderer(
-        <Router initialEntries={['/profile/michael']}>
-          <Routes>
-            <Route path="user/:id" element={<User />} />
-            <Redirect from="profile/:id" to="user/:id" />
-          </Routes>
-        </Router>
-      );
+      let renderer;
+      act(() => {
+        renderer = createTestRenderer(
+          <Router initialEntries={['/profile/michael']}>
+            <Routes>
+              <Route path="user/:id" element={<User />} />
+              <Redirect from="profile/:id" to="user/:id" />
+            </Routes>
+          </Router>
+        );
+      });
 
       expect(renderer.toJSON()).toMatchInlineSnapshot(`
         <h1>

--- a/packages/react-router/index.js
+++ b/packages/react-router/index.js
@@ -97,7 +97,9 @@ if (__DEV__) {
  */
 export function Navigate({ to, replace = false, state }) {
   let navigate = useNavigate();
-  navigate(to, { replace, state });
+  React.useEffect(() => {
+    navigate(to, { replace, state });
+  }, [navigate, replace, state, to]);
   return null;
 }
 


### PR DESCRIPTION
- makes navigate called in effects
- fix unit tests

The issue was found when router tries to do initial redirect navigation when rendering, but it in fact resulting in a synchronous `setState` somewhere. Put the call in effect fix this issue.
![image](https://user-images.githubusercontent.com/584378/77153801-68613200-6ad5-11ea-8a11-b59de272e4ff.png)
