### PR TITLE
Update links to history docs

### DIFF
--- a/packages/react-router/docs/api/history.md
+++ b/packages/react-router/docs/api/history.md
@@ -22,7 +22,7 @@ The following terms are also used:
 - `go(n)` - (function) Moves the pointer in the history stack by `n` entries
 - `goBack()` - (function) Equivalent to `go(-1)`
 - `goForward()` - (function) Equivalent to `go(1)`
-- `block(prompt)` - (function) Prevents navigation (see [the history docs](https://github.com/ReactTraining/history#blocking-transitions))
+- `block(prompt)` - (function) Prevents navigation (see [the history docs](https://github.com/ReactTraining/history/blob/master/docs/Blocking.md))
 
 ## history is mutable
 
@@ -44,4 +44,4 @@ class Comp extends React.Component {
 <Route component={Comp} />;
 ```
 
-Additional properties may also be present depending on the implementation you're using. Please refer to [the history documentation](https://github.com/ReactTraining/history#properties) for more details.
+Additional properties may also be present depending on the implementation you're using. Please refer to [the history documentation](https://github.com/ReactTraining/history/tree/master/docs) for more details.


### PR DESCRIPTION
Wasn't sure about the "properties" link so I just pointed it to the main docs page. Alternatively, it could point to ["Misc"](https://github.com/ReactTraining/history/blob/master/docs/Misc.md)?