### PR TITLE
[v6] Add setSearchParams updater function

### DIFF
--- a/packages/react-router-dom/__tests__/search-params-test.js
+++ b/packages/react-router-dom/__tests__/search-params-test.js
@@ -30,6 +30,25 @@ describe('useSearchParams', () => {
     );
   }
 
+  function SearchUpdaterPage({ getId }) {
+    let [searchParams, setSearchParams] = useSearchParams();
+    let query = searchParams.get('q');
+    let id = searchParams.get('id');
+
+    React.useEffect(() => {
+      setSearchParams(prev => {
+        prev.set('id', getId());
+        return prev;
+      });
+    }, [setSearchParams, getId]);
+
+    return (
+      <div>
+        The current query is "{query}" with id "{id}".
+      </div>
+    );
+  }
+
   let node;
   beforeEach(() => {
     node = document.createElement('div');
@@ -69,5 +88,28 @@ describe('useSearchParams', () => {
     });
 
     expect(node.innerHTML).toMatch(/The current query is "Ryan Florence"/);
+  });
+
+  it('append to search string using setSearchParams updater', () => {
+    const getId = jest.fn(() => '1');
+
+    act(() => {
+      render(
+        <Router initialEntries={['/search?q=Michael+Jackson']}>
+          <Routes>
+            <Route
+              path="search"
+              element={<SearchUpdaterPage getId={getId} />}
+            />
+          </Routes>
+        </Router>,
+        node
+      );
+    });
+
+    expect(node.innerHTML).toMatch(
+      /The current query is "Michael Jackson" with id "1"/
+    );
+    expect(getId).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/react-router-dom/index.tsx
+++ b/packages/react-router-dom/index.tsx
@@ -319,6 +319,9 @@ export function useSearchParams(defaultInit?: URLSearchParamsInit) {
   let defaultSearchParamsRef = React.useRef(createSearchParams(defaultInit));
 
   let location = useLocation();
+  let locationRef = React.useRef<typeof location>(location);
+  locationRef.current = location;
+
   let searchParams = React.useMemo(() => {
     let searchParams = createSearchParams(location.search);
 
@@ -334,12 +337,22 @@ export function useSearchParams(defaultInit?: URLSearchParamsInit) {
   }, [location.search]);
 
   let navigate = useNavigate();
+
   let setSearchParams = React.useCallback(
     (
-      nextInit: URLSearchParamsInit,
+      nextInit:
+        | URLSearchParamsInit
+        | ((params: URLSearchParams) => URLSearchParamsInit),
       navigateOptions?: { replace?: boolean; state?: State }
     ) => {
-      navigate('?' + createSearchParams(nextInit), navigateOptions);
+      const location = locationRef.current;
+
+      const next =
+        typeof nextInit === 'function'
+          ? createSearchParams(nextInit(createSearchParams(location.search)))
+          : createSearchParams(nextInit);
+
+      navigate('?' + next, navigateOptions);
     },
     [navigate]
   );

--- a/packages/react-router-dom/index.tsx
+++ b/packages/react-router-dom/index.tsx
@@ -322,6 +322,11 @@ export function useSearchParams(defaultInit?: URLSearchParamsInit) {
   let locationRef = React.useRef<typeof location>(location);
   locationRef.current = location;
 
+  let currentSearchRef = React.useRef<string | null>(null);
+  React.useEffect(() => {
+    currentSearchRef.current = null;
+  }, [location]);
+
   let searchParams = React.useMemo(() => {
     let searchParams = createSearchParams(location.search);
 
@@ -337,7 +342,6 @@ export function useSearchParams(defaultInit?: URLSearchParamsInit) {
   }, [location.search]);
 
   let navigate = useNavigate();
-
   let setSearchParams = React.useCallback(
     (
       nextInit:
@@ -347,10 +351,12 @@ export function useSearchParams(defaultInit?: URLSearchParamsInit) {
     ) => {
       const location = locationRef.current;
 
+      const currentSearch = currentSearchRef.current ?? location.search;
       const next =
         typeof nextInit === 'function'
-          ? createSearchParams(nextInit(createSearchParams(location.search)))
+          ? createSearchParams(nextInit(createSearchParams(currentSearch)))
           : createSearchParams(nextInit);
+      currentSearchRef.current = next.toString();
 
       navigate('?' + next, navigateOptions);
     },


### PR DESCRIPTION
Having updater would allow to work with search params more convenient via useSearchParams hook


```js
useEffect(() => {
  // append foo=123 to /search?q=Michael+Jackson
  setSearchParams(prev => {
    prev.set('foo', '123');
    return prev;
  });
}, [setSearchParams]);

```