### PR TITLE
Replace state on repeated Link navigations

### DIFF
--- a/packages/react-router-dom/modules/Link.js
+++ b/packages/react-router-dom/modules/Link.js
@@ -1,5 +1,6 @@
 import React from "react";
 import { __RouterContext as RouterContext } from "react-router";
+import { createPath } from 'history';
 import PropTypes from "prop-types";
 import invariant from "tiny-invariant";
 import {
@@ -100,7 +101,8 @@ const Link = forwardRef(
             href,
             navigate() {
               const location = resolveToLocation(to, context.location);
-              const method = replace ? history.replace : history.push;
+              const isDuplicateNavigation = createPath(context.location) === createPath(location);
+              const method = (replace || isDuplicateNavigation) ? history.replace : history.push;
 
               method(location);
             }


### PR DESCRIPTION
Back ported this fix from v6 to v5: https://github.com/ReactTraining/react-router/blob/dev/packages/react-router-dom/index.tsx#L186-L189

To check:
- Should the normalised location from the scope above (line 93) not be used?