### PR TITLE
Make parameter names typesafe by adding string literal arguments to useParams() and Params

### DIFF
--- a/packages/react-router/index.tsx
+++ b/packages/react-router/index.tsx
@@ -514,7 +514,7 @@ export function useOutlet(): React.ReactElement | null {
  * This is useful for using ids embedded in the URL to fetch data, but we
  * eventually want to provide something at a higher level for this.
  */
-export function useParams<T extends string>(): Params<T> {
+export function useParams<T extends string = string>(): Params<T> {
   return React.useContext(RouteContext).params;
 }
 
@@ -761,7 +761,7 @@ export function generatePath(pathname: string, params: Params = {}): string {
 /**
  * The parameters that were parsed from the URL path.
  */
-export type Params<T extends string> = Record<T, string>;
+export type Params<T extends string = string> = Record<T, string>;
 
 /**
  * Matches the given routes to a location and returns the match data.

--- a/packages/react-router/index.tsx
+++ b/packages/react-router/index.tsx
@@ -514,7 +514,7 @@ export function useOutlet(): React.ReactElement | null {
  * This is useful for using ids embedded in the URL to fetch data, but we
  * eventually want to provide something at a higher level for this.
  */
-export function useParams(): Params {
+export function useParams<T extends string>(): Params<T> {
   return React.useContext(RouteContext).params;
 }
 
@@ -761,7 +761,7 @@ export function generatePath(pathname: string, params: Params = {}): string {
 /**
  * The parameters that were parsed from the URL path.
  */
-export type Params = Record<string, string>;
+export type Params<T extends string> = Record<T, string>;
 
 /**
  * Matches the given routes to a location and returns the match data.


### PR DESCRIPTION
This change is backwards compatible, meaning `useParams()` without any type arguments returns the same `Record<string,string>` type as of now.

However you are now able to provide the names of your parameters as a string literal. I.e. the following compiles successfully and gives intellisense when destructuring the returned object from `useParams`

```jsx
const { id, name } = useParams<"id"|"name">()
```
`id` and `name` have both the type `string`.

The following produces a typescript compile error as the name in the type argument and the destructured value are not exactly the same:
```jsx
const { misspelldParam } = useParams<"misspelledParam">()
```