### PR TITLE
chore(package): update mini-create-react-context to v0.4.0

### DIFF
--- a/packages/react-router/package.json
+++ b/packages/react-router/package.json
@@ -40,7 +40,7 @@
     "history": "^4.9.0",
     "hoist-non-react-statics": "^3.1.0",
     "loose-envify": "^1.3.1",
-    "mini-create-react-context": "^0.3.0",
+    "mini-create-react-context": "^0.4.0",
     "path-to-regexp": "^1.7.0",
     "prop-types": "^15.6.2",
     "react-is": "^16.6.0",


### PR DESCRIPTION
Update to latest version, as it doesn't depend anymore on the `gud` package, a package that has a problematic license file (missing copyright).
The API seems to be the same, so there shouldn't be any issues with this update.