### PR TITLE
fix broken markup on testing page

### DIFF
--- a/packages/react-router/docs/guides/testing.md
+++ b/packages/react-router/docs/guides/testing.md
@@ -99,9 +99,7 @@ const App = () => (
     />
   </div>
 );
-```
 
-```jsx
 // you can also use a renderer like "@testing-library/react" or "enzyme/mount" here
 import { render, unmountComponentAtNode } from "react-dom";
 import { act } from 'react-dom/test-utils';


### PR DESCRIPTION
jsx code visually breaks because there are 2 pre blocks one after another
https://reactrouter.com/web/guides/testing