### PR TITLE
Allow for "false" value for aria-current NavLink attribute

### DIFF
--- a/packages/react-router-dom/docs/api/NavLink.md
+++ b/packages/react-router-dom/docs/api/NavLink.md
@@ -88,6 +88,7 @@ The value of the `aria-current` attribute used on an active link. Available valu
 - `"date"` - used to indicate the current date within a calendar
 - `"time"` - used to indicate the current time within a timetable
 - `"true"` - used to indicate if the NavLink is active
+- `"false"` - used to prevent assistive technologies from reacting to a current link (a use case would be to prevent multiple aria-current tags on a single page)
 
 Defaults to `"page"`.
 

--- a/packages/react-router-dom/modules/NavLink.js
+++ b/packages/react-router-dom/modules/NavLink.js
@@ -104,7 +104,8 @@ if (__DEV__) {
     "location",
     "date",
     "time",
-    "true"
+    "true",
+    "false"
   ]);
 
   NavLink.propTypes = {


### PR DESCRIPTION
In the [spec](https://www.w3.org/TR/wai-aria-1.1/#aria-current) the default value is "false" and currently there is an error that comes up when trying to set the value to false. The use case for this would be if there are multiple links on a page with `aria-current="page"` then the screen reader would alert the user multiple times about what the current page is.

I considered allowing for `false` as a boolean but that would be a larger change and "false" is already an option in the spec.

There are no tests currently enforcing what values are passed into `aria-current`, only that the expected output is returned, so I didn't need to update any tests for this PR.