### PR TITLE
Add missing generic types to useLocation

### DIFF
--- a/packages/react-router/index.tsx
+++ b/packages/react-router/index.tsx
@@ -347,7 +347,7 @@ export function useInRouterContext(): boolean {
  *
  * @see https://reactrouter.com/api/useLocation
  */
-export function useLocation(): Location {
+export function useLocation<S extends State = State>(): Location<S> {
   invariant(
     useInRouterContext(),
     // TODO: This error is probably because they somehow have 2 versions of the


### PR DESCRIPTION
I tried to use `useLocation` as `useNavigate` with `state`, but I can't declare a generic type of `Location<S>` that return type of `useLocation`. I've read contribute guidelines,  but this change is a simple type declaration. So I don't think no more tests are needed.