### PR TITLE
Fix mistakes that make test fail

### DIFF
--- a/packages/react-router/docs/guides/testing.md
+++ b/packages/react-router/docs/guides/testing.md
@@ -106,7 +106,7 @@ import { act } from 'react-dom/test-utils';
 import { MemoryRouter } from "react-router-dom";
 
 // app.test.js
-it("navigates home when you click the logo", async => {
+it("navigates home when you click the logo", () => {
   // in a real test a renderer like "@testing-library/react"
   // would take care of setting up the DOM elements
   const root = document.createElement('div');
@@ -114,7 +114,7 @@ it("navigates home when you click the logo", async => {
 
   // Render app
   render(
-    <MemoryRouter initialEntries={['/my/initial/route']}>
+    <MemoryRouter initialEntries={['/dashboard']}>
       <App />
     </MemoryRouter>,
     root
@@ -123,13 +123,13 @@ it("navigates home when you click the logo", async => {
   // Interact with page
   act(() => {
     // Find the link (perhaps using the text content)
-    const goHomeLink = document.querySelector('#nav-logo-home');
+    const goHomeLink = document.querySelector('#click-me');
     // Click it
     goHomeLink.dispatchEvent(new MouseEvent("click", { bubbles: true }));
   });
 
   // Check correct page content showed up
-  expect(document.body.textContent).toBe('Home');
+  expect(document.body.textContent).toBe('Welcome');
 });
 ```
 


### PR DESCRIPTION
"navigates home when you click the logo" fails because of minor issues

* the path to the route with the link was wrong
* the id for the link was wrong
* the text on the target page was wrong
* providing an argument to the anonymous function makes the timeout waiting for completion callback