### PR TITLE
Doc: make it explicit that the root route should be the last one

### DIFF
--- a/packages/react-router-dom/docs/guides/quick-start.md
+++ b/packages/react-router-dom/docs/guides/quick-start.md
@@ -61,7 +61,7 @@ export default function App() {
           <Route path="/users">
             <Users />
           </Route>
-          <Route path="/">
+          <Route path="/"> {/* The root route must be the last one, otherwise it will always match. */}
             <Home />
           </Route>
         </Switch>


### PR DESCRIPTION
Help beginners not to fall in the trap of putting the `/` route before other routes, by making it explicit that it this route must be the last one, otherwise it will always match before others.