### PR TITLE
[v6] Allow generatePath to use empty string params

### DIFF
--- a/packages/react-router/index.tsx
+++ b/packages/react-router/index.tsx
@@ -708,8 +708,12 @@ export interface RouteObject {
  */
 export function generatePath(pathname: string, params: Params = {}): string {
   return pathname
-    .replace(/:(\w+)/g, (_, key) => params[key] || `:${key}`)
-    .replace(/\*$/, splat => params[splat] || splat);
+    .replace(/:(\w+)/g, (_, key) =>
+      params[key] != undefined ? params[key] : `:${key}`
+    )
+    .replace(/\*$/, splat =>
+      params[splat] != undefined ? params[splat] : splat
+    );
 }
 
 /**


### PR DESCRIPTION
Fixes #7237

An empty string falls through the `||`, so this makes our check more explicit around `undefined/null`.

(I know I have no tests. I'm using the web editor...)