### PR TITLE
chore(docs): update link to "blocking" docs

### DIFF
--- a/packages/react-router/docs/api/history.md
+++ b/packages/react-router/docs/api/history.md
@@ -22,7 +22,7 @@ The following terms are also used:
 - `go(n)` - (function) Moves the pointer in the history stack by `n` entries
 - `goBack()` - (function) Equivalent to `go(-1)`
 - `goForward()` - (function) Equivalent to `go(1)`
-- `block(prompt)` - (function) Prevents navigation (see [the history docs](https://github.com/ReactTraining/history/blob/master/docs/Blocking.md))
+- `block(prompt)` - (function) Prevents navigation (see [the history docs](https://github.com/ReactTraining/history/blob/master/docs/blocking-transitions.md))
 
 ## history is mutable
 


### PR DESCRIPTION
In https://github.com/ReactTraining/history/commit/9532fb2170ab8000bddf69116661a9cb400c1ed6 the file for blocking transitions docs was renamed. The link to that file from the docs here was not not updated, so I do that in this PR.