### PR TITLE
Unnecessary type declaration

### DIFF
--- a/packages/react-router/index.tsx
+++ b/packages/react-router/index.tsx
@@ -528,7 +528,7 @@ export function useResolvedLocation(to: To): ResolvedLocation {
  */
 export function useRoutes(
   partialRoutes: PartialRouteObject[],
-  basename: string = ''
+  basename = ''
 ): React.ReactElement | null {
   invariant(
     useInRouterContext(),
@@ -1000,7 +1000,7 @@ function safelyDecodeURIComponent(value: string, paramName: string) {
  */
 export function resolveLocation(
   to: To,
-  fromPathname: string = '/'
+  fromPathname = '/'
 ): ResolvedLocation {
   let { pathname: toPathname, search = '', hash = '' } =
     typeof to === 'string' ? parsePath(to) : to;


### PR DESCRIPTION
By providing a fallback value (here string), the type of that parameter will already be cast to string, so its unnecessary.