### PR TITLE
[v6] Allow specifying State type in 'useLocation' hook

### DIFF
--- a/packages/react-router/index.tsx
+++ b/packages/react-router/index.tsx
@@ -347,7 +347,7 @@ export function useInRouterContext(): boolean {
  *
  * @see https://reactrouter.com/api/useLocation
  */
-export function useLocation(): Location {
+export function useLocation<S extends State = State>(): Location<S> {
   invariant(
     useInRouterContext(),
     // TODO: This error is probably because they somehow have 2 versions of the
@@ -355,7 +355,7 @@ export function useLocation(): Location {
     `useLocation() may be used only in the context of a <Router> component.`
   );
 
-  return React.useContext(LocationContext).location as Location;
+  return React.useContext(LocationContext).location as Location<S>;
 }
 
 /**
@@ -373,7 +373,7 @@ export function useMatch(pattern: PathPattern): PathMatch | null {
     `useMatch() may be used only in the context of a <Router> component.`
   );
 
-  let location = useLocation() as Location;
+  let location = useLocation();
   return matchPath(pattern, location.pathname);
 }
 
@@ -529,7 +529,7 @@ function useRoutes_(
 
   basename = basename ? joinPaths([parentPathname, basename]) : parentPathname;
 
-  let location = useLocation() as Location;
+  let location = useLocation();
   let matches = React.useMemo(() => matchRoutes(routes, location, basename), [
     location,
     routes,


### PR DESCRIPTION
### Version
v6

### Problem
`useLocation()` does not accept State as type parameter in v6, which makes using state object cumbersome.

In v5 with `@types/react-router@5.1.13`, useLocation's type is defined as follows 
```typescript
export function useLocation<S = H.LocationState>(): H.Location<S>;
```

In v6, it's currently typed as 
```typescript
 useLocation(): Location
```

If you want to use, for example, an optional `from` prop in LocationState, you're forced to type cast or use an assertion
```typescript
if (
    location.state !== null &&
    (location.state as { from?: string }).from !== undefined
  ) {
  const from = (location.state as { from: string }).from
}
```
## Solution
Accept State as generics
```typescript
const location = useLocation<{ from?: string } | null>()
```