### PR TITLE
Add a 'useStaticContext' hook

### DIFF
--- a/packages/react-router-dom/modules/index.js
+++ b/packages/react-router-dom/modules/index.js
@@ -12,7 +12,8 @@ export {
   useHistory,
   useLocation,
   useParams,
-  useRouteMatch
+  useRouteMatch,
+  useStaticContext
 } from "react-router";
 
 export { default as BrowserRouter } from "./BrowserRouter.js";

--- a/packages/react-router-native/main.js
+++ b/packages/react-router-native/main.js
@@ -12,7 +12,8 @@ export {
   useHistory,
   useLocation,
   useParams,
-  useRouteMatch
+  useRouteMatch,
+  useStaticContext
 } from "react-router";
 
 export { default as BackButton } from "./BackButton.js";

--- a/packages/react-router/docs/api/hooks.md
+++ b/packages/react-router/docs/api/hooks.md
@@ -153,3 +153,37 @@ const match = useRouteMatch({
   sensitive: true
 });
 ```
+
+## `useStaticContext`
+
+The `useStaticContext` hook returns the `staticContext` object passed in from the `StaticRouter`'s `context` prop, during a server side render.
+
+Now, instead of
+
+```jsx
+import { Route } from "react-router-dom";
+
+function BlogPost() {
+  return (
+    <Route
+      render={({ staticContext }) => {
+        // Do whatever you want with the staticContext...
+        return <div />;
+      }}
+    />
+  );
+}
+```
+
+you can just
+
+```jsx
+import { useStaticContext } from "react-router-dom";
+
+function BlogPost() {
+  let staticContext = useStaticContext();
+
+  // Do whatever you want with the match...
+  return <div />;
+}
+```

--- a/packages/react-router/modules/__tests__/useStaticContext-test.js
+++ b/packages/react-router/modules/__tests__/useStaticContext-test.js
@@ -1,0 +1,33 @@
+import React from "react";
+import ReactDOM from "react-dom";
+import { StaticRouter, Route, useStaticContext } from "react-router";
+
+import renderStrict from "./utils/renderStrict.js";
+
+describe("useStaticContext", () => {
+  const node = document.createElement("div");
+
+  afterEach(() => {
+    ReactDOM.unmountComponentAtNode(node);
+  });
+
+  it("returns the static context object", () => {
+    let staticContext;
+
+    function HomePage() {
+      staticContext = useStaticContext();
+      return null;
+    }
+
+    renderStrict(
+      <StaticRouter location="/home" context={{ foo: "bar" }}>
+        <Route path="/home">
+          <HomePage />
+        </Route>
+      </StaticRouter>,
+      node
+    );
+
+    expect(staticContext).toEqual({ foo: "bar" });
+  });
+});

--- a/packages/react-router/modules/hooks.js
+++ b/packages/react-router/modules/hooks.js
@@ -53,3 +53,14 @@ export function useRouteMatch(path) {
   const match = useContext(RouterContext).match;
   return path ? matchPath(location.pathname, path) : match;
 }
+
+export function useStaticContext(path) {
+  if (__DEV__) {
+    invariant(
+      typeof useContext === "function",
+      "You must use React >= 16.8 in order to use useRouteMatch()"
+    );
+  }
+
+  return useContext(RouterContext).staticContext;
+}

--- a/packages/react-router/modules/index.js
+++ b/packages/react-router/modules/index.js
@@ -35,4 +35,10 @@ export { default as withRouter } from "./withRouter.js";
 export { default as __HistoryContext } from "./HistoryContext.js";
 export { default as __RouterContext } from "./RouterContext.js";
 
-export { useHistory, useLocation, useParams, useRouteMatch } from "./hooks.js";
+export {
+  useHistory,
+  useLocation,
+  useParams,
+  useRouteMatch,
+  useStaticContext
+} from "./hooks.js";


### PR DESCRIPTION
This PR adds a `useStaticContext` hook, to get a hold of the `staticContext` without needing to instantiate a `Route` wrapper.

This just mirrors the work already done to achieve e.g. `useLocation`.