### PR TITLE
Improve useSearchParams types

### DIFF
--- a/packages/react-router-dom/index.tsx
+++ b/packages/react-router-dom/index.tsx
@@ -389,13 +389,16 @@ export function useSearchParams(defaultInit: URLSearchParamsInit) {
 
   let navigate = useNavigate();
   let setSearchParams = React.useCallback(
-    (nextInit, navigateOpts) => {
+    (
+      nextInit: URLSearchParamsInit,
+      navigateOpts?: { replace?: boolean; state?: State | null }
+    ) => {
       navigate('?' + createSearchParams(nextInit), navigateOpts);
     },
     [navigate]
   );
 
-  return [searchParams, setSearchParams];
+  return [searchParams, setSearchParams] as const;
 }
 
 /**


### PR DESCRIPTION
This types the return as const to correctly infer the items within the array. Previously, the return array was (searchParams|setSearchParams)[], instead of [searchParams , setSearchParams], which made the usage impossible with correct typings.
Also setSearchParams parameters are now typed instead of just being any.