### PR TITLE
Fixed Link component prop type check

### DIFF
--- a/packages/react-router-native/Link.js
+++ b/packages/react-router-native/Link.js
@@ -45,7 +45,7 @@ const __DEV__ = true; // TODO
 if (__DEV__) {
   Link.propTypes = {
     onPress: PropTypes.func,
-    component: PropTypes.oneOfType([PropTypes.func, PropTypes.instanceOf(React.Component)]),
+    component: PropTypes.elementType,
     replace: PropTypes.bool,
     to: PropTypes.oneOfType([PropTypes.string, PropTypes.object])
   };

--- a/packages/react-router-native/Link.js
+++ b/packages/react-router-native/Link.js
@@ -45,7 +45,7 @@ const __DEV__ = true; // TODO
 if (__DEV__) {
   Link.propTypes = {
     onPress: PropTypes.func,
-    component: PropTypes.func,
+    component: PropTypes.oneOfType([PropTypes.func, PropTypes.instanceOf(React.Component)]),
     replace: PropTypes.bool,
     to: PropTypes.oneOfType([PropTypes.string, PropTypes.object])
   };


### PR DESCRIPTION
The `Link` component in `react-router-native` always throws a warning regarding the type of its `component` prop when it is not explicitly passed a function. This is because by default `component` is set to `TouchableOpacity`, which always fails the propType test in development mode since `component: PropTypes.func`. Changing the type test to  `component: PropTypes.oneOfType([PropTypes.func, PropTypes.instanceOf(React.Component)])` preserves the intended behavior and doesn't throw a warning by default.