### PR TITLE
Add support for using children as a render prop in NavLink

### DIFF
--- a/packages/react-router-dom/docs/api/NavLink.md
+++ b/packages/react-router-dom/docs/api/NavLink.md
@@ -92,3 +92,15 @@ The value of the `aria-current` attribute used on an active link. Available valu
 Defaults to `"page"`.
 
 Based on [WAI-ARIA 1.1 specifications](https://www.w3.org/TR/wai-aria-1.1/#aria-current)
+
+## children: func
+
+There may be some cases where need to know if the `NavLink` is active to inform props for child components. In
+these case you can use a 'children' render prop which receives `isActive` as an argument. This is especially useful
+when working with component libraries that use props instead of CSS to dictate styles.
+
+```jsx
+<NavLink strict to="/events/">
+  {isActive => <Text color={isActive ? "red" : "blue"}>Link</Text>}
+</NavLink>
+```

--- a/packages/react-router-dom/modules/NavLink.js
+++ b/packages/react-router-dom/modules/NavLink.js
@@ -37,6 +37,7 @@ const NavLink = forwardRef(
       style: styleProp,
       to,
       innerRef, // TODO: deprecate
+      children,
       ...rest
     },
     forwardedRef
@@ -78,6 +79,8 @@ const NavLink = forwardRef(
             className,
             style,
             to: toLocation,
+            children:
+              typeof children === "function" ? children(isActive) : children,
             ...rest
           };
 
@@ -112,6 +115,7 @@ if (__DEV__) {
     "aria-current": ariaCurrentType,
     activeClassName: PropTypes.string,
     activeStyle: PropTypes.object,
+    children: PropTypes.oneOfType([PropTypes.func, PropTypes.node]),
     className: PropTypes.string,
     exact: PropTypes.bool,
     isActive: PropTypes.func,

--- a/packages/react-router-dom/modules/__tests__/NavLink-test.js
+++ b/packages/react-router-dom/modules/__tests__/NavLink-test.js
@@ -167,6 +167,16 @@ describe("A <NavLink>", () => {
 
       expect(ref instanceof WrappedComponent).toBe(true);
     });
+
+    it("renders children function with true", () => {
+      renderStrict(
+        <MemoryRouter initialEntries={["/pizza"]}>
+          <NavLink to="/pizza">{String}</NavLink>
+        </MemoryRouter>,
+        node
+      );
+      expect(node.textContent).toBe("true");
+    });
   });
 
   describe("when inactive", () => {
@@ -267,6 +277,16 @@ describe("A <NavLink>", () => {
       );
 
       expect(ref instanceof WrappedComponent).toBe(true);
+    });
+
+    it("renders children function with false", () => {
+      renderStrict(
+        <MemoryRouter initialEntries={["/pizza"]}>
+          <NavLink to="/salad">{String}</NavLink>
+        </MemoryRouter>,
+        node
+      );
+      expect(node.textContent).toBe("false");
     });
   });
 


### PR DESCRIPTION
This is a feature request in the form of a PR because it was pretty easy. This adds support for using children as a render prop in `NavLink`. The render function takes `isActive` as an argument, so it can be used for props passed to child components. This will be useful when using a component library that uses props to dictate styling.

```jsx
<NavLink to="/events/">
  {isActive => <Text color={isActive ? "red" : "blue"}>Link</Text>}
</NavLink>
```

This is a non-breaking API change. Docs and tests are included. Let me know what you think.