### PR TITLE
refactor: don't set "?" if searchParams are empty

### DIFF
--- a/packages/react-router-dom/index.tsx
+++ b/packages/react-router-dom/index.tsx
@@ -415,7 +415,8 @@ export function useSearchParams(defaultInit?: URLSearchParamsInit) {
       nextInit: URLSearchParamsInit,
       navigateOptions?: { replace?: boolean; state?: State }
     ) => {
-      navigate('?' + createSearchParams(nextInit), navigateOptions);
+      const searchParams = createSearchParams(nextInit).toString();
+      navigate(searchParams !== '' ? `?${searchParams}` : '', navigateOptions);
     },
     [navigate]
   );


### PR DESCRIPTION
This removes the unnecessary ```?``` when there's no searchParams