### PR TITLE
[v6] Added documentation for NavLink `end` prop

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -383,6 +383,12 @@ function NavList() {
 }
 ```
 
+ If the `end` prop is used, it will ensure this component isn't matched as "active" when its descendant paths are matched:
+ 
+ ```
+ <NavLink to="/" end>Home</NavLink>
+ ```
+
 <a name="navigate"></a>
 
 ### `<Navigate>`


### PR DESCRIPTION
refs #7414 

I think there should be a prominent mention of the `end` prop and why you would use it, so I've added a note and code sample to the API Reference.

(I hope my description is accurate, but maybe "descendant paths" is incorrect?)