### PR TITLE
Add default value for toPathname in resolvePath

### DIFF
--- a/packages/react-router/index.tsx
+++ b/packages/react-router/index.tsx
@@ -1033,7 +1033,7 @@ function safelyDecodeURIComponent(value: string, paramName: string) {
  * @see https://reactrouter.com/api/resolvePath
  */
 export function resolvePath(to: To, fromPathname = '/'): Path {
-  let { pathname: toPathname, search = '', hash = '' } =
+  let { pathname: toPathname = '', search = '', hash = '' } =
     typeof to === 'string' ? parsePath(to) : to;
 
   let pathname = toPathname


### PR DESCRIPTION
`parsePath` returns `undefined` for `{ pathname }` if path with only hash or search is provided. Without default value `resolvePath('?search', '/somepath')` would resolve path relative to `'/'`, not relative to `'/somepath'`.

fixes #7353