### PR TITLE
[Defect reporting] useParams with array of path of a Route does not find matches

### DIFF
--- a/packages/react-router/modules/__tests__/useParams-test.js
+++ b/packages/react-router/modules/__tests__/useParams-test.js
@@ -1,4 +1,3 @@
-import { beforeEach, describe } from "jest-circus";
 import React from "react";
 import ReactDOM from "react-dom";
 import { MemoryRouter, Route, useParams, useRouteMatch } from "react-router";

--- a/packages/react-router/modules/__tests__/useParams-test.js
+++ b/packages/react-router/modules/__tests__/useParams-test.js
@@ -1,3 +1,4 @@
+import { beforeEach, describe } from "jest-circus";
 import React from "react";
 import ReactDOM from "react-dom";
 import { MemoryRouter, Route, useParams, useRouteMatch } from "react-router";
@@ -117,6 +118,76 @@ describe("useParams", () => {
 
       expect(typeof params).toBe("object");
       expect(Object.keys(params)).toHaveLength(0);
+    });
+  });
+
+  describe("when the Route path is an array of routes order matters.", () => {
+    let params;
+    function HomePage() {
+      params = useParams();
+      return null;
+    }
+    beforeEach(() => (params = undefined));
+
+    test("the route param isn't matched going from root path to nested route path", () => {
+      renderStrict(
+        <MemoryRouter initialEntries={["/id-not-found"]}>
+          <Route
+            path={["/", "/:id", "/nested/:id", "/nested/again/:id"]}
+            children={() => <HomePage />}
+          />
+        </MemoryRouter>,
+        node
+      );
+
+      expect(typeof params).toBe("object");
+      expect(Object.keys(params)).toHaveLength(0);
+    });
+
+    test("the route param isn't matched going from root path to deep-nested route path", () => {
+      renderStrict(
+        <MemoryRouter initialEntries={["/nested/nested-not-found"]}>
+          <Route
+            path={["/", "/:id", "/nested/:id", "/nested/again/:id"]}
+            children={() => <HomePage />}
+          />
+        </MemoryRouter>,
+        node
+      );
+      expect(typeof params).toBe("object");
+      expect(Object.keys(params)).toHaveLength(0);
+    });
+
+    test("the route param is matched going from nested route path to root path", () => {
+      renderStrict(
+        <MemoryRouter initialEntries={["/id-found"]}>
+          <Route
+            path={["/nested/again/:id", "/nested/:id", "/:id", "/"]}
+            children={() => <HomePage />}
+          />
+        </MemoryRouter>,
+        node
+      );
+
+      expect(typeof params).toBe("object");
+      expect(Object.keys(params)).toHaveLength(1);
+      expect(params.id).toBe("id-found");
+    });
+
+    test("the route param is matched going from deep-nested route path to root path", () => {
+      renderStrict(
+        <MemoryRouter initialEntries={["/nested/nested-found"]}>
+          <Route
+            path={["/nested/again/:id", "/nested/:id", "/:id", "/"]}
+            children={() => <HomePage />}
+          />
+        </MemoryRouter>,
+        node
+      );
+
+      expect(typeof params).toBe("object");
+      expect(Object.keys(params)).toHaveLength(1);
+      expect(params.id).toBe("nested-found");
     });
   });
 });


### PR DESCRIPTION
I am filing this PR as recommended for filing bugs.  However, I am unclear if this is an actual bug or not.  I wrote some tests to illustrate issue.  There are no actual code changes here.

---

I have a root provider in my app which checks for id value in the URL, such as on an URL page refresh and the global store is not updated, we need to set the value of associated details based on this ID.

Using the hook is very straight forward:
```
const { id } = useParams<{ id: string }>();
```
However, the `id` is undefined unless I have a list of all the possible routes with params, so I need to wrap everything with a Route component, using an array of paths like: `<Route path={[..array of routes]}>`.

However, it seems the order of the array paths matter. Why is this?

Works:
```
<Route path={["/nested/again/:id", "/nested/:id", "/:id", "/"]}> 
```
Does not work:
```
<Route path={[ "/", "/:id", "/nested/:id", "/nested/again/:id"]}>
```

I understand that this is not optimal path declaration where the `:id` param is in different locations within the url, but it cannot be changed at this time within my work environment.

Actual Codesandbox with UI example: https://codesandbox.io/s/useparams-with-array-of-route-match-options-forked-3dcbz?file=/example.js:214-270

