### PR TITLE
Remove location prop from `Routes` and `useRoutes`

### DIFF
--- a/packages/react-router/__tests__/Routes-test.tsx
+++ b/packages/react-router/__tests__/Routes-test.tsx
@@ -82,26 +82,4 @@ describe("A <Routes>", () => {
 
     expect(renderer.toJSON()).toMatchSnapshot();
   });
-
-  it("Uses the `location` prop instead of context location`", () => {
-    let node = document.createElement("div");
-    document.body.appendChild(node);
-
-    act(() => {
-      ReactDOM.render(
-        <Router initialEntries={["/one"]}>
-          <Routes location={{ pathname: "/two" }}>
-            <Route path="/one" element={<h1>one</h1>} />
-            <Route path="/two" element={<h1>two</h1>} />
-          </Routes>
-        </Router>,
-        node
-      );
-    });
-
-    expect(node.innerHTML).toMatch(/two/);
-
-    // cleanup
-    document.body.removeChild(node);
-  });
 });

--- a/packages/react-router/__tests__/Routes-test.tsx
+++ b/packages/react-router/__tests__/Routes-test.tsx
@@ -1,8 +1,6 @@
 import * as React from "react";
-import * as ReactDOM from "react-dom";
 import { create as createTestRenderer } from "react-test-renderer";
 import { MemoryRouter as Router, Routes, Route } from "react-router";
-import { act } from "react-dom/test-utils";
 
 describe("A <Routes>", () => {
   it("renders the first route that matches the URL", () => {

--- a/packages/react-router/__tests__/useRoutes-test.tsx
+++ b/packages/react-router/__tests__/useRoutes-test.tsx
@@ -1,8 +1,6 @@
 import * as React from "react";
-import * as ReactDOM from "react-dom";
 import { create as createTestRenderer } from "react-test-renderer";
 import { MemoryRouter as Router, useRoutes } from "react-router";
-import { act } from "react-dom/test-utils";
 import type { PartialRouteObject } from "react-router";
 
 describe("useRoutes", () => {
@@ -28,40 +26,14 @@ describe("useRoutes", () => {
 
     expect(renderer.toJSON()).toMatchSnapshot();
   });
-
-  it("Uses the `location` prop instead of context location`", () => {
-    let node = document.createElement("div");
-    document.body.appendChild(node);
-
-    let routes = [
-      { path: "one", element: <h1>one</h1> },
-      { path: "two", element: <h1>two</h1> }
-    ];
-
-    act(() => {
-      ReactDOM.render(
-        <Router initialEntries={["/one"]}>
-          <RoutesRenderer routes={routes} location={{ pathname: "/two" }} />
-        </Router>,
-        node
-      );
-    });
-
-    expect(node.innerHTML).toMatch(/two/);
-
-    // cleanup
-    document.body.removeChild(node);
-  });
 });
 
 function RoutesRenderer({
   routes,
-  basename,
-  location
+  basename
 }: {
   routes: PartialRouteObject[];
   basename?: string;
-  location?: Partial<Location>;
 }) {
-  return useRoutes(routes, basename, location);
+  return useRoutes(routes, basename);
 }

--- a/packages/react-router/index.tsx
+++ b/packages/react-router/index.tsx
@@ -255,7 +255,6 @@ export function Router({
 export interface RoutesProps {
   basename?: string;
   children?: React.ReactNode;
-  location?: Partial<Location>;
 }
 
 /**
@@ -266,11 +265,11 @@ export interface RoutesProps {
  */
 export function Routes({
   basename = "",
-  children,
-  location
+  children
 }: RoutesProps): React.ReactElement | null {
   let routes = createRoutesFromChildren(children);
-  return useRoutes_(routes, basename, location);
+  let location = useLocation();
+  return useRoutes_(routes, location, basename);
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -492,8 +491,7 @@ export function useResolvedPath(to: To): Path {
  */
 export function useRoutes(
   partialRoutes: PartialRouteObject[],
-  basename = "",
-  locationProp?: Partial<Location>
+  basename = ""
 ): React.ReactElement | null {
   invariant(
     useInRouterContext(),
@@ -502,18 +500,19 @@ export function useRoutes(
     `useRoutes() may be used only in the context of a <Router> component.`
   );
 
+  let location = useLocation();
   let routes = React.useMemo(
     () => createRoutesFromArray(partialRoutes),
     [partialRoutes]
   );
 
-  return useRoutes_(routes, basename, locationProp);
+  return useRoutes_(routes, location, basename);
 }
 
 function useRoutes_(
   routes: RouteObject[],
-  basename = "",
-  locationProp?: Partial<Location>
+  location: Location,
+  basename = ""
 ): React.ReactElement | null {
   let {
     route: parentRoute,
@@ -541,12 +540,6 @@ function useRoutes_(
 
   basename = basename ? joinPaths([parentPathname, basename]) : parentPathname;
 
-  let contextLocation = useLocation() as Location;
-  let location = React.useMemo(() => {
-    return locationProp
-      ? { ...contextLocation, ...locationProp }
-      : contextLocation;
-  }, [locationProp, contextLocation]);
   let matches = React.useMemo(
     () => matchRoutes(routes, location, basename),
     [location, routes, basename]


### PR DESCRIPTION
After discussing this more with @mjackson, we believe the `location` prop on `Switch` in v5 is still the wrong API. The primary use case as far as we can tell is for Route animations. Michael is going to open a new issue for a deeper discussion about this, and we'll likely introduce some even better solutions in a new beta scheduled for next week.