### PR TITLE
Update Link example

### DIFF
--- a/packages/react-router-dom/docs/api/Link.md
+++ b/packages/react-router-dom/docs/api/Link.md
@@ -87,7 +87,7 @@ let anchorRef = React.createRef()
 If you would like utilize your own navigation component, you can simply do so by passing it through the `component` prop.
 
 ```jsx
-const FancyLink = React.forwardRef((props, ref) => (
+const FancyLink = React.forwardRef(({ navigate, ...props }, ref) => (
   <a ref={ref} {...props}>💅 {props.children}</a>
 ))
 


### PR DESCRIPTION
When passing a custom component to Link, you will get a warning if you pass all the props through to the anchor element. The `navigate` prop must be removed before passing through.

https://github.com/ReactTraining/react-router/issues/6962