### PR TITLE
[v6] Fix 'getting started' link

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ do not yet recommend it for use in production. Please wait until we have a
 stable release before deploying it on your production app.
 
 If you're new to React Router, we recommend you start with [the getting started
-guide](/docs/guides/getting-started.md).
+guide](/docs/installation/getting-started.md).
 
 If you're migrating to v6 from v5 (or v4, which is the same as v5), check out
 [the migration guide](/docs/advanced-guides/migrating-5-to-6.md).


### PR DESCRIPTION
Right now the link is broken, fixed the URL