### PR TITLE
Fixed location test documentation

### DIFF
--- a/packages/react-router/docs/guides/testing.md
+++ b/packages/react-router/docs/guides/testing.md
@@ -142,15 +142,15 @@ You shouldn't have to access the `location` or `history` objects very often in t
 ```jsx
 // app.test.js
 test("clicking filter links updates product query params", () => {
-  let history, location;
+  let testHistory, testLocation;
   render(
     <MemoryRouter initialEntries={["/my/initial/route"]}>
       <App />
       <Route
         path="*"
         render={({ history, location }) => {
-          history = history;
-          location = location;
+          testHistory = history;
+          testLocation = location;
           return null;
         }}
       />
@@ -163,8 +163,8 @@ test("clicking filter links updates product query params", () => {
   });
 
   // assert about url
-  expect(location.pathname).toBe("/products");
-  const searchParams = new URLSearchParams(location.search);
+  expect(testLocation.pathname).toBe("/products");
+  const searchParams = new URLSearchParams(testLocation.search);
   expect(searchParams.has("id")).toBe(true);
   expect(searchParams.get("id")).toEqual("1234");
 });


### PR DESCRIPTION
This PR fixes a bug with the testing documentation.
Currently it states you can call the same 'let' and replace it inside the render callback. This is not valid javascript and will not assign anything to the top level let. Therefore you need to call it something else rather then the destructed name eg testLocation and testHistory.