### PR TITLE
[v6] Fix definition for useSearchParams arguments and return type

### DIFF
--- a/packages/react-router-dom/index.tsx
+++ b/packages/react-router-dom/index.tsx
@@ -373,8 +373,7 @@ export function usePrompt(message: string, when = true) {
  * A convenient wrapper for reading and writing search parameters via the
  * URLSearchParams interface.
  */
-export function useSearchParams(defaultInit?: URLSearchParamsInit): [URLSearchParams, (nextInit: URLSearchParamsInit,
-  navigateOptions?: { replace?: boolean; state?: State }) => void] {
+export function useSearchParams(defaultInit?: URLSearchParamsInit) {
   warning(
     typeof URLSearchParams !== 'undefined',
     'You cannot use the `useSearchParams` hook in a browser that does not' +
@@ -414,7 +413,7 @@ export function useSearchParams(defaultInit?: URLSearchParamsInit): [URLSearchPa
     [navigate]
   );
 
-  return [searchParams, setSearchParams];
+  return [searchParams, setSearchParams] as const;
 }
 
 /**

--- a/packages/react-router-dom/index.tsx
+++ b/packages/react-router-dom/index.tsx
@@ -373,7 +373,8 @@ export function usePrompt(message: string, when = true) {
  * A convenient wrapper for reading and writing search parameters via the
  * URLSearchParams interface.
  */
-export function useSearchParams(defaultInit: URLSearchParamsInit) {
+export function useSearchParams(defaultInit?: URLSearchParamsInit): [URLSearchParams, (nextInit: URLSearchParamsInit,
+  navigateOptions?: { replace?: boolean; state?: State }) => void] {
   warning(
     typeof URLSearchParams !== 'undefined',
     'You cannot use the `useSearchParams` hook in a browser that does not' +
@@ -413,7 +414,7 @@ export function useSearchParams(defaultInit: URLSearchParamsInit) {
     [navigate]
   );
 
-  return [searchParams, setSearchParams] as const;
+  return [searchParams, setSearchParams];
 }
 
 /**


### PR DESCRIPTION
### Arguments
The `useSearchParams` hook actually takes an *optional* argument, according to how it interacts with `createSearchParams`.

### Return type
The original declaration indicated that the return type is `(URLSearchParams | ((nextInit: any, navigateOpts: any) => void))[]`, meaning array whose every elements can be either `URLSearchParams` or a function, which is obviously not correct.

### Additionally
I strongly suggest a `NavigateOption` interface with generic `State`.