### PR TITLE
Added support for the as prop in Link components

### DIFF
--- a/packages/react-router-dom/__tests__/link-click-test.js
+++ b/packages/react-router-dom/__tests__/link-click-test.js
@@ -208,6 +208,95 @@ describe('A <Link> click', () => {
     });
   });
 
+  describe('when a custom component is used in the as prop', () => {
+    it('should render that component', () => {
+      function CustomComponent(props) {
+        return <button {...props} />;
+      }
+
+      function Home() {
+        return (
+          <div>
+            <h1>Home</h1>
+            <Link to="../about" as={CustomComponent}>
+              About
+            </Link>
+          </div>
+        );
+      }
+
+      function About() {
+        return <h1>About</h1>;
+      }
+
+      act(() => {
+        ReactDOM.render(
+          <Router initialEntries={['/home']}>
+            <Routes>
+              <Route path="home" element={<Home />} />
+              <Route path="about" element={<About />} />
+            </Routes>
+          </Router>,
+          node
+        );
+      });
+
+      let anchor = node.querySelector('a');
+      expect(anchor).toBeNull();
+
+      let button = node.querySelector('button');
+      expect(button).not.toBeNull();
+    });
+
+    it('should navigate like normal', () => {
+      function CustomComponent(props) {
+        return <button {...props} />;
+      }
+
+      function Home() {
+        return (
+          <div>
+            <h1>Home</h1>
+            <Link to="../about" as={CustomComponent}>
+              About
+            </Link>
+          </div>
+        );
+      }
+
+      function About() {
+        return <h1>About</h1>;
+      }
+
+      act(() => {
+        ReactDOM.render(
+          <Router initialEntries={['/home']}>
+            <Routes>
+              <Route path="home" element={<Home />} />
+              <Route path="about" element={<About />} />
+            </Routes>
+          </Router>,
+          node
+        );
+      });
+
+      let button = node.querySelector('button');
+      act(() => {
+        button.dispatchEvent(
+          new MouseEvent('click', {
+            view: window,
+            bubbles: true,
+            cancelable: true
+          })
+        );
+      });
+
+      let h1 = node.querySelector('h1');
+      expect(h1).not.toBeNull();
+      expect(h1.textContent).toEqual('About');
+    });
+  });
+
   describe('when the modifier keys are used', () => {
     it('stays on the same page', () => {
       function Home() {

--- a/packages/react-router-dom/index.tsx
+++ b/packages/react-router-dom/index.tsx
@@ -185,12 +185,26 @@ function isModifiedEvent(event: React.MouseEvent) {
   return !!(event.metaKey || event.altKey || event.ctrlKey || event.shiftKey);
 }
 
+const DefaultAnchorLink = React.forwardRef<HTMLAnchorElement, LinkProps>(
+  function DefaultAnchorLinkWithRef(props, ref) {
+    // eslint-disable-next-line jsx-a11y/anchor-has-content
+    return <a {...props} ref={ref} />;
+  }
+);
 /**
  * The public API for rendering a history-aware <a>.
  */
 export const Link = React.forwardRef<HTMLAnchorElement, LinkProps>(
   function LinkWithRef(
-    { onClick, replace: replaceProp = false, state, target, to, ...rest },
+    {
+      onClick,
+      replace: replaceProp = false,
+      state,
+      target,
+      to,
+      as: Component = DefaultAnchorLink,
+      ...rest
+    },
     ref
   ) {
     let href = useHref(to);
@@ -217,16 +231,16 @@ export const Link = React.forwardRef<HTMLAnchorElement, LinkProps>(
       }
     }
 
-    return (
-      // eslint-disable-next-line jsx-a11y/anchor-has-content
-      <a
-        {...rest}
-        href={href}
-        onClick={handleClick}
-        ref={ref}
-        target={target}
-      />
-    );
+    const props = {
+      ...rest,
+      href,
+      onClick: handleClick,
+      ref,
+      target,
+      to
+    };
+
+    return <Component {...props} />;
   }
 );
 
@@ -235,6 +249,7 @@ export interface LinkProps
   replace?: boolean;
   state?: State;
   to: To;
+  as?: React.ComponentType<any>;
 }
 
 if (__DEV__) {


### PR DESCRIPTION
According to the migration guide here: https://github.com/ReactTraining/react-router/blob/dev/docs/advanced-guides/migrating-5-to-6.md#rename-link-component-to-link-as the `<Link>` component has moved `component` to `as` but neither prop seemed to be implemented in the current release.

I've taken a quick stab at adding back the functionality with some tests.

Thanks for everybody's your work on `v6` it's looking great!

❤️  

@mjackson @ryanflorence