### PR TITLE
memoize last result of matchPath

### DIFF
--- a/packages/react-router/modules/__tests__/matchPath-test.js
+++ b/packages/react-router/modules/__tests__/matchPath-test.js
@@ -132,5 +132,20 @@ describe("matchPath", () => {
       expect(!!trueFalse).toBe(true);
       expect(!!falseTrue).toBe(false);
     });
+
+    it("memoize last result of matchPath", () => {
+      const result1 = matchPath("/one/two", {
+        path: "/one/two/",
+        exact: true,
+        strict: false
+      });
+      const result2 = matchPath("/one/two", {
+        path: "/one/two/",
+        exact: true,
+        strict: false
+      });
+
+      expect(result1).toBe(result2);
+    });
   });
 });

--- a/packages/react-router/modules/__tests__/matchPath-test.js
+++ b/packages/react-router/modules/__tests__/matchPath-test.js
@@ -144,8 +144,20 @@ describe("matchPath", () => {
         exact: true,
         strict: false
       });
+      const result3 = matchPath("/one/two", {
+        path: "/one/two/",
+        exact: false,
+        strict: false
+      });
+      const result4 = matchPath("/one/two", {
+        path: "/one/two/",
+        exact: true,
+        strict: false
+      });
 
       expect(result1).toBe(result2);
+      expect(result1 !== result3).toBe(true);
+      expect(result1 !== result4).toBe(true);
     });
   });
 });

--- a/packages/react-router/modules/matchPath.js
+++ b/packages/react-router/modules/matchPath.js
@@ -25,6 +25,9 @@ function compilePath(path, options) {
 /**
  * Public API for matching a URL pathname to a path.
  */
+
+let matchPathCache = {};
+
 function matchPath(pathname, options = {}) {
   if (typeof options === "string" || Array.isArray(options)) {
     options = { path: options };
@@ -32,9 +35,13 @@ function matchPath(pathname, options = {}) {
 
   const { path, exact = false, strict = false, sensitive = false } = options;
 
+  const cacheKey = `${pathname}${path}${exact}${strict}${sensitive}`;
+  if (matchPathCache[cacheKey]) return matchPathCache[cacheKey];
+  matchPathCache = {}; // cache only last result
+
   const paths = [].concat(path);
 
-  return paths.reduce((matched, path) => {
+  const result = paths.reduce((matched, path) => {
     if (!path && path !== "") return null;
     if (matched) return matched;
 
@@ -62,6 +69,8 @@ function matchPath(pathname, options = {}) {
       }, {})
     };
   }, null);
+  matchPathCache[cacheKey] = result;
+  return result;
 }
 
 export default matchPath;


### PR DESCRIPTION
## Summary

Using `react-router@5.1.2` i noticed that `<Route />` when re-renders it creates new `match` object
<img width="586" alt="Screenshot 2021-01-21 at 15 59 57" src="https://user-images.githubusercontent.com/14371261/105354663-eca6a900-5c01-11eb-9bdc-df9ffb491295.png">
Which forces child component to re-render also (at least if you don't use `React.memo`).

This PR memoizes `matchPath` function to return same result if arguments are the same. Cache has size=1, cause we need it only when render same screen.

## Test plan

Added unit test to check if result is equal for the first time and then cache resets when new arguments appear
