### PR TITLE
[v6]: prop-types has no default export

### DIFF
--- a/packages/react-router-dom/index.tsx
+++ b/packages/react-router-dom/index.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import * as PropTypes from 'prop-types';
 import {
   BrowserHistory,
   HashHistory,

--- a/packages/react-router/index.tsx
+++ b/packages/react-router/index.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import * as PropTypes from 'prop-types';
 import {
   Action,
   Blocker,


### PR DESCRIPTION
When I set `allowSyntheticDefaultImports: true` in `tsconfig.json`, if I run the script `tsc`, it will display the error that 

> node_modules/react-router-dom/index.d.ts:2:8 - error TS1192: Module '"./node_modules/@types/prop-types/index"' has no default export.

So wh should change the way of importing `prop-types` :

``` js
import * as PropTypes from 'prop-types';
```

Looking forward to you being able to merge in and release a new version to fix it.
