### PR TITLE
Route accepts function prop type

### DIFF
--- a/packages/react-router/modules/Route.js
+++ b/packages/react-router/modules/Route.js
@@ -91,8 +91,10 @@ if (__DEV__) {
     exact: PropTypes.bool,
     location: PropTypes.object,
     path: PropTypes.oneOfType([
+      PropTypes.func,
       PropTypes.string,
-      PropTypes.arrayOf(PropTypes.string)
+      PropTypes.arrayOf(PropTypes.string),
+      PropTypes.arrayOf(PropTypes.func)
     ]),
     render: PropTypes.func,
     sensitive: PropTypes.bool,


### PR DESCRIPTION
I came across a scenario where I had to use a function return in the `path` prop (some old third-party developed code)

Just a thought to add this in 😄 