### PR TITLE
Correctly infer the read only type

### DIFF
--- a/packages/react-router/index.tsx
+++ b/packages/react-router/index.tsx
@@ -19,7 +19,7 @@ import {
   parsePath
 } from 'history';
 
-const readOnly: <T extends object>(obj: T) => T = __DEV__
+const readOnly: <T extends unknown>(obj: T) => T = __DEV__
   ? obj => Object.freeze(obj)
   : obj => obj;
 

--- a/packages/react-router/index.tsx
+++ b/packages/react-router/index.tsx
@@ -19,7 +19,7 @@ import {
   parsePath
 } from 'history';
 
-const readOnly: (obj: any) => any = __DEV__
+const readOnly: <T extends object>(obj: T) => T = __DEV__
   ? obj => Object.freeze(obj)
   : obj => obj;
 


### PR DESCRIPTION
This PR adds a generic to readOnly to return the passed in object type.