### PR TITLE
Fix og:image

### DIFF
--- a/website/index.html.ejs
+++ b/website/index.html.ejs
@@ -12,7 +12,7 @@
     <link rel="mask-icon" href="<%= webpackConfig.output.publicPath %>safari-pinned-tab.svg" color="#5bbad5">
     <meta name="theme-color" content="#ffffff">
 
-    <meta property="og:image" content="<%= webpackConfig.output.publicPath %>react-square.png">
+    <meta property="og:image" content="https://reactrouter.com/react-square.png">
 
     <meta property="og:site_name" content="ReactRouterWebsite">
 


### PR DESCRIPTION
Currently, Logo is not displayed at Twitter card.
`og:image` is url, not path.
https://ogp.me/