### PR TITLE
update the docs for browserrouter in the example of basename.

### DIFF
--- a/packages/react-router-dom/docs/api/BrowserRouter.md
+++ b/packages/react-router-dom/docs/api/BrowserRouter.md
@@ -18,8 +18,11 @@ A [`<Router>`](../../../react-router/docs/api/Router.md) that uses the HTML5 his
 The base URL for all locations. If your app is served from a sub-directory on your server, you'll want to set this to the sub-directory. A properly formatted basename should have a leading slash, but no trailing slash.
 
 ```jsx
-<BrowserRouter basename="/calendar" />
-<Link to="/today"/> // renders <a href="/calendar/today">
+<BrowserRouter basename="/calendar">
+    <Link to="/today"/> // renders <a href="/calendar/today">
+    <Link to="/tomorrow"/> // renders <a href="/calendar/tomorrow">
+    ...
+</BrowserRouter>
 ```
 
 ## getUserConfirmation: func


### PR DESCRIPTION
Updated the docs of BroswerRouter to change the example code of basename case in which BroswerRouter for self-closing so as per the issue #7197 it should be defined with a closing tag.