### PR TITLE
Improve QueryParams docs

### DIFF
--- a/packages/react-router-dom/examples/QueryParams.js
+++ b/packages/react-router-dom/examples/QueryParams.js
@@ -27,7 +27,9 @@ export default function QueryParamsExample() {
 // A custom hook that builds on useLocation to parse
 // the query string for you.
 function useQuery() {
-  return new URLSearchParams(useLocation().search);
+  const { search } = useLocation();
+
+  return React.useMemo(() => new URLSearchParams(search), [search]);
 }
 
 function QueryParamsDemo() {


### PR DESCRIPTION
# Hello everyone

This PR changes the **QueryParams docs**. Change `useQuery` to memoize the `URLSearchParams` instance, creating a new instance only if **search** changes.

_I suggest this 'cause I was using `useQuery` and my app keeps reloading a lot, I found it interesting to share the solution I found._