### PR TITLE
Document useRouteMatch empty case

### DIFF
--- a/packages/react-router/docs/api/hooks.md
+++ b/packages/react-router/docs/api/hooks.md
@@ -141,8 +141,9 @@ function BlogPost() {
 }
 ```
 
-The `useRouteMatch` hook either :
+The `useRouteMatch` hook either:
 
+- takes no argument and returns the match object of the current `<Route>`
 - takes a single argument, which is identical to [props argument of matchPath](./matchPath.md#props). It can be either a pathname as a string (like the example above) or an object with the matching props that `Route` accepts, like this:
 
 ```jsx
@@ -152,5 +153,3 @@ const match = useRouteMatch({
   sensitive: true
 });
 ```
-
-- takes no argument and returns the match object of the current `<Route>`

--- a/packages/react-router/docs/api/hooks.md
+++ b/packages/react-router/docs/api/hooks.md
@@ -141,7 +141,9 @@ function BlogPost() {
 }
 ```
 
-The `useRouteMatch` hook takes a single argument, which is identical to [props argument of matchPath](./matchPath.md#props). It can be either a pathname as a string (like the example above) or an object with the matching props that `Route` accepts, like this:
+The `useRouteMatch` hook either :
+
+- takes a single argument, which is identical to [props argument of matchPath](./matchPath.md#props). It can be either a pathname as a string (like the example above) or an object with the matching props that `Route` accepts, like this:
 
 ```jsx
 const match = useRouteMatch({
@@ -150,3 +152,5 @@ const match = useRouteMatch({
   sensitive: true
 });
 ```
+
+- takes no argument and returns the match object of the current `<Route>`


### PR DESCRIPTION
On one of my projects I needed to access the match object in a component and after searching in react-router code I found that `useRouteMatch` had an undocumented behaviour which is that it returns the Route context match when it is provided with no argument (see [here in the code](https://github.com/ReactTraining/react-router/blob/master/packages/react-router/modules/hooks.js#L44)).

The purpose of this PR is to document this.