### PR TITLE
Allow "+" character in param value

### DIFF
--- a/packages/react-router/index.tsx
+++ b/packages/react-router/index.tsx
@@ -1013,7 +1013,7 @@ function compilePath(
 
 function safelyDecodeURIComponent(value: string, paramName: string) {
   try {
-    return decodeURIComponent(value.replace(/\+/g, ' '));
+    return decodeURIComponent(value);
   } catch (error) {
     warning(
       false,


### PR DESCRIPTION
There can be situations where you have a "+" character in URLs, for example: galaxy-s10+.

Replacing "+" with " " can break both frontend and backend logic, user needing to adapt workarounds. 
In my case, I had to make the reverse change in project code (" " => "+").