### PR TITLE
Split navigate function signature

### DIFF
--- a/packages/react-router/index.tsx
+++ b/packages/react-router/index.tsx
@@ -431,7 +431,8 @@ type PathPattern =
  * The interface for the navigate() function returned from useNavigate().
  */
 export interface NavigateFunction {
-  (to: To | number, options?: { replace?: boolean; state?: State }): void;
+  (delta: number): void;
+  (to: To, options?: { replace?: boolean; state?: State }): void;
 }
 
 /**


### PR DESCRIPTION
There's two different signatures.
Options cannot be provided when using a delta number.